### PR TITLE
Alternative pad indication: Highlight instead of fade

### DIFF
--- a/prototype/devices/teensy41/hardware.py
+++ b/prototype/devices/teensy41/hardware.py
@@ -250,7 +250,7 @@ drumpad_to_led = {
 }
 
 
-def fade_color(color, amount):
+def attenuate_color(color, amount):
     (r, g, b) = color
     return (int(r * amount), int(g * amount), int(b * amount))
 
@@ -282,14 +282,14 @@ class Display:
         pixel_index = pixel_index_from_key(key)
         self.pixels[pixel_index] = color
 
-    def fade(
+    def attenuate(
         self,
         key: Drumpad | SequencerKey | ControlKey,
         amount: float
     ) -> None:
         pixel_index = pixel_index_from_key(key)
         old_color = self.pixels[pixel_index]
-        self.pixels[pixel_index] = fade_color(old_color, amount)
+        self.pixels[pixel_index] = attenuate_color(old_color, amount)
 
 
 def pixel_index_from_key(key):

--- a/prototype/devices/teensy41/pizza_view.py
+++ b/prototype/devices/teensy41/pizza_view.py
@@ -4,7 +4,7 @@ from .hardware import (
     Display,
     Drumpad,
     SequencerKey,
-    fade_color,
+    attenuate_color,
     # SampleSelectKey,
     # Direction,
     ControlKey,
@@ -33,7 +33,13 @@ class PadIndicator:
 
         self.last_triggered_step = step_index
         pad = Drumpad(self.index)
-        display.set_color(pad, fade_color(color, 1 - fade_amount))
+        attenuation = 1.8
+        base_amount = 0.2
+        color = attenuate_color(
+            color,
+            attenuation * (base_amount + fade_amount * (1 - base_amount)))
+
+        display.set_color(pad, color)
 
     def update(self, delta_ms: int):
         if self.fade_remaining_ms > 0:
@@ -56,7 +62,8 @@ class SequencerRing:
 
             if self.fade_remaining_ms > 0:
                 fade_amount = self.fade_remaining_ms / FADE_TIME_MS
-                display.set_color(key, fade_color(step_color, fade_amount))
+                display.set_color(key, attenuate_color(
+                    step_color, fade_amount))
             elif step.active:
                 display.set_color(key, step_color)
 
@@ -75,7 +82,8 @@ class Cursor:
         display: Display, track_index: int, current_step: int, beat_position: float
     ) -> None:
         display.set_color(ControlKey(ControlName.Start), ColorScheme.Cursor)
-        display.set_color(SequencerKey(current_step, track_index), ColorScheme.Cursor)
+        display.set_color(SequencerKey(
+            current_step, track_index), ColorScheme.Cursor)
 
     def apply_fade(
         self,
@@ -94,13 +102,13 @@ class Cursor:
 
         self.last_beat_position = beat_position
         if playing:
-            display.fade(sequencer_key, amount)
+            display.attenuate(sequencer_key, amount)
         else:
             if self.fade_play_toggle:
-                display.fade(sequencer_key, amount)
+                display.attenuate(sequencer_key, amount)
                 display.set_color(start_key, (0, 0, 0))
             else:
-                display.fade(start_key, amount)
+                display.attenuate(start_key, amount)
                 display.set_color(sequencer_key, (0, 0, 0))
 
 
@@ -110,7 +118,8 @@ class PizzaView:
             PadIndicator(track_index) for track_index in range(Track.Count)
         ]
 
-        self.rings = [SequencerRing(track_index) for track_index in range(Track.Count)]
+        self.rings = [SequencerRing(track_index)
+                      for track_index in range(Track.Count)]
         self.cursor = Cursor()
 
     def update(self, delta_ms: int) -> None:


### PR DESCRIPTION
I've been feeling like the fade-out upon sample trigger looks kind of like a glitch and did a quick experiment where I keep t
the color a bit lower by default and blink the pad upon trigger instead.
I think it looks a lot more natural, but not sure what you guys prefer.
@qqquuuiii I will merge this to `main` so you can try it out easier. If you think the old version is better, we can revert this change.