### PR TITLE
Fix tempo knob position ignored when switching clock sources

### DIFF
--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -612,24 +612,9 @@ void PizzaControls::AnalogControlComponent::handle_control_change(
                                                        value, 3);
     break;
   case SPEED: {
-    if (controls->_tempo_handler_ref.get_clock_source() ==
-        musin::timing::ClockSource::INTERNAL) {
-      // Internal clock: existing BPM behavior
-      float bpm = config::analog_controls::MIN_BPM_ADJUST +
-                  value * (config::analog_controls::MAX_BPM_ADJUST -
-                           config::analog_controls::MIN_BPM_ADJUST);
-      controls->_tempo_handler_ref.set_bpm(bpm);
-    } else {
-      // External clock: pot controls speed modifier
-      musin::timing::SpeedModifier modifier =
-          musin::timing::SpeedModifier::NORMAL_SPEED;
-      if (value < 0.1f) {
-        modifier = musin::timing::SpeedModifier::HALF_SPEED;
-      } else if (value > 0.9f) {
-        modifier = musin::timing::SpeedModifier::DOUBLE_SPEED;
-      }
-      controls->_tempo_handler_ref.set_speed_modifier(modifier);
-    }
+    // Let TempoHandler decide whether to set BPM or speed modifier based on
+    // clock source
+    controls->_tempo_handler_ref.set_tempo_control_value(value);
     parent_controls->_message_router_ref.set_parameter(drum::Parameter::TEMPO,
                                                        value);
   } break;

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -92,6 +92,14 @@ public:
   void set_speed_modifier(SpeedModifier modifier);
 
   /**
+   * @brief Set tempo control value from knob position (0.0-1.0).
+   * Automatically applies appropriate BPM or speed modifier based on current
+   * clock source.
+   * @param knob_value Normalized knob position (0.0-1.0).
+   */
+  void set_tempo_control_value(float knob_value);
+
+  /**
    * @brief Get the current speed modifier.
    */
   [[nodiscard]] SpeedModifier get_speed_modifier() const {
@@ -160,6 +168,9 @@ private:
 
   // Tracks whether set_clock_source has performed initial attachment/setup.
   bool initialized_ = false;
+
+  // Last tempo knob position for re-evaluation on clock source changes
+  float last_tempo_knob_value_ = 0.5f;
 };
 
 } // namespace musin::timing


### PR DESCRIPTION
## Summary
- Fixes issue #486: TEMPO knob position is now read when switching clock sources
- Adds unified tempo control interface to TempoHandler 
- Simplifies PizzaControls by removing duplicate clock source logic

## Changes
- **TempoHandler**: Added `set_tempo_control_value()` method that handles both BPM and speed modifier logic based on current clock source
- **Clock source switching**: Modified `set_clock_source()` to re-evaluate stored knob position for new source
- **PizzaControls**: Simplified SPEED case to delegate tempo decisions to TempoHandler

## Test plan  
- [x] Build completes successfully
- [ ] Test tempo knob behavior when switching from internal to external sync
- [ ] Test tempo knob behavior when switching from external sync to internal
- [ ] Verify BPM changes work correctly on internal clock
- [ ] Verify speed modifiers work correctly on external clocks
- [ ] Test MIDI clock source switching