### PR TITLE
feat: implement linear MIDI note to sample slot mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ DRUM is a MIDI drum machine/sequencer running on RP2350 microcontroller. Feature
 
 ### Building & Testing
 ```bash
-./build.sh [options]  # See README.md for full options
+drum/build.sh [options]  # See README.md for full options
 cd test && ./run_all_tests.sh
 ```
 
@@ -84,5 +84,5 @@ cd test && ./run_all_tests.sh
 ## Testing Philosophy
 Use dependency injection and abstractions to enable comprehensive testing of business logic.
 
-**Reference:** See CONVENTIONS.md for detailed C++/SDK interaction patterns.
+**[Reference](Reference):** See CONVENTIONS.md for detailed C++/SDK interaction patterns.
 **Build details:** See README.md and drum/README.md for comprehensive build/MIDI specs.

--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -201,16 +201,9 @@ void AudioEngine::set_crush_depth(float normalized_value) {
 }
 
 void AudioEngine::notification(drum::Events::NoteEvent event) {
-  const auto &defs = drum::config::global_note_definitions;
-  auto it = std::find_if(defs.begin(), defs.end(),
-                         [midi_note = event.note](const auto &def) {
-                           return def.midi_note_number == midi_note;
-                         });
-
-  if (it != defs.end()) {
-    size_t sample_id = std::distance(defs.begin(), it);
-    play_on_voice(event.track_index, sample_id, event.velocity);
-  }
+  // Direct mapping: MIDI note = sample slot
+  size_t sample_id = event.note;
+  play_on_voice(event.track_index, sample_id, event.velocity);
 }
 
 } // namespace drum

--- a/drum/config.h
+++ b/drum/config.h
@@ -104,25 +104,25 @@ constexpr uint8_t RANDOM_PROBABILITY_DEFAULT =
     75; // chance to flip steps when random is active
 } // namespace drumpad
 
