### PR TITLE
Bug/479 sync double half speed

### DIFF
--- a/musin/timing/clock_multiplier.cpp
+++ b/musin/timing/clock_multiplier.cpp
@@ -42,15 +42,7 @@ void ClockMultiplier::notification(musin::timing::ClockEvent event) {
   multiplied_event.timestamp_us =
       (event.timestamp_us != 0) ? event.timestamp_us
                                 : static_cast<uint32_t>(to_us_since_boot(now));
-  // Emit anchor intent for the immediate tick of each physical pulse.
-  // Alternate between 12 and 0 to align eighth boundaries.
-  if (is_physical) {
-    multiplied_event.anchor_to_phase =
-        next_anchor_is_12_ ? PHASE_EIGHTH_OFFBEAT : PHASE_DOWNBEAT;
-    next_anchor_is_12_ = !next_anchor_is_12_;
-  } else {
-    multiplied_event.anchor_to_phase = ClockEvent::ANCHOR_PHASE_NONE;
-  }
+  multiplied_event.anchor_to_phase = ClockEvent::ANCHOR_PHASE_NONE;
   notify_observers(multiplied_event);
   pulse_counter_++;
   if (pulse_interval_us_ > 0) {
@@ -86,8 +78,6 @@ void ClockMultiplier::reset() {
   pulse_interval_us_ = 0;
   last_pulse_time_ = nil_time;
   next_pulse_time_ = nil_time;
-  // After reset/source change, start with 12 as the first anchor
-  next_anchor_is_12_ = true;
 }
 
 // Note: Speed modification is handled by TempoHandler; no speed controls here.

--- a/musin/timing/clock_multiplier.h
+++ b/musin/timing/clock_multiplier.h
@@ -34,8 +34,6 @@ private:
   absolute_time_t last_pulse_time_ = nil_time;
   absolute_time_t next_pulse_time_ = nil_time;
   ClockSource current_source_ = ClockSource::INTERNAL;
-  // Alternate anchors 0/12 on each physical pulse; start at 12 after reset
-  bool next_anchor_is_12_ = true;
 };
 
 } // namespace musin::timing

--- a/musin/timing/clock_router.cpp
+++ b/musin/timing/clock_router.cpp
@@ -5,11 +5,10 @@ namespace musin::timing {
 
 ClockRouter::ClockRouter(InternalClock &internal_clock_ref,
                          MidiClockProcessor &midi_clock_processor_ref,
-                         ClockMultiplier &clock_multiplier_ref,
-                         ClockSource initial_source)
+                         SyncIn &sync_in_ref, ClockSource initial_source)
     : internal_clock_(internal_clock_ref),
-      midi_clock_processor_(midi_clock_processor_ref),
-      clock_multiplier_(clock_multiplier_ref), current_source_(initial_source) {
+      midi_clock_processor_(midi_clock_processor_ref), sync_in_(sync_in_ref),
+      current_source_(initial_source) {
   set_clock_source(initial_source);
 }
 
@@ -51,8 +50,7 @@ void ClockRouter::detach_current_source() {
     midi_clock_processor_.set_forward_echo_enabled(false);
     break;
   case ClockSource::EXTERNAL_SYNC:
-    clock_multiplier_.remove_observer(*this);
-    clock_multiplier_.reset();
+    sync_in_.remove_observer(*this);
     break;
   }
 }
@@ -69,8 +67,7 @@ void ClockRouter::attach_source(ClockSource source) {
     midi_clock_processor_.set_forward_echo_enabled(true);
     break;
   case ClockSource::EXTERNAL_SYNC:
-    clock_multiplier_.add_observer(*this);
-    clock_multiplier_.reset();
+    sync_in_.add_observer(*this);
     break;
   }
 }

--- a/musin/timing/clock_router.h
+++ b/musin/timing/clock_router.h
@@ -3,9 +3,9 @@
 
 #include "etl/observer.h"
 #include "musin/timing/clock_event.h"
-#include "musin/timing/clock_multiplier.h"
 #include "musin/timing/internal_clock.h"
 #include "musin/timing/midi_clock_processor.h"
