### PR TITLE
Send ChannelPressure instead of internal mute level

### DIFF
--- a/prototype/devices/teensy41/pizza_controller.py
+++ b/prototype/devices/teensy41/pizza_controller.py
@@ -1,4 +1,4 @@
-from firmware.device_api import Controls, SampleChange, OutputParam, EffectName
+from firmware.device_api import Controls, SampleChange, OutputParam, TrackParam, EffectName
 from firmware.controller_api import Controller
 from firmware.drum import Drum, Track
 
@@ -149,7 +149,8 @@ class PizzaController(Controller):
 
         for track_ind, pitch_setting in enumerate(self.pitch_settings):
             pitch_setting.read(
-                lambda pitch: controls.set_track_pitch(
+                lambda pitch: controls.set_track_param(
+                    TrackParam.Pitch,
                     track_ind,
                     percentage_from_pot(pitch)))
 
@@ -158,11 +159,12 @@ class PizzaController(Controller):
                 lambda velocity: controls.play_track_sample(
                     ind, percentage_from_pot(velocity)))
 
-        for (ind, muter) in enumerate(self.mute_pads):
+        for (track_index, muter) in enumerate(self.mute_pads):
             muter.read(
                 lambda amount:
-                    controls.set_track_mute(
-                        ind,
+                    controls.set_track_param(
+                        TrackParam.Mute,
+                        track_index,
                         100 - percentage_from_pot(amount))
             )
 

--- a/prototype/firmware/application.py
+++ b/prototype/firmware/application.py
@@ -1,5 +1,5 @@
 from .drum import Drum
-from .device_api import Controls, Output, SampleChange, EffectName
+from .device_api import Controls, Output, SampleChange, EffectName, TrackParam
 from .controller_api import Controller
 from .tempo import Tempo, TempoSource
 
@@ -18,9 +18,6 @@ class AppControls(Controls):
 
     def toggle_track_step(self, track, step):
         self.drum.tracks[track].sequencer.toggle_step(step)
-
-    def set_track_pitch(self, track_index, pitch):
-        self.output.set_channel_pitch(track_index, pitch)
 
     def change_sample(self, track_index, change):
         if change == SampleChange.Prev:
@@ -45,9 +42,11 @@ class AppControls(Controls):
         track = self.drum.tracks[track_index]
         track.note_player.play(track.note, velocity)
 
-    def set_track_mute(self, track_index: int, amount_percent: float):
-        track = self.drum.tracks[track_index]
-        track.note_player.mute_level = amount_percent
+    def set_track_param(self, param, track_index: int, amount_percent: float):
+        if TrackParam.Pitch == param:
+            self.output.set_channel_pitch(track_index, amount_percent)
+        elif TrackParam.Mute == param:
+            self.output.set_channel_mute(track_index, amount_percent)
 
     def set_output_param(self, param, percent) -> None:
         self.output.set_param(param, percent)
@@ -69,6 +68,7 @@ class AppControls(Controls):
                 self.drum.repeat_effect.set_repeat_divider(1)
         elif EffectName.Random == effect_name:
             self.drum.set_random_enabled(percentage > 50)
+
     def adjust_swing(self, amount_percent):
         self.tempo.swing.adjust(amount_percent)
 
@@ -81,7 +81,6 @@ class AppControls(Controls):
 
     def reset_tempo(self):
         self.tempo.reset()
-
 
 
 class Application:

--- a/prototype/firmware/device_api.py
+++ b/prototype/firmware/device_api.py
@@ -37,10 +37,23 @@ class Output:
     def on_tempo_tick(self, source):
         _not_implemented("Output.on_tempo_tick", source)
 
+    def set_channel_mute(self, channel: int, amount_percent: float):
+        _not_implemented("Output.set_channel_mute",
+                         channel, amount_percent)
+
+
+class TrackParam:
+    Pitch = 1
+    Mute = 2
+
 
 class Controls:
     def set_output_param(self, param, amount_percent):
         _not_implemented("Controls.set_output_param", param, amount_percent)
+
+    def set_track_param(self, param, track_index, amount_percent):
+        _not_implemented("Controls.set_track_param", param,
+                         track_index, amount_percent)
 
     def set_bpm(self, bpm):
         _not_implemented("Controls.set_bpm", bpm)
@@ -49,16 +62,8 @@ class Controls:
         _not_implemented("Controls.play_track_sample",
                          track_index, velocity_percent)
 
-    def set_track_mute(self, track_index: int, amount_percent: float):
-        _not_implemented("Controls.set_track_mute",
-                         track_index, amount_percent)
-
     def toggle_track_step(self, track_index: int, step):
         _not_implemented("Controls.toggle_track_step", track_index, step)
-
-    def set_track_pitch(self, track_index: int, pitch_percent: float):
-        _not_implemented("Controls.set_track_pitch",
-                         track_index, pitch_percent)
 
     def set_effect_level(self, effect_name, percentage):
         _not_implemented("Controls.set_effect_level", effect_name, percentage)

--- a/prototype/firmware/midi_output.py
+++ b/prototype/firmware/midi_output.py
@@ -5,12 +5,14 @@ from adafruit_midi.control_change import ControlChange  # type: ignore
 from adafruit_midi.note_on import NoteOn  # type: ignore
 from adafruit_midi.note_off import NoteOff  # type: ignore
 from adafruit_midi.timing_clock import TimingClock  # type: ignore
+from adafruit_midi.channel_pressure import ChannelPressure  # type: ignore
 
 
 class MIDIOutput(Output):
     def __init__(self, midi: MIDI):
         self.midi = midi
         self.filter_amount = 64
+
     def send_note_on(self, channel: int, note: int, vel_percent: float):
         self.midi.send(
             NoteOn(note, percent_to_midi(vel_percent)), channel=channel)
@@ -19,28 +21,33 @@ class MIDIOutput(Output):
         self.midi.send(NoteOff(note), channel=channel)
 
     def set_channel_pitch(self, channel: int, pitch_percent: float):
-        self.send_cc(16 + channel, percent_to_midi(pitch_percent))
+        self._send_cc(16 + channel, percent_to_midi(pitch_percent))
+
+    def set_channel_mute(self, channel: int, pressure: float):
+        midi_value = percent_to_midi(pressure)
+        print(f"[{channel}] ChannelPressure: {midi_value}")
+        self.midi.send(ChannelPressure(midi_value), channel=channel)
 
     def set_param(self, param, value) -> None:
         if param == OutputParam.Volume:
-            self.send_cc(7, percent_to_midi(value))
+            self._send_cc(7, percent_to_midi(value))
 
         elif param == OutputParam.LowPass:
-            self.send_cc(75, percent_to_midi(value))
+            self._send_cc(75, percent_to_midi(value))
 
         elif param == OutputParam.HighPass:
-            self.send_cc(76, percent_to_midi(value))
+            self._send_cc(76, percent_to_midi(value))
 
         elif param == OutputParam.AdjustFilter:
             self.filter_amount = constrain_midi(
                 int(self.filter_amount + value))
-            self.send_cc(74, self.filter_amount)
+            self._send_cc(74, self.filter_amount)
 
     def on_tempo_tick(self, source) -> None:
         if source == TempoSource.Internal:
             self.midi.send(TimingClock())
 
-    def send_cc(self, cc, value, channel=0):
+    def _send_cc(self, cc, value, channel=0):
         print(f"[{channel}] CC {cc}: {value}")
         self.midi.send(ControlChange(cc, value), channel=channel)
 

--- a/prototype/firmware/note_player.py
+++ b/prototype/firmware/note_player.py
@@ -11,13 +11,12 @@ class NotePlayer:
         self.channel = channel
         self.ticks = 0
         self.output = output
-        self.mute_level = 0.0
 
-    def play(self, note: int, vel: float = 100.0) -> None:
+    def play(self, note: int, velocity: float = 100.0) -> None:
         if self.played_note is not None:
             self.output.send_note_off(self.channel, self.played_note)
 
-        self.output.send_note_on(self.channel, note, vel - self.mute_level)
+        self.output.send_note_on(self.channel, note, velocity)
         self.ticks = 0
         self.played_note = note
 


### PR DESCRIPTION
Remake of https://github.com/datomusic/drum-firmware/pull/39 based on latest main.
Also simplifies the API a bit by introducing `TrackParam` for simple single-value settings relating to tracks.