-// MIDI Note Numbers from DATO_Drum_midi_implementation_chart.md for general
-// MIDI input Track 1 - Kick/Bass Drums
-constexpr etl::array<uint8_t, 8> track_0_notes = {
-    {35, 36, 37, 41, 43, 47, 48, 50}};
-// Track 2 - Snare Drums
-constexpr etl::array<uint8_t, 8> track_1_notes = {
-    {38, 40, 39, 54, 56, 75, 76, 77}};
-// Track 3 - Percussion
-constexpr etl::array<uint8_t, 8> track_2_notes = {
-    {45, 58, 59, 60, 61, 62, 63, 64}};
-// Track 4 - Hi-Hats & Cymbals
-constexpr etl::array<uint8_t, 8> track_3_notes = {
-    {42, 44, 46, 49, 51, 52, 53, 57}};
+// Linear MIDI note to sample slot mapping
+// Each track has a contiguous range of MIDI notes that map directly to sample
+// slots
+struct TrackRange {
+  uint8_t low_note;  // Inclusive lower bound
+  uint8_t high_note; // Inclusive upper bound
 
-constexpr etl::array<etl::span<const uint8_t>, NUM_DRUMPADS> track_note_ranges =
-    {{etl::span<const uint8_t>(track_0_notes),
-      etl::span<const uint8_t>(track_1_notes),
-      etl::span<const uint8_t>(track_2_notes),
-      etl::span<const uint8_t>(track_3_notes)}};
+  constexpr bool contains(uint8_t note) const {
+    return note >= low_note && note <= high_note;
+  }
+};
+
+// Default ranges - MIDI note N maps directly to sample slot N
+constexpr etl::array<TrackRange, NUM_TRACKS> track_ranges = {{
+    {30, 37}, // Track 0: notes 30-37 → sample slots 30-37
+    {38, 45}, // Track 1: notes 38-45 → sample slots 38-45
+    {46, 53}, // Track 2: notes 46-53 → sample slots 46-53
+    {54, 61}  // Track 3: notes 54-61 → sample slots 54-61
+}};
 
 // Note Definitions with Colors
 struct NoteDefinition {
@@ -131,42 +131,42 @@ struct NoteDefinition {
 };
 
 constexpr etl::array<NoteDefinition, 32> global_note_definitions = {
-    {// Track 0 (Kick/Bass)
-     {35, 0xFF0000},
-     {36, 0xFF0020},
-     {37, 0xFF0040},
-     {41, 0xFF0060},
-     {43, 0xFF1010},
-     {47, 0xFF1020},
-     {48, 0xFF2040},
-     {50, 0xFF2060},
-     // Track 1 (Snare)
+    {// Track 0 (notes 30-37)
+     {30, 0xFF0000},
+     {31, 0xFF0020},
+     {32, 0xFF0040},
+     {33, 0xFF0060},
+     {34, 0xFF1010},
+     {35, 0xFF1020},
+     {36, 0xFF2040},
+     {37, 0xFF2060},
+     // Track 1 (notes 38-45)
      {38, 0x0000FF},
-     {40, 0x0028FF},
-     {39, 0x0050FF},
-     {54, 0x0078FF},
-     {56, 0x1010FF},
-     {75, 0x1028FF},
-     {76, 0x2050FF},
-     {77, 0x3078FF},
-     // Track 2 (Percussion)
-     {45, 0x00FF00},
-     {58, 0x00FF1E},
-     {59, 0x00FF3C},
-     {60, 0x00FF5A},
-     {61, 0x10FF10},
-     {62, 0x10FF1E},
-     {63, 0x10FF3C},
-     {64, 0x20FF5A},
-     // Track 3 (Hi-Hats/Cymbals)
-     {42, 0xFFFF00},
-     {44, 0xFFE100},
-     {46, 0xFFC300},
-     {49, 0xFFA500},
-     {51, 0xFFFF20},
-     {52, 0xFFE120},
-     {53, 0xFFC320},
-     {57, 0xFFA520}}};
+     {39, 0x0028FF},
+     {40, 0x0050FF},
+     {41, 0x0078FF},
+     {42, 0x1010FF},
+     {43, 0x1028FF},
+     {44, 0x2050FF},
+     {45, 0x3078FF},
+     // Track 2 (notes 46-53)
+     {46, 0x00FF00},
+     {47, 0x00FF1E},
+     {48, 0x00FF3C},
+     {49, 0x00FF5A},
+     {50, 0x10FF10},
+     {51, 0x10FF1E},
+     {52, 0x10FF3C},
+     {53, 0x20FF5A},
+     // Track 3 (notes 54-61)
+     {54, 0xFFFF00},
+     {55, 0xFFE100},
+     {56, 0xFFC300},
+     {57, 0xFFA500},
+     {58, 0xFFFF20},
+     {59, 0xFFE120},
+     {60, 0xFFC320},
+     {61, 0xFFA520}}};
 
 // Analog Control Component Configuration
 namespace analog_controls {

--- a/drum/configuration_manager.h
+++ b/drum/configuration_manager.h
@@ -37,7 +37,7 @@ struct SampleConfig {
 class ConfigurationManager {
 public:
   static constexpr const char *CONFIG_PATH = "/kit.bin";
-  static constexpr size_t MAX_SAMPLES = 32;
+  static constexpr size_t MAX_SAMPLES = 128;
 
   explicit ConfigurationManager(musin::Logger &logger);
 

--- a/drum/sample_repository.h
+++ b/drum/sample_repository.h
@@ -21,7 +21,7 @@ namespace drum {
  */
 class SampleRepository {
 public:
-  static constexpr size_t MAX_SAMPLES = 32;
+  static constexpr size_t MAX_SAMPLES = 128;
   static constexpr size_t MAX_PATH_LENGTH = 16; // "/NN.pcm" is small
 
   explicit SampleRepository(musin::Logger &logger);

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -635,10 +635,9 @@ void SequencerController<NumTracks, NumSteps>::select_random_sequencer() {
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::initialize_active_notes() {
   for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
-    if (track_idx < config::track_note_ranges.size() &&
-        !config::track_note_ranges[track_idx].empty()) {
+    if (track_idx < config::track_ranges.size()) {
       _active_note_per_track[track_idx] =
-          config::track_note_ranges[track_idx][0];
+          config::track_ranges[track_idx].low_note;
     }
   }
 }

--- a/drum/sequencer_persistence.h
+++ b/drum/sequencer_persistence.h
@@ -39,10 +39,12 @@ struct SequencerPersistentState {
 
   SequencerPersistentState() : magic(MAGIC_NUMBER), version(FORMAT_VERSION) {
     // Initialize active notes with first note from each track's range
-    active_notes[0] = config::track_0_notes[0]; // Kick
-    active_notes[1] = config::track_1_notes[0]; // Snare
-    active_notes[2] = config::track_2_notes[0]; // Percussion
-    active_notes[3] = config::track_3_notes[0]; // Hi-Hat
+    active_notes[0] = config::track_ranges[0]
+                          .high_note; // Track 1: 37 Kick on old drumcomputers
+    active_notes[1] = config::track_ranges[1]
+                          .low_note; // Track 1: 38 Snare on old drumcomputers
+    active_notes[2] = config::track_ranges[2].low_note; // Track 2: 46
+    active_notes[3] = config::track_ranges[3].low_note; // Track 3: 54
 
     // Clear all pattern data
     for (auto &track : tracks) {

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -756,14 +756,16 @@ function parseExplicitSlots(fileArgs, sampleRate) {
 // Parse auto-increment format (just filenames)
 function parseAutoIncrement(fileArgs, sampleRate) {
   const transfers = [];
-  
+  const AUTO_SLOT_OFFSET = 30; // Start auto-assignment from slot 30
+
   fileArgs.forEach((filePath, index) => {
-    if (index > 127) {
-      throw new Error(`Too many files. Maximum 128 slots (0-127).`);
+    const slot = index + AUTO_SLOT_OFFSET;
+    if (slot > 127) {
+      throw new Error(`Too many files. Maximum ${128 - AUTO_SLOT_OFFSET} files when auto-assigning from slot ${AUTO_SLOT_OFFSET}.`);
     }
-    transfers.push({ filePath, slot: index, sampleRate });
+    transfers.push({ filePath, slot, sampleRate });
   });
-  
+
   return transfers;
 }
 
@@ -823,7 +825,7 @@ if (!command) {
   console.log("");
   console.log("Send Arguments:");
   console.log("  file:slot      - Audio file path and target slot (0-127)");
-  console.log("  file           - Audio file path (auto-assigns slots 0,1,2... in order)");
+  console.log("  file           - Audio file path (auto-assigns slots 30,31,32... in order)");
   console.log("  sample_rate    - Sample rate in Hz for raw PCM files (default: 44100).");
   console.log("                   For WAV files, the sample rate is detected automatically.");
   console.log("  --verbose, -v  - Show detailed transfer information");
@@ -832,8 +834,8 @@ if (!command) {
   console.log("  # Explicit slot assignment (WAV files are auto-converted):");
   console.log("  drumtool.js send kick.wav:0 snare.wav:1");
   console.log("  ");
-  console.log("  # Auto-increment slots (starts from 0):");
-  console.log("  drumtool.js send kick.wav snare.wav hat.wav   # Slots 0,1,2 automatically");
+  console.log("  # Auto-increment slots (starts from 30):");
+  console.log("  drumtool.js send kick.wav snare.wav hat.wav   # Slots 30,31,32 automatically");
   console.log("  ");
   console.log("  # Transfer raw PCM data with a specific sample rate:");
   console.log("  drumtool.js send my_sample.pcm:10 22050 -v");


### PR DESCRIPTION
## Summary
Implements linear MIDI note to sample slot mapping where MIDI note N maps directly to sample slot N.

• **Track Ranges**: 30-37, 38-45, 46-53, 54-61 mapped to respective sample slots
• **First Match Wins**: Overlapping ranges handled by track priority order
• **Direct Mapping**: MIDI note 36 plays sample `/36.pcm` 
• **Increased Capacity**: MAX_SAMPLES expanded from 32 to 128
• **Tool Updates**: drumtool now auto-assigns samples starting from slot 30

## Changes
- Replaced lookup tables with TrackRange structure in config.h
- Updated MIDI message routing for direct note-to-slot mapping
- Modified AudioEngine to use linear mapping
- Updated sample repository to support 128 samples
- Fixed drumtool auto-assignment to start at slot 30
- Updated global_note_definitions for linear 30-61 range

## Test plan
- [ ] Build firmware successfully
- [ ] Upload samples using drumtool (auto-assigns to slots 30+)
- [ ] Send MIDI note 36 and verify `/36.pcm` is played
- [ ] Test all track ranges respond to correct MIDI notes
- [ ] Verify first-match-wins behavior for any overlaps

Closes #473