### PR TITLE
Randomize steps per track

### DIFF
--- a/prototype/devices/teensy41/pizza_controller.py
+++ b/prototype/devices/teensy41/pizza_controller.py
@@ -91,7 +91,7 @@ class PizzaController(Controller):
             show_track(
                 self.display,
                 ColorScheme.Tracks[drum.tracks[track_index].note],
-                drum.get_indicator_step(),
+                drum.get_indicator_step(track_index),
                 drum.tracks[track_index],
                 track_index,
             )

--- a/prototype/firmware/application.py
+++ b/prototype/firmware/application.py
@@ -68,8 +68,7 @@ class AppControls(Controls):
                 self.drum.repeat_effect.set_repeat_count(0)
                 self.drum.repeat_effect.set_repeat_divider(1)
         elif EffectName.Random == effect_name:
-            self.drum.random_effect.enabled = percentage > 50
-
+            self.drum.set_random_enabled(percentage > 50)
     def adjust_swing(self, amount_percent):
         self.tempo.swing.adjust(amount_percent)
 
@@ -82,6 +81,7 @@ class AppControls(Controls):
 
     def reset_tempo(self):
         self.tempo.reset()
+
 
 
 class Application:


### PR DESCRIPTION
Implements https://github.com/datomusic/drum-firmware/issues/13 as per the latest comment, where we apply randomization per track.
I think a possible improvement could be to lock a random seed when the button is pressed, and reset the randomization to this seed after N steps. That way we get a coherent fill rather than full-on randomization.