### PR TITLE
feat(audio): Mute audio during SysEx transfers

### DIFF
--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -153,9 +153,25 @@ void AudioEngine::set_pitch(uint8_t voice_index, float value) {
 }
 
 void AudioEngine::set_volume(float volume) {
-  // Clamp volume to [0.0, 1.0] before passing to AudioOutput
-  volume = std::clamp(volume, 0.0f, 1.0f);
-  AudioOutput::volume(volume);
+  // Clamp volume to [0.0, 1.0]
+  current_volume_ = std::clamp(volume, 0.0f, 1.0f);
+  if (!muted_) {
+    AudioOutput::volume(current_volume_);
+  }
+}
+
+void AudioEngine::mute() {
+  if (!muted_) {
+    muted_ = true;
+    AudioOutput::volume(0.0f);
+  }
+}
+
+void AudioEngine::unmute() {
+  if (muted_) {
+    muted_ = false;
+    AudioOutput::volume(current_volume_);
+  }
 }
 
 void AudioEngine::set_filter_frequency(float normalized_value) {

--- a/drum/audio_engine.h
+++ b/drum/audio_engine.h
@@ -96,6 +96,16 @@ public:
   void set_volume(float volume);
 
   /**
+   * @brief Mutes the audio output.
+   */
+  void mute();
+
+  /**
+   * @brief Unmutes the audio output.
+   */
+  void unmute();
+
+  /**
    * @brief Sets the global lowpass filter cutoff frequency.
    * @param normalized_value The frequency value, normalized (0.0f to 1.0f).
    */
@@ -145,6 +155,8 @@ private:
   };
 
   bool is_initialized_ = false;
+  bool muted_ = false;
+  float current_volume_ = 1.0f;
 };
 
 } // namespace drum

--- a/drum/message_router.cpp
+++ b/drum/message_router.cpp
@@ -253,9 +253,11 @@ void MessageRouter::notification(drum::Events::NoteEvent event) {
 void MessageRouter::notification(
     drum::Events::SysExTransferStateChangeEvent event) {
   if (event.is_active) {
+    _audio_engine.mute();
     _previous_local_control_mode = get_local_control_mode();
     set_local_control_mode(LocalControlMode::OFF);
   } else {
+    _audio_engine.unmute();
     if (_previous_local_control_mode.has_value()) {
       set_local_control_mode(_previous_local_control_mode.value());
       _previous_local_control_mode.reset();


### PR DESCRIPTION
Introduces mute/unmute functionality to the AudioEngine to prevent audible crackling during SysEx file transfers.

The MessageRouter now observes SysEx transfer state changes and mutes the AudioEngine when a transfer begins and unmutes it upon completion. This ensures a clean audio output during data-intensive operations without altering the existing local control logic.

Closes #326