### PR TITLE
Beat repeat synced with sequencer

### DIFF
--- a/prototype/firmware/application.py
+++ b/prototype/firmware/application.py
@@ -54,21 +54,21 @@ class AppControls(Controls):
 
     def set_effect_level(self, effect_name, percentage):
         if EffectName.Repeat == effect_name:
-            print(percentage)
             if percentage > 99:
                 self.drum.repeat_effect.set_repeat_count(1)
-                self.drum.repeat_effect.set_repeat_divider(2)
+                self.drum.repeat_effect.set_subdivision(2)
             elif percentage > 94:
                 self.drum.repeat_effect.set_repeat_count(2)
-                self.drum.repeat_effect.set_repeat_divider(2)
+                self.drum.repeat_effect.set_subdivision(2)
             elif percentage > 30:
                 self.drum.repeat_effect.set_repeat_count(3)
-                self.drum.repeat_effect.set_repeat_divider(2)
+                self.drum.repeat_effect.set_subdivision(2)
             else:
                 self.drum.repeat_effect.set_repeat_count(0)
-                self.drum.repeat_effect.set_repeat_divider(1)
+                self.drum.repeat_effect.set_subdivision(1)
         elif EffectName.Random == effect_name:
             self.drum.set_random_enabled(percentage > 50)
+
     def adjust_swing(self, amount_percent):
         self.tempo.swing.adjust(amount_percent)
 
@@ -81,7 +81,6 @@ class AppControls(Controls):
 
     def reset_tempo(self):
         self.tempo.reset()
-
 
 
 class Application:
@@ -99,7 +98,6 @@ class Application:
 
     def _on_tick(self, source) -> None:
         self.output.on_tempo_tick(source)
-        self.drum.tick()
 
     def _on_half_beat(self) -> None:
         self.drum.advance_step()

--- a/prototype/firmware/drum.py
+++ b/prototype/firmware/drum.py
@@ -57,16 +57,11 @@ class Drum:
         else:
             return self._get_play_step_index(track_index)
 
-    def tick(self):
-        if self.playing:
-            if self.repeat_effect.tick():
-                self._play_track_steps()
-
     def advance_step(self) -> None:
         if self.playing:
-            if not self.repeat_effect.active():
-                self._play_track_steps()
+            self._play_track_steps()
             self._next_step_index = (self._next_step_index + 1) % STEP_COUNT
+            self.repeat_effect.advance()
 
         for track in self.tracks:
             track.tick()

--- a/prototype/firmware/repeat_effect.py
+++ b/prototype/firmware/repeat_effect.py
@@ -1,43 +1,42 @@
-from .tempo import Divider, TICKS_PER_BEAT
-
 
 class RepeatEffect:
     def __init__(self, cur_step_getter):
+        self.final_step = None
         self.repeat_count = 0
-        self.start_step = None
         self.cur_step_getter = cur_step_getter
         self.step_counter = 0
-        self.repeat_ticks = Divider(TICKS_PER_BEAT)
 
     def active(self):
         return self.repeat_count > 0
 
-    def tick(self):
-        should_step = self.repeat_ticks.tick()
-        if self.repeat_count > 0:
-            if should_step:
-                self.step_counter += 1
-                return True
-        else:
-            return False
+    def advance(self):
+        if self.active():
+            self.step_counter += 1
 
-    def set_repeat_divider(self, divider):
-        self.repeat_ticks.set_division(TICKS_PER_BEAT / divider)
+    def set_subdivision(self, divider):
+        # TODO:  Implement subdivision
+        pass
 
     def set_repeat_count(self, count):
         self.repeat_count = count
 
         if count <= 0:
-            self.start_step = None
-        elif self.start_step is None:
+            self.final_step = None
+        elif self.final_step is None:
             self._start()
 
     def _start(self):
-        self.start_step = (self.cur_step_getter)()
+        self.final_step = (self.cur_step_getter)()
         self.step_counter = 0
 
-    def get_step(self):
-        if self.start_step is None:
+    # Plays final_step first, just after triggering.
+    # Then loops from repeat_count steps back.
+    def get_step(self) -> None | int:
+        if self.final_step is None:
             return None
         else:
-            return (self.start_step - (self.repeat_count - (self.step_counter % self.repeat_count)))
+            start = self.final_step - self.repeat_count + 1
+            return (
+                start +
+                (self.step_counter + self.repeat_count - 1) % self.repeat_count
+            )


### PR DESCRIPTION
The current implementation of the beat repeat does weird things and doesn't feel right, because it keeps track of it's own ticks and isn't synced with the main sequencer.
This PR drives the beat repeat effect from the half-beat steps of the sequencer, which also makes it follow swing. We don't have subdivisions of the beat repeat now, but that can be added as a next step. At least with this PR we have a working, in-sync, repeat effect that does what you'd expect (at least from my testing).