### PR TITLE
feat: add 1s timeout before transitioning from FileTransfer to SequencerState

### DIFF
--- a/drum/state_implementations.cpp
+++ b/drum/state_implementations.cpp
@@ -56,18 +56,40 @@ void SequencerState::exit(musin::Logger &logger) {
 
 void FileTransferState::enter(musin::Logger &logger) {
   logger.debug("Entering FileTransfer state");
+  transfer_active_ = true;
+  last_transfer_activity_ = get_absolute_time();
 }
 
-void FileTransferState::update(
-    [[maybe_unused]] musin::Logger &logger,
-    [[maybe_unused]] SystemStateMachine &state_machine,
-    [[maybe_unused]] absolute_time_t now) {
-  // TODO Phase 4: Handle file transfer-specific logic
-  // Minimal implementation for now
+void FileTransferState::update(musin::Logger &logger,
+                               SystemStateMachine &state_machine,
+                               absolute_time_t now) {
+  // Check if we should transition back to Sequencer after timeout
+  if (!transfer_active_) {
+    uint64_t elapsed_us =
+        to_us_since_boot(now) - to_us_since_boot(last_transfer_activity_);
+    if (elapsed_us > (TIMEOUT_MS * 1000)) { // Convert ms to us
+      logger.debug("File transfer timeout - transitioning to Sequencer");
+      state_machine.transition_to(SystemStateId::Sequencer);
+    }
+  }
 }
 
 void FileTransferState::exit(musin::Logger &logger) {
   logger.debug("Exiting FileTransfer state");
+}
+
+void FileTransferState::reset_timeout() {
+  transfer_active_ = true;
+  last_transfer_activity_ = get_absolute_time();
+}
+
+void FileTransferState::mark_transfer_inactive() {
+  transfer_active_ = false;
+  last_transfer_activity_ = get_absolute_time();
+}
+
+bool FileTransferState::is_transfer_active() const {
+  return transfer_active_;
 }
 
 // --- FallingAsleepState Implementation ---

--- a/drum/state_implementations.h
+++ b/drum/state_implementations.h
@@ -49,6 +49,27 @@ public:
   SystemStateId get_id() const override {
     return SystemStateId::FileTransfer;
   }
+
+  /**
+   * @brief Reset the inactivity timeout when file transfer activity occurs.
+   */
+  void reset_timeout();
+
+  /**
+   * @brief Mark transfer as inactive and start timeout countdown.
+   */
+  void mark_transfer_inactive();
+
+  /**
+   * @brief Check if file transfer is currently active.
+   * @return true if actively transferring, false if in timeout period
+   */
+  bool is_transfer_active() const;
+
+private:
+  absolute_time_t last_transfer_activity_;
+  bool transfer_active_;
+  static constexpr uint32_t TIMEOUT_MS = 1000; // 1 second timeout
 };
 
 /**

--- a/drum/system_state_machine.cpp
+++ b/drum/system_state_machine.cpp
@@ -51,9 +51,22 @@ void SystemStateMachine::notification(
     drum::Events::SysExTransferStateChangeEvent event) {
   // Handle SysEx transfer state changes
   if (event.is_active) {
-    transition_to(SystemStateId::FileTransfer);
+    if (get_current_state() == SystemStateId::FileTransfer) {
+      // Reset timeout if already in FileTransfer state
+      FileTransferState *ft_state =
+          static_cast<FileTransferState *>(current_state_.get());
+      ft_state->reset_timeout();
+    } else {
+      // Transition to FileTransfer state
+      transition_to(SystemStateId::FileTransfer);
+    }
   } else {
-    transition_to(SystemStateId::Sequencer);
+    // Mark transfer as inactive - let FileTransferState handle timeout
+    if (get_current_state() == SystemStateId::FileTransfer) {
+      FileTransferState *ft_state =
+          static_cast<FileTransferState *>(current_state_.get());
+      ft_state->mark_transfer_inactive();
+    }
   }
 }
 


### PR DESCRIPTION
- Added timeout tracking to FileTransferState to prevent UI flashing
- FileTransferState now waits 1000ms after last transfer activity before transitioning to Sequencer
- SystemStateMachine notification method updated to reset/mark transfer inactive appropriately
- Fixes rapid UI mode switching when transferring multiple files in succession

Resolves #414