### PR TITLE
feat(display): add velocity ring lighting for drumpad feedback

### DIFF
--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -337,11 +337,13 @@ void PizzaControls::DrumpadComponent::DrumpadEventHandler::notification(
         uint8_t note = parent->get_note_for_pad(event.pad_index);
         uint8_t velocity = event.velocity.value();
         seq_controller.trigger_note_on(event.pad_index, note, velocity);
+        seq_controller.record_velocity_hit(event.pad_index);
       }
     } else if (event.type == musin::ui::DrumpadEvent::Type::Release) {
       logger.debug("RELEASED ", static_cast<uint32_t>(event.pad_index));
       uint8_t note = parent->get_note_for_pad(event.pad_index);
       seq_controller.trigger_note_off(event.pad_index, note);
+      seq_controller.clear_velocity_hit(event.pad_index);
     } else if (event.type == musin::ui::DrumpadEvent::Type::Hold) {
       logger.debug("HELD ", static_cast<uint32_t>(event.pad_index));
     }

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -529,6 +529,31 @@ uint8_t SequencerController<NumTracks, NumSteps>::get_retrigger_mode_for_track(
 }
 
 template <size_t NumTracks, size_t NumSteps>
+void SequencerController<NumTracks, NumSteps>::record_velocity_hit(
+    uint8_t track_index) {
+  if (track_index < NumTracks) {
+    _has_active_velocity_hit[track_index] = true;
+  }
+}
+
+template <size_t NumTracks, size_t NumSteps>
+void SequencerController<NumTracks, NumSteps>::clear_velocity_hit(
+    uint8_t track_index) {
+  if (track_index < NumTracks) {
+    _has_active_velocity_hit[track_index] = false;
+  }
+}
+
+template <size_t NumTracks, size_t NumSteps>
+bool SequencerController<NumTracks, NumSteps>::has_recent_velocity_hit(
+    uint8_t track_index) const {
+  if (track_index < NumTracks) {
+    return _has_active_velocity_hit[track_index];
+  }
+  return false;
+}
+
+template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::activate_play_on_every_step(
     uint8_t track_index, uint8_t mode) {
   if (track_index < NumTracks && (mode == 1 || mode == 2)) {
@@ -664,6 +689,7 @@ void SequencerController<NumTracks, NumSteps>::initialize_timing_and_random() {
   srand(time_us_32());
   _just_played_step_per_track.fill(std::nullopt);
   _pad_pressed_state.fill(false);
+  _has_active_velocity_hit.fill(false);
 }
 
 template <size_t NumTracks, size_t NumSteps>

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -211,6 +211,10 @@ public:
   void set_pad_pressed_state(uint8_t track_index, bool is_pressed);
   [[nodiscard]] bool is_pad_pressed(uint8_t track_index) const;
 
+  void record_velocity_hit(uint8_t track_index);
+  void clear_velocity_hit(uint8_t track_index);
+  [[nodiscard]] bool has_recent_velocity_hit(uint8_t track_index) const;
+
   /**
    * @brief Get the current retrigger mode for a track.
    * @param track_index The track index to check.
@@ -264,6 +268,7 @@ private:
   etl::array<uint8_t, NumTracks> _active_note_per_track{};
   etl::array<bool, NumTracks> _pad_pressed_state{};
   etl::array<RetriggerMode, NumTracks> _retrigger_mode_per_track{};
+  etl::array<bool, NumTracks> _has_active_velocity_hit{};
 
   // Persistence management (optional until filesystem is ready)
   std::optional<SequencerStorage<NumTracks, NumSteps>> storage_;

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -168,7 +168,8 @@ void SequencerDisplayMode::update_track_override_colors(PizzaDisplay &display) {
   for (uint8_t track_idx = 0;
        track_idx < PizzaDisplay::SEQUENCER_TRACKS_DISPLAYED; ++track_idx) {
     if (_sequencer_controller_ref.is_pad_pressed(track_idx) ||
-        _sequencer_controller_ref.get_retrigger_mode_for_track(track_idx) > 0) {
+        _sequencer_controller_ref.get_retrigger_mode_for_track(track_idx) > 0 ||
+        _sequencer_controller_ref.has_recent_velocity_hit(track_idx)) {
       uint8_t active_note =
           _sequencer_controller_ref.get_active_note_for_track(track_idx);
       std::optional<Color> color_opt =


### PR DESCRIPTION
## Summary
- Adds visual feedback by lighting up the entire sequencer ring when drumpads are hit with velocity
- Ring lights up during velocity hit and clears when drumpad is released
- Leverages existing ring lighting infrastructure used by retrigger mode

## Implementation
- Added velocity tracking boolean flags to SequencerController
- Extended DrumpadEventHandler to record/clear velocity hits on Press/Release events  
- Updated display logic to include velocity condition in ring lighting

## Testing
- [x] Code compiles successfully
- [ ] Manual testing on hardware pending

Closes #465