### PR TITLE
Fix bright flash during sleep transition (#448)

### DIFF
--- a/drum/state_implementations.cpp
+++ b/drum/state_implementations.cpp
@@ -168,7 +168,7 @@ void SleepState::update(musin::Logger &logger,
       logger.debug("Button released - now monitoring for wake press");
     }
     // Don't check for wake press while waiting for release
-    sleep_us(1000);
+    sleep_us(10000);
     watchdog_update();
     return;
   }

--- a/drum/state_implementations.h
+++ b/drum/state_implementations.h
@@ -101,6 +101,9 @@ public:
   SystemStateId get_id() const override {
     return SystemStateId::Sleep;
   }
+
+private:
+  bool waiting_for_button_release_ = true;
 };
 
 } // namespace drum

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -412,7 +412,8 @@ void SleepDisplayMode::draw(PizzaDisplay &display, absolute_time_t now) {
     // Delegate drawing to the previous mode with new brightness
     _previous_mode->get().draw(display, now);
   } else {
-    // Dimming complete - clear display and deinit immediately
+    // We turn off at brightness 1 and below to prevent bright flash
+    // Dimming complete - deinit() before clear to prevent bright flash
     display.deinit();
     display.clear();
   }

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -408,11 +408,12 @@ void SleepDisplayMode::draw(PizzaDisplay &display, absolute_time_t now) {
   const uint8_t current_brightness = calculate_brightness(now);
   display.set_brightness(current_brightness);
 
-  if (current_brightness > 0 && _previous_mode.has_value()) {
+  if (current_brightness > 1 && _previous_mode.has_value()) {
     // Delegate drawing to the previous mode with new brightness
     _previous_mode->get().draw(display, now);
   } else {
-    // Dimming complete - clear display
+    // Dimming complete - clear display and deinit immediately
+    display.deinit();
     display.clear();
   }
 }


### PR DESCRIPTION
## Summary
Fixes the bright flash that sometimes occurs just before device turn off on long PLAYBUTTON press.

## Root Cause Analysis
The issue was caused by a blocking `while` loop in `SleepState::enter()` that waited for button release, which:
- Froze the main loop during sleep transition
- Prevented smooth display dimming completion  
- Created timing gaps where full brightness could flash

## Solution
Implemented a three-part fix:

### 1. Non-blocking Button Release Detection
- Moved button release detection from `SleepState::enter()` to `SleepState::update()`
- Added `waiting_for_button_release_` state flag
- Maintains responsive main loop during sleep transition

### 2. Synchronized State Timing  
- Changed `FallingAsleepState` timeout from 750ms → 500ms
- Now matches `SleepDisplayMode::DIMMING_DURATION_MS` exactly
- Ensures state transition happens when dimming completes

### 3. Immediate Display Deinit
- `SleepDisplayMode` now calls `display.deinit()` immediately when brightness reaches zero
- Eliminates any gap between software dimming and hardware shutdown
- Zero coupling approach - sleep mode handles its own cleanup

## Testing
- ✅ Build successful with no compilation errors
- ✅ Code formatting and pre-commit hooks passed
- ✅ Firmware uploaded to device successfully

## Files Changed
- `drum/state_implementations.h` - Added button release state tracking
- `drum/state_implementations.cpp` - Non-blocking button detection + timing sync
- `drum/ui/display_mode.cpp` - Immediate display deinit on brightness zero

Closes #448