### PR TITLE
Velocity on HOLD when step is disabled

### DIFF
--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -138,8 +138,8 @@ void PizzaControls::KeypadComponent::KeypadEventHandler::handle_sequencer_step(
   uint8_t track_index =
       (drum::PizzaDisplay::SEQUENCER_TRACKS_DISPLAYED - 1) - event.col;
   uint8_t step_index = (KEYPAD_ROWS - 1) - event.row;
-  auto &track =
-      controls->_sequencer_controller_ref.get_sequencer().get_track(track_index);
+  auto &track = controls->_sequencer_controller_ref.get_sequencer().get_track(
+      track_index);
 
   if (event.type == musin::ui::KeypadEvent::Type::Press) {
     const bool now_enabled = track.toggle_step_enabled(step_index);
@@ -153,7 +153,7 @@ void PizzaControls::KeypadComponent::KeypadEventHandler::handle_sequencer_step(
                                                             step_velocity);
       }
     }
-  } 
+  }
   if (event.type == musin::ui::KeypadEvent::Type::Hold) {
     if (!track.get_step(step_index).enabled) {
       track.set_step_enabled(step_index, true);


### PR DESCRIPTION
Previously, HOLDing a step button when a step was disabled would turn it on at a lower velocity. If the step was already enabled, HOLDing would have no effect.

This PR changes the behaviour by letting a HOLD action always result in an enabled step with lower velocity. It keeps the PRESS event as trigger for toggling between enabled and disabled. This means interacting with the sequencer remains snappy but also results in the step toggling between on and off between the PRESS and HOLD state if it was previously on. This is an intentional tradeoff.