+#include "musin/timing/sync_in.h"
 #include <cstdint>
 
 namespace musin::timing {
@@ -15,7 +15,7 @@ constexpr size_t MAX_CLOCK_ROUTER_OBSERVERS = 3;
 /**
  * Selects the active raw 24 PPQN clock source and fans it out to observers.
  * Starts/stops internal clock, enables/disables MIDI forward echo,
- * and resets external multipliers on source changes.
+ * and handles sync source management on source changes.
  */
 class ClockRouter
     : public etl::observer<musin::timing::ClockEvent>,
@@ -23,8 +23,7 @@ class ClockRouter
                              MAX_CLOCK_ROUTER_OBSERVERS> {
 public:
   ClockRouter(InternalClock &internal_clock_ref,
-              MidiClockProcessor &midi_clock_processor_ref,
-              ClockMultiplier &clock_multiplier_ref,
+              MidiClockProcessor &midi_clock_processor_ref, SyncIn &sync_in_ref,
               ClockSource initial_source = ClockSource::INTERNAL);
 
   void set_clock_source(ClockSource source);
@@ -41,7 +40,7 @@ private:
 
   InternalClock &internal_clock_;
   MidiClockProcessor &midi_clock_processor_;
-  ClockMultiplier &clock_multiplier_;
+  SyncIn &sync_in_;
   ClockSource current_source_;
   bool initialized_ = false;
 };

--- a/musin/timing/sync_in.cpp
+++ b/musin/timing/sync_in.cpp
@@ -40,6 +40,9 @@ void SyncIn::update(absolute_time_t now) {
       if (!is_nil_time(last_physical_pulse_time_)) {
         uint64_t physical_interval_us =
             absolute_time_diff_us(last_physical_pulse_time_, now);
+        // Note: Integer division truncates fractional microseconds, causing minor
+        // timing drift for interpolated ticks. This error is reset on each
+        // physical pulse and does not accumulate.
         tick_interval_us_ = physical_interval_us / PPQN_MULTIPLIER;
       }
       last_physical_pulse_time_ = now;

--- a/musin/timing/sync_in.cpp
+++ b/musin/timing/sync_in.cpp
@@ -27,7 +27,6 @@ SyncIn::SyncIn(uint32_t sync_pin, uint32_t detect_pin)
   tick_interval_us_ = 0;
   interpolated_tick_counter_ = 0;
   next_tick_time_ = nil_time;
-  next_anchor_is_12_ = true;
 }
 
 void SyncIn::update(absolute_time_t now) {
@@ -45,11 +44,8 @@ void SyncIn::update(absolute_time_t now) {
       }
       last_physical_pulse_time_ = now;
 
-      // Emit immediate physical pulse tick with anchor
-      uint8_t anchor_phase =
-          next_anchor_is_12_ ? PHASE_EIGHTH_OFFBEAT : PHASE_DOWNBEAT;
-      emit_clock_event(now, true, anchor_phase);
-      next_anchor_is_12_ = !next_anchor_is_12_;
+      // Emit immediate physical pulse tick
+      emit_clock_event(now, true);
 
       // Schedule next 11 interpolated ticks if we have timing
       if (tick_interval_us_ > 0) {
@@ -105,12 +101,10 @@ bool SyncIn::is_cable_connected() const {
   return !current_detect_state_; // Active low: true when pin is low
 }
 
-void SyncIn::emit_clock_event(absolute_time_t timestamp, bool is_physical,
-                              uint8_t anchor_phase) {
+void SyncIn::emit_clock_event(absolute_time_t timestamp, bool is_physical) {
   ClockEvent event{ClockSource::EXTERNAL_SYNC};
   event.is_physical_pulse = is_physical;
   event.timestamp_us = static_cast<uint32_t>(to_us_since_boot(timestamp));
-  event.anchor_to_phase = anchor_phase;
   notify_observers(event);
 }
 
@@ -129,8 +123,8 @@ void SyncIn::emit_scheduled_ticks(absolute_time_t now) {
   }
 
   if (time_reached(next_tick_time_)) {
-    // Emit interpolated tick (not physical, no anchor)
-    emit_clock_event(next_tick_time_, false, ClockEvent::ANCHOR_PHASE_NONE);
+    // Emit interpolated tick (not physical)
+    emit_clock_event(next_tick_time_, false);
 
     interpolated_tick_counter_++;
 

--- a/musin/timing/sync_in.h
+++ b/musin/timing/sync_in.h
@@ -43,14 +43,12 @@ private:
   uint64_t tick_interval_us_ = 0;         // Interval for 24 PPQN ticks
   uint8_t interpolated_tick_counter_ = 0; // 0-11, tracks interpolated ticks
   absolute_time_t next_tick_time_ = nil_time;
-  bool next_anchor_is_12_ = true; // Alternate anchors between 0 and 12
 
   static constexpr uint32_t PULSE_DEBOUNCE_US = 5000;   // 5ms
   static constexpr uint32_t DETECT_DEBOUNCE_US = 50000; // 50ms
   static constexpr uint8_t PPQN_MULTIPLIER = 12;        // 2 PPQN to 24 PPQN
 
-  void emit_clock_event(absolute_time_t timestamp, bool is_physical,
-                        uint8_t anchor_phase = ClockEvent::ANCHOR_PHASE_NONE);
+  void emit_clock_event(absolute_time_t timestamp, bool is_physical);
   void schedule_interpolated_ticks(absolute_time_t now);
   void emit_scheduled_ticks(absolute_time_t now);
 };

--- a/musin/timing/sync_in.h
+++ b/musin/timing/sync_in.h
@@ -12,6 +12,17 @@ namespace musin::timing {
 
 constexpr size_t MAX_SYNC_IN_OBSERVERS = 1;
 
+/**
+ * Handles external sync input, providing three main functions:
+ * 1. Debounces the incoming physical sync pulse (2 PPQN).
+ * 2. Detects whether the sync cable is connected (active-low).
+ * 3. Converts the 2 PPQN signal to a 24 PPQN clock signal by emitting 11
+ *    interpolated ticks between each physical pulse.
+ *
+ * Note on initial sync: A timing interval cannot be established until two
+ * physical pulses have been received. Therefore, full 24 PPQN clock output
+ * begins after the second physical pulse.
+ */
 class SyncIn : public etl::observable<etl::observer<musin::timing::ClockEvent>,
                                       MAX_SYNC_IN_OBSERVERS> {
 public:

--- a/test/musin/timing/tempo_handler_external_sync_test.cpp
+++ b/test/musin/timing/tempo_handler_external_sync_test.cpp
@@ -1,0 +1,139 @@
+
+#include "midi_test_support.h"
+#include "musin/hal/null_logger.h"
+#include "pico/time.h"
+#include "test_support.h"
+
+#include "musin/midi/midi_output_queue.h"
+#include "musin/timing/clock_multiplier.h"
+#include "musin/timing/clock_router.h"
+#include "musin/timing/internal_clock.h"
+#include "musin/timing/midi_clock_out.h"
+#include "musin/timing/midi_clock_processor.h"
+#include "musin/timing/speed_adapter.h"
+#include "musin/timing/sync_in.h" // Test override provides stub
+#include "musin/timing/tempo_handler.h"
+#include "musin/timing/timing_constants.h"
+
+#include <etl/observer.h>
+#include <vector>
+
+using musin::timing::ClockEvent;
+using musin::timing::ClockSource;
+using musin::timing::InternalClock;
+using musin::timing::MidiClockProcessor;
+using musin::timing::PlaybackState;
+using musin::timing::SpeedModifier;
+using musin::timing::TempoEvent;
+using musin::timing::TempoHandler;
+
+namespace {
+
+// Simple observer to capture TempoEvents for assertions
+struct TempoEventRecorder : etl::observer<TempoEvent> {
+  std::vector<TempoEvent> events;
+  void notification(TempoEvent e) {
+    events.push_back(e);
+  }
+  void clear() {
+    events.clear();
+  }
+};
+
+// Helper to advance mock time
+static void advance_time_us(uint64_t us) {
+  advance_mock_time_us(us);
+}
+
+} // namespace
+
+TEST_CASE("TempoHandler external sync half-speed forwards every other tick") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_proc;
+  musin::timing::SyncIn sync_in(0, 1);
+  musin::timing::ClockMultiplier clock_multiplier(12);
+  musin::timing::ClockRouter clock_router(internal_clock, midi_proc, sync_in,
+                                          ClockSource::EXTERNAL_SYNC);
+  musin::timing::SpeedAdapter speed_adapter;
+
+  TempoHandler th(
+      internal_clock, midi_proc, sync_in, clock_router, speed_adapter,
+      /*send_midi_clock_when_stopped*/ false, ClockSource::EXTERNAL_SYNC);
+
+  th.set_speed_modifier(SpeedModifier::HALF_SPEED);
+
+  clock_router.add_observer(clock_multiplier);
+  clock_multiplier.add_observer(speed_adapter);
+  speed_adapter.add_observer(th);
+
+  TempoEventRecorder rec;
+  th.add_observer(rec);
+
+  // Simulate 4 external physical pulses.
+  for (int i = 0; i < 4; ++i) {
+    ClockEvent e{ClockSource::EXTERNAL_SYNC};
+    e.is_physical_pulse = true;
+    e.timestamp_us =
+        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
+    clock_router.notification(e);
+  }
+
+  REQUIRE(rec.events.size() == 2);
+  REQUIRE(rec.events[0].phase_24 == 1);
+  REQUIRE(rec.events[1].phase_24 == 2);
+}
+
+TEST_CASE("TempoHandler external sync double-speed interpolates correctly") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_proc;
+  musin::timing::SyncIn sync_in(0, 1);
+  musin::timing::ClockMultiplier clock_multiplier(12);
+  musin::timing::ClockRouter clock_router(internal_clock, midi_proc, sync_in,
+                                          ClockSource::EXTERNAL_SYNC);
+  musin::timing::SpeedAdapter speed_adapter;
+
+  TempoHandler th(
+      internal_clock, midi_proc, sync_in, clock_router, speed_adapter,
+      /*send_midi_clock_when_stopped*/ false, ClockSource::EXTERNAL_SYNC);
+
+  th.set_speed_modifier(SpeedModifier::DOUBLE_SPEED);
+
+  clock_router.add_observer(clock_multiplier);
+  clock_multiplier.add_observer(speed_adapter);
+  speed_adapter.add_observer(th);
+
+  TempoEventRecorder rec;
+  th.add_observer(rec);
+
+  // Simulate 2 physical pulses.
+  for (int i = 0; i < 2; ++i) {
+    ClockEvent e{ClockSource::EXTERNAL_SYNC};
+    e.is_physical_pulse = true;
+    e.timestamp_us =
+        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
+    clock_router.notification(e);
+
+    // Simulate time passing for interpolated ticks to be generated
+    for (int j = 0; j < 12; ++j) {
+      advance_time_us(1000);
+      clock_multiplier.update(get_absolute_time());
+      speed_adapter.update(get_absolute_time());
+    }
+  }
+
+  REQUIRE(rec.events.size() >= 40);
+
+  bool phase_always_increments = true;
+  for (size_t i = 1; i < rec.events.size(); ++i) {
+    uint8_t expected_phase = (rec.events[i - 1].phase_24 + 1) % 24;
+    if (rec.events[i].phase_24 != expected_phase) {
+      phase_always_increments = false;
+      break;
+    }
+  }
+  REQUIRE(phase_always_increments);
+}


### PR DESCRIPTION
## Summary

- External SyncIn emitted alternating anchor hints (0/12) that TempoHandler
  consumed, resetting `phase_24` to the hardware pulse cadence. Every new sync
  edge overrode `SpeedAdapter` adjustments, so half/double speed would only
  hold until the next physical pulse, and swing sometimes stalled waiting for
  a tick that the anchor logic suppressed.
- ClockMultiplier also enforced the same anchor alternation while expanding
  the 2 PPQN pulse train to 24 PPQN, compounding the override and making it
  impossible for downstream layers to manage phase independently.
- Removed anchor suggestions from both SyncIn and ClockMultiplier. They now
  emit bare `ClockEvent`s with the `is_physical_pulse` flag only, leaving
  TempoHandler free to advance phase monotonically while honoring resyncs
  explicitly requested by higher layers.
- Updated the external-sync tests to reflect the new behavior and added a
  regression suite ensuring half/double speed and interpolated ticks stay in
  lockstep when driven by SyncIn.
