### PR TITLE
Short tap sets lower velocity on sequencer

### DIFF
--- a/drum/config.h
+++ b/drum/config.h
@@ -29,6 +29,7 @@ constexpr uint8_t SAMPLE_SELECT_START_COLUMN = 4;
 constexpr uint8_t PREVIEW_NOTE_VELOCITY = 100;
 constexpr uint8_t DEFAULT_STEP_VELOCITY = 100;
 constexpr uint8_t MAX_STEP_VELOCITY_ON_HOLD = 127;
+constexpr uint8_t STEP_VELOCITY_ON_TAP = 30;
 } // namespace keypad
 
 // Drumpad Component Configuration

--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -155,28 +155,29 @@ void PizzaControls::KeypadComponent::KeypadEventHandler::notification(
   // Get a reference to the track to modify it
   auto &track = controls->_sequencer_controller_ref.get_sequencer().get_track(track_idx);
 
+  uint8_t step_velocity;
+  bool now_enabled;
+
   if (event.type == musin::ui::KeypadEvent::Type::Press) {
-    bool now_enabled = track.toggle_step_enabled(step_idx);
-
-    if (now_enabled) {
-      // Get the current note assigned to the corresponding drumpad
-      uint8_t note = controls->drumpad_component.get_note_for_pad(track_idx);
-      track.set_step_note(step_idx, note);
-
-      uint8_t step_velocity;
-      if (!track.get_step_velocity(step_idx).has_value()) {
-        track.set_step_velocity(step_idx, config::keypad::DEFAULT_STEP_VELOCITY);
-        step_velocity = config::keypad::DEFAULT_STEP_VELOCITY;
-      } else {
-        step_velocity = track.get_step_velocity(step_idx).value();
-      }
-
-      if (!controls->is_running()) {
-        controls->_sequencer_controller_ref.trigger_note_on(track_idx, note, step_velocity);
-      }
-    }
+    now_enabled = track.toggle_step_enabled(step_idx);
+    step_velocity = config::keypad::DEFAULT_STEP_VELOCITY;
   } else if (event.type == musin::ui::KeypadEvent::Type::Hold) {
-    track.set_step_velocity(step_idx, config::keypad::MAX_STEP_VELOCITY_ON_HOLD);
+    step_velocity = config::keypad::MAX_STEP_VELOCITY_ON_HOLD;
+  } else if (event.type == musin::ui::KeypadEvent::Type::Tap) {
+    now_enabled = track.toggle_step_enabled(step_idx);
+    step_velocity = config::keypad::STEP_VELOCITY_ON_TAP;
+  }
+
+  if (now_enabled) {
+    // Get the current note assigned to the corresponding drumpad
+    uint8_t note = controls->drumpad_component.get_note_for_pad(track_idx);
+    track.set_step_note(step_idx, note);
+
+    track.set_step_velocity(step_idx, step_velocity);
+
+    if (!controls->is_running()) {
+      controls->_sequencer_controller_ref.trigger_note_on(track_idx, note, step_velocity);
+    }
   }
 }
 

--- a/musin/ui/keypad_hc138.h
+++ b/musin/ui/keypad_hc138.h
@@ -53,7 +53,8 @@ enum class KeyState : std::uint8_t {
 struct KeyData {
   KeyState state = KeyState::IDLE;            ///< Current debounced and hold state.
   absolute_time_t transition_time = nil_time; ///< Time of the last relevant state change start.
-  absolute_time_t press_event_time = nil_time; ///< Time of the confirmed press event for tap detection.
+  absolute_time_t press_event_time =
+      nil_time;              ///< Time of the confirmed press event for tap detection.
   bool just_pressed = false; ///< Flag indicating a transition to PRESSED occurred in the last scan.
   bool just_released = false; ///< Flag indicating a transition to IDLE occurred in the last scan.
 };
@@ -80,7 +81,7 @@ public:
   static constexpr std::uint32_t DEFAULT_SCAN_INTERVAL_MS = 10; ///< 10ms default scan rate
   static constexpr std::uint32_t DEFAULT_DEBOUNCE_TIME_MS = 5;  ///< 5ms default debounce time
   static constexpr std::uint32_t DEFAULT_HOLD_TIME_MS = 500;    ///< 500ms default hold time
-  static constexpr std::uint32_t DEFAULT_TAP_TIME_MS = 150;     ///< 150ms default tap time threshold
+  static constexpr std::uint32_t DEFAULT_TAP_TIME_MS = 60; ///< 150ms default tap time threshold
 
   /**
    * @brief Construct a new Keypad_HC138 driver instance.

--- a/musin/ui/keypad_hc138.tpp
+++ b/musin/ui/keypad_hc138.tpp
@@ -245,8 +245,7 @@ void Keypad_HC138<NumRows, NumCols>::update_key_state(std::uint8_t r, std::uint8
           }
         }
         key.press_event_time = nil_time; // Reset for next press cycle
-        key.transition_time = nil_time; // Reset for next state change
-
+        key.transition_time = nil_time;  // Reset for next state change
       }
       // else: Debounce time not yet elapsed, remain in DEBOUNCING_RELEASE
     } else {


### PR DESCRIPTION
A super short tap on a sequencer button sets the velocity to a lower state for extra expression. The tap is very short so it's almost impossible to accidentally trigger.