### PR TITLE
Remapped sample select buttons, leds and drumpads

### DIFF
--- a/prototype/devices/teensy41/hardware.py
+++ b/prototype/devices/teensy41/hardware.py
@@ -180,21 +180,21 @@ def translate_key_event(event) -> KeyEvent | None:
     if (n % 5) < 4:
         key = SequencerKey(int(n / 5), n % 5)
     elif n == 9:
-        key = SampleSelectKey(Direction.Up, 3)
-    elif n == 14:
-        key = SampleSelectKey(Direction.Down, 3)
-    elif n == 19:
-        key = SampleSelectKey(Direction.Up, 2)
-    elif n == 24:
-        key = SampleSelectKey(Direction.Down, 2)
-    elif n == 29:
-        key = SampleSelectKey(Direction.Up, 1)
-    elif n == 34:
-        key = SampleSelectKey(Direction.Down, 1)
-    elif n == 39:
         key = SampleSelectKey(Direction.Up, 0)
-    elif n == 4:
+    elif n == 14:
         key = SampleSelectKey(Direction.Down, 0)
+    elif n == 19:
+        key = SampleSelectKey(Direction.Up, 1)
+    elif n == 24:
+        key = SampleSelectKey(Direction.Down, 1)
+    elif n == 29:
+        key = SampleSelectKey(Direction.Up, 2)
+    elif n == 34:
+        key = SampleSelectKey(Direction.Down, 2)
+    elif n == 39:
+        key = SampleSelectKey(Direction.Up, 3)
+    elif n == 4:
+        key = SampleSelectKey(Direction.Down, 3)
     else:
         key = None
         # key = ControlKey(n)
@@ -240,7 +240,12 @@ step_to_led = {
     31: 7,
 }
 
-drumpad_to_led = {0: 5, 1: 16, 2: 25, 3: 36}
+drumpad_to_led = {
+    0: 36,
+    1: 25,
+    2: 16,
+    3: 5,
+}
 
 
 class Display:

--- a/prototype/devices/teensy41/pizza_controller.py
+++ b/prototype/devices/teensy41/pizza_controller.py
@@ -63,13 +63,10 @@ class PizzaController(Controller):
             PotReader(self.hardware.drum_pad4_bottom)
         ]
         
-        self.last_update = time.monotonic()
+        self.last_update = time.monotonic_ns()
 
     def update(self, controls: Controls) -> None:
-        update_interval = time.monotonic() - self.last_update
-        self.last_update = time.monotonic()
         gc.collect()
-        print(f"update interval: {int(update_interval*1000)}ms, mem free: {gc.mem_free()}")
         self._read_pots(controls)
         self._process_keys(controls)
 
@@ -101,7 +98,7 @@ class PizzaController(Controller):
 
         self.filter_setting.read(
             lambda val: controls.adjust_filter(percentage_from_pot(val) / 30))
-
+        
         for track_ind, pitch_setting in enumerate(self.pitch_settings):
             pitch_setting.read(
                 lambda pitch: controls.set_track_pitch(


### PR DESCRIPTION
Aims to address https://github.com/datomusic/drum-firmware/issues/33

The innermost circle connects to pad 1 (0 in the code) and the outermost to pad 4 (3 in the code)