### PR TITLE
Separate ClockRouter from TempoHandler responsibilities

### DIFF
--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -64,8 +64,7 @@ static musin::timing::SpeedAdapter
     speed_adapter(musin::timing::SpeedModifier::NORMAL_SPEED);
 static musin::timing::SyncOut sync_out(DATO_SUBMARINE_SYNC_OUT_PIN);
 static musin::timing::TempoHandler
-    tempo_handler(internal_clock, midi_clock_processor, sync_in, sync_out,
-                  clock_router, speed_adapter,
+    tempo_handler(clock_router, speed_adapter,
                   drum::config::SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER,
                   musin::timing::ClockSource::INTERNAL);
 static musin::timing::MidiClockOut
@@ -158,6 +157,7 @@ int main() {
 
   sync_out.enable();
 
+  clock_router.set_sync_out(&sync_out);
   clock_router.add_observer(sync_out);
   clock_router.add_observer(midi_clock_out);
   clock_router.add_observer(speed_adapter);
@@ -231,7 +231,7 @@ int main() {
       pizza_display.update(now);
       midi_manager.process_input();
       internal_clock.update(now);
-      tempo_handler.update();
+      clock_router.update_auto_source_switching();
 
       // ClockRouter handles raw clock routing; SyncOut remains attached
       musin::midi::process_midi_output_queue(

--- a/musin/timing/clock_router.h
+++ b/musin/timing/clock_router.h
@@ -10,6 +10,8 @@
 
 namespace musin::timing {
 
+class SyncOut;
+
 constexpr size_t MAX_CLOCK_ROUTER_OBSERVERS = 3;
 
 /**
@@ -31,6 +33,16 @@ public:
     return current_source_;
   }
 
+  // Control API
+  void set_bpm(float bpm);
+  void trigger_resync();
+  void resync_sync_output();
+  void set_sync_out(SyncOut *sync_out_ptr);
+
+  // Auto source switching
+  void update_auto_source_switching();
+  void set_auto_switching_enabled(bool enabled);
+
   // From selected upstream source
   void notification(musin::timing::ClockEvent event) override;
 
@@ -43,6 +55,8 @@ private:
   SyncIn &sync_in_;
   ClockSource current_source_;
   bool initialized_ = false;
+  bool auto_switching_enabled_ = true;
+  SyncOut *sync_out_ = nullptr;
 };
 
 } // namespace musin::timing

--- a/musin/timing/midi_clock_processor.h
+++ b/musin/timing/midi_clock_processor.h
@@ -53,16 +53,9 @@ public:
     return forward_echo_enabled_;
   }
 
-  void set_speed_modifier(SpeedModifier modifier);
-  [[nodiscard]] SpeedModifier get_speed_modifier() const;
-
 private:
   absolute_time_t _last_raw_tick_time;
   bool forward_echo_enabled_ = false;
-
-  // Speed modification
-  SpeedModifier speed_modifier_ = SpeedModifier::NORMAL_SPEED;
-  bool half_speed_toggle_ = false; // For dropping every other MIDI tick
 
   // Timeout for considering MIDI clock inactive.
   static constexpr uint32_t MIDI_CLOCK_TIMEOUT_US = 500000; // 500ms

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -6,44 +6,44 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
   current_source_ = event.source;
 
   if (event.is_resync) {
-    // Forward resync immediately and reset internal state
     notify_observers(event);
+    tick_counter_ = 0;
     last_tick_us_ = 0;
     last_interval_us_ = 0;
     next_insert_time_ = nil_time;
     return;
   }
 
-  // Use provided timestamp from the source
   uint32_t now_us = event.timestamp_us;
 
   switch (modifier_) {
-  case SpeedModifier::NORMAL_SPEED:
-  case SpeedModifier::HALF_SPEED: {
-    // HALF_SPEED is now handled by individual clock sources,
-    // so just pass through like NORMAL_SPEED
-    notify_observers(event);
-    // Track interval for potential future DOUBLE transitions
+  case SpeedModifier::HALF_SPEED:
+    tick_counter_++;
+    if (tick_counter_ % 2 == 0) {
+      notify_observers(event);
+    }
     if (last_tick_us_ != 0) {
       last_interval_us_ = now_us - last_tick_us_;
     }
     last_tick_us_ = now_us;
     break;
-  }
-  case SpeedModifier::DOUBLE_SPEED: {
-    // Pass-through incoming tick immediately
-    notify_observers(event);
 
-    // Measure interval to schedule a mid tick for the NEXT gap
+  case SpeedModifier::NORMAL_SPEED:
+    notify_observers(event);
     if (last_tick_us_ != 0) {
       last_interval_us_ = now_us - last_tick_us_;
     }
     last_tick_us_ = now_us;
+    break;
 
-    // If we have a measured interval, schedule an inserted mid tick
+  case SpeedModifier::DOUBLE_SPEED:
+    notify_observers(event);
+    if (last_tick_us_ != 0) {
+      last_interval_us_ = now_us - last_tick_us_;
+    }
+    last_tick_us_ = now_us;
     schedule_double_insert_after(get_absolute_time());
     break;
-  }
   }
 }
 

--- a/musin/timing/speed_adapter.h
+++ b/musin/timing/speed_adapter.h
@@ -14,11 +14,9 @@ constexpr size_t MAX_SPEED_ADAPTER_OBSERVERS = 2;
  * and downstream consumers.
  *
  * - NORMAL: pass-through.
+ * - HALF_SPEED: emit every 2nd tick.
  * - DOUBLE: pass through incoming ticks and insert an interpolated tick midway
  *   between them using the previous measured interval.
- *
- * Note: HALF_SPEED is now handled directly by individual clock sources
- * (SyncIn and MidiClockProcessor) for better musical alignment.
  *
  * Resets on incoming resync. Interpolated ticks are marked as
  * is_downbeat=false.
@@ -36,7 +34,7 @@ public:
     if (modifier_ == m)
       return;
     modifier_ = m;
-    // Reset internal scheduling state when mode changes
+    tick_counter_ = 0;
     last_tick_us_ = 0;
     last_interval_us_ = 0;
     next_insert_time_ = nil_time;
@@ -54,6 +52,7 @@ private:
   void schedule_double_insert_after(absolute_time_t now);
 
   SpeedModifier modifier_;
+  uint32_t tick_counter_ = 0;
 
   // Timing for DOUBLE mode
   uint32_t last_tick_us_ = 0;     // timestamp of last source tick

--- a/musin/timing/sync_in.h
+++ b/musin/timing/sync_in.h
@@ -31,9 +31,6 @@ public:
   void update(absolute_time_t now);
   [[nodiscard]] bool is_cable_connected() const;
 
-  void set_speed_modifier(SpeedModifier modifier);
-  [[nodiscard]] SpeedModifier get_speed_modifier() const;
-
 private:
   enum class PulseDebounceState {
     WAITING_FOR_RISING_EDGE,
@@ -58,17 +55,9 @@ private:
   uint8_t interpolated_tick_counter_ = 0; // 0-11, tracks interpolated ticks
   absolute_time_t next_tick_time_ = nil_time;
 
-  // Speed modification
-  SpeedModifier speed_modifier_ = SpeedModifier::NORMAL_SPEED;
-  bool physical_pulse_toggle_ =
-      false; // For marking only half of physical pulses in half-speed
-
   static constexpr uint32_t PULSE_DEBOUNCE_US = 5000;   // 5ms
   static constexpr uint32_t DETECT_DEBOUNCE_US = 50000; // 50ms
   static constexpr uint8_t PPQN_MULTIPLIER = 12;        // 2 PPQN to 24 PPQN
-  // Half speed: machine runs at 24 PPQN, normal speed converts 2 PPQN input
-  // to 24 PPQN (×12), half speed converts to 12 PPQN (24/2/2 = 6)
-  static constexpr uint8_t PPQN_MULTIPLIER_HALF = PPQN_MULTIPLIER / 2;
 
   void emit_clock_event(absolute_time_t timestamp, bool is_downbeat);
   void schedule_interpolated_ticks(absolute_time_t now);

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -1,30 +1,16 @@
 #include "musin/timing/tempo_handler.h"
 #include "drum/config.h"
-#include "midi_Defs.h"
-#include "musin/midi/midi_wrapper.h"
-#include "musin/timing/clock_event.h"
-#include "musin/timing/clock_router.h"
-#include "musin/timing/midi_clock_processor.h"
-#include "musin/timing/sync_in.h"
-#include "musin/timing/sync_out.h"
 #include "musin/timing/tempo_event.h"
 #include "musin/timing/timing_constants.h"
-#include "pico/time.h"
 
 namespace musin::timing {
 
-TempoHandler::TempoHandler(InternalClock &internal_clock_ref,
-                           MidiClockProcessor &midi_clock_processor_ref,
-                           SyncIn &sync_in_ref, SyncOut &sync_out_ref,
-                           ClockRouter &clock_router_ref,
+TempoHandler::TempoHandler(ClockRouter &clock_router_ref,
                            SpeedAdapter &speed_adapter_ref,
                            bool send_midi_clock_when_stopped,
                            ClockSource initial_source)
-    : _internal_clock_ref(internal_clock_ref),
-      _midi_clock_processor_ref(midi_clock_processor_ref),
-      _sync_in_ref(sync_in_ref), _sync_out_ref(sync_out_ref),
-      _clock_router_ref(clock_router_ref),
-      _speed_adapter_ref(speed_adapter_ref), current_source_(initial_source),
+    : _clock_router_ref(clock_router_ref),
+      _speed_adapter_ref(speed_adapter_ref),
       _playback_state(PlaybackState::STOPPED),
       current_speed_modifier_(SpeedModifier::NORMAL_SPEED), phase_24_(0),
       tick_count_(0),
@@ -34,27 +20,18 @@ TempoHandler::TempoHandler(InternalClock &internal_clock_ref,
 }
 
 void TempoHandler::set_clock_source(ClockSource source) {
-  // If already set and initialized, nothing to do
-  if (source == current_source_ && initialized_) {
+  if (source == _clock_router_ref.get_clock_source() && initialized_) {
     return;
   }
 
-  current_source_ = source;
-  phase_24_ = 0; // Reset phase on source change
-
-  // Route raw 24 PPQN through ClockRouter
-  _clock_router_ref.set_clock_source(current_source_);
-
-  // Re-evaluate tempo knob position for the new clock source
-  // This fixes issue #486: tempo knob position is now applied when switching
-  // sources
+  phase_24_ = 0;
+  _clock_router_ref.set_clock_source(source);
   set_tempo_control_value(last_tempo_knob_value_);
-
   initialized_ = true;
 }
 
 ClockSource TempoHandler::get_clock_source() const {
-  return current_source_;
+  return _clock_router_ref.get_clock_source();
 }
 
 uint8_t TempoHandler::calculate_aligned_phase() const {
@@ -72,18 +49,11 @@ uint8_t TempoHandler::calculate_aligned_phase() const {
 }
 
 void TempoHandler::notification(musin::timing::ClockEvent event) {
-  if (event.source != current_source_) {
-    return;
-  }
-
-  // Always realign on external physical pulses
   if (event.source == ClockSource::EXTERNAL_SYNC && event.is_downbeat) {
     event.anchor_to_phase = calculate_aligned_phase();
   }
 
   if (event.is_resync) {
-    // Handle resync: set phase to anchor or 0, increment tick, emit resync
-    // event, return
     phase_24_ = (event.anchor_to_phase != ClockEvent::ANCHOR_PHASE_NONE)
                     ? event.anchor_to_phase
                     : 0;
@@ -94,7 +64,6 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
     return;
   }
 
-  // Handle normal tick: advance phase normally or honor anchor if present
   uint8_t next_phase = (event.anchor_to_phase != ClockEvent::ANCHOR_PHASE_NONE)
                            ? event.anchor_to_phase
                            : (phase_24_ + 1) % musin::timing::DEFAULT_PPQN;
@@ -106,45 +75,32 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
   notify_observers(tempo_event);
 }
 
-// Removed: speed scaling and tick selection is handled by SpeedAdapter
-
 void TempoHandler::set_bpm(float bpm) {
-  if (current_source_ == ClockSource::INTERNAL) {
-    _internal_clock_ref.set_bpm(bpm);
-  }
+  _clock_router_ref.set_bpm(bpm);
 }
 
 void TempoHandler::set_speed_modifier(SpeedModifier modifier) {
   current_speed_modifier_ = modifier;
+  _speed_adapter_ref.set_modifier(modifier);
+}
 
-  // Route speed changes to individual external clock sources
-  _sync_in_ref.set_speed_modifier(modifier);
-  _midi_clock_processor_ref.set_speed_modifier(modifier);
+SpeedModifier TempoHandler::get_speed_modifier() const {
+  return current_speed_modifier_;
+}
 
-  // Handle SpeedAdapter: force to NORMAL_SPEED for HALF_SPEED to prevent double
-  // modification, otherwise pass through for DOUBLE_SPEED or other cases
-  if (modifier == SpeedModifier::HALF_SPEED) {
-    // External sources handle half-speed internally, ensure SpeedAdapter
-    // doesn't also halve
-    _speed_adapter_ref.set_modifier(SpeedModifier::NORMAL_SPEED);
-  } else {
-    // For DOUBLE_SPEED or NORMAL_SPEED, pass through to SpeedAdapter
-    _speed_adapter_ref.set_modifier(modifier);
-  }
+PlaybackState TempoHandler::get_playback_state() const {
+  return _playback_state;
 }
 
 void TempoHandler::set_tempo_control_value(float knob_value) {
-  // Store the knob value for re-evaluation on clock source changes
   last_tempo_knob_value_ = knob_value;
 
-  if (current_source_ == ClockSource::INTERNAL) {
-    // Internal clock: knob controls BPM
+  if (get_clock_source() == ClockSource::INTERNAL) {
     float bpm = drum::config::analog_controls::MIN_BPM_ADJUST +
                 knob_value * (drum::config::analog_controls::MAX_BPM_ADJUST -
                               drum::config::analog_controls::MIN_BPM_ADJUST);
     set_bpm(bpm);
   } else {
-    // External clock: knob controls speed modifier
     SpeedModifier modifier = SpeedModifier::NORMAL_SPEED;
     if (knob_value < 0.1f) {
       modifier = SpeedModifier::HALF_SPEED;
@@ -159,87 +115,25 @@ void TempoHandler::set_playback_state(PlaybackState new_state) {
   _playback_state = new_state;
 }
 
-/**
- * @brief Automatically switches the clock source based on a fixed priority.
- *
- * This method implements the automatic clock source selection logic, which
- * is called periodically from the main loop. The priority is as follows:
- * 1. External Sync: If a sync cable is connected, it will always be the
- *    selected source.
- * 2. MIDI Clock: If no sync cable is connected, it checks for an active MIDI
- *    clock signal. If MIDI clock is being received, it becomes the source.
- * 3. Internal Clock: If neither External Sync nor MIDI clock is available,
- *    the system falls back to the internal clock.
- */
-void TempoHandler::update() {
-  if (_sync_in_ref.is_cable_connected()) {
-    if (current_source_ != ClockSource::EXTERNAL_SYNC) {
-      set_clock_source(ClockSource::EXTERNAL_SYNC);
-    }
-  } else {
-    if (_midi_clock_processor_ref.is_active()) {
-      if (current_source_ != ClockSource::MIDI) {
-        set_clock_source(ClockSource::MIDI);
-      }
-    } else {
-      if (current_source_ != ClockSource::MIDI &&
-          current_source_ != ClockSource::INTERNAL) {
-        set_clock_source(ClockSource::INTERNAL);
-      }
-    }
-  }
-}
-
 void TempoHandler::trigger_manual_sync() {
   if (!drum::config::RETRIGGER_SYNC_ON_PLAYBUTTON) {
     return;
   }
 
-  switch (current_source_) {
+  switch (get_clock_source()) {
   case ClockSource::INTERNAL:
-    // Reset internal clock timing so the next automatic tick lands one
-    // interval after the manual downbeat we emit below.
-    _internal_clock_ref.reset();
-
-    // Emit resync event to TempoHandler observers for phase alignment
-    emit_manual_resync_event(calculate_aligned_phase());
-
-    // Resync SyncOut to align pulse timing
-    _sync_out_ref.resync();
-    break;
   case ClockSource::MIDI:
-    // Emit resync event to TempoHandler observers for phase alignment
+    _clock_router_ref.trigger_resync();
     emit_manual_resync_event(calculate_aligned_phase());
-
-    // Resync SyncOut to align pulse timing
-    _sync_out_ref.resync();
     break;
   case ClockSource::EXTERNAL_SYNC:
-    // No immediate realignment - respect external timing reference
     break;
   }
 }
 
-void TempoHandler::advance_phase_and_emit_event() {
-  // Advance the 24 PPQN phase counter (0..DEFAULT_PPQN-1)
-  phase_24_ = (phase_24_ + 1) % musin::timing::DEFAULT_PPQN;
-
-  // Advance the running tick count
-  tick_count_++;
-
-  // Emit tempo event with current phase information
-  musin::timing::TempoEvent tempo_event{
-      .tick_count = tick_count_, .phase_24 = phase_24_, .is_resync = false};
-
-  notify_observers(tempo_event);
-}
-
 void TempoHandler::emit_manual_resync_event(uint8_t anchor_phase) {
-  // Set phase to anchor and increment tick count
   phase_24_ = anchor_phase;
   tick_count_++;
-
-  // Emit resync tempo event
   musin::timing::TempoEvent tempo_event{
       .tick_count = tick_count_, .phase_24 = phase_24_, .is_resync = true};
   notify_observers(tempo_event);

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -11,11 +11,6 @@
 
 namespace musin::timing {
 
-// Forward declarations
-class MidiClockProcessor;
-class SyncIn;
-class SyncOut;
-
 /**
  * @brief Defines the playback state of the sequencer.
  */
@@ -29,31 +24,18 @@ enum class PlaybackState : uint8_t {
 constexpr size_t MAX_TEMPO_OBSERVERS = 4;
 
 /**
- * @brief Manages the selection of the active clock source and forwards ticks.
+ * @brief Manages tempo tracking and phase alignment.
  *
- * Listens to clock events from various sources (Internal, MIDI, External)
- * via the Observer pattern. Based on the selected `ClockSource`, it filters
- * and forwards valid tempo ticks to its own observers as `TempoEvent`s.
+ * Observes SpeedAdapter for speed-modified clock events and emits TempoEvents
+ * with phase information. Delegates clock source selection and speed control
+ * to ClockRouter and SpeedAdapter.
  */
 class TempoHandler
     : public etl::observer<musin::timing::ClockEvent>,
       public etl::observable<etl::observer<musin::timing::TempoEvent>,
                              MAX_TEMPO_OBSERVERS> {
 public:
-  /**
-   * @brief Constructor.
-   * @param internal_clock_ref Reference to the InternalClock instance.
-   * @param midi_clock_processor_ref Reference to the MidiClockProcessor.
-   * @param sync_in_ref Reference to the SyncIn instance.
-   * @param sync_out_ref Reference to the SyncOut instance.
-   * @param send_midi_clock_when_stopped If true, MIDI clock is sent even when
-   * stopped.
-   * @param initial_source The clock source to use initially.
-   */
-  explicit TempoHandler(InternalClock &internal_clock_ref,
-                        MidiClockProcessor &midi_clock_processor_ref,
-                        SyncIn &sync_in_ref, SyncOut &sync_out_ref,
-                        ClockRouter &clock_router_ref,
+  explicit TempoHandler(ClockRouter &clock_router_ref,
                         SpeedAdapter &speed_adapter_ref,
                         bool send_midi_clock_when_stopped,
                         ClockSource initial_source = ClockSource::INTERNAL);
@@ -62,117 +44,35 @@ public:
   TempoHandler(const TempoHandler &) = delete;
   TempoHandler &operator=(const TempoHandler &) = delete;
 
-  /**
-   * @brief Set the active clock source.
-   * @param source The new clock source to use.
-   */
   void set_clock_source(ClockSource source);
-
-  /**
-   * @brief Get the currently active clock source.
-   * @return The current ClockSource enum value.
-   */
   [[nodiscard]] ClockSource get_clock_source() const;
 
-  /**
-   * @brief Notification handler called when a ClockEvent is received.
-   * @param event The received clock event.
-   */
-  void notification(musin::timing::ClockEvent event);
-
-  /**
-   * @brief Set the tempo for the internal clock.
-   * @param bpm Beats Per Minute.
-   */
   void set_bpm(float bpm);
-
-  /**
-   * @brief Set the speed modifier for all external clock sources (MIDI and
-   * Sync).
-   * @param modifier The speed modifier to apply (half, normal, double speed).
-   */
   void set_speed_modifier(SpeedModifier modifier);
-
-  /**
-   * @brief Set tempo control value from knob position (0.0-1.0).
-   * Automatically applies appropriate BPM or speed modifier based on current
-   * clock source.
-   * @param knob_value Normalized knob position (0.0-1.0).
-   */
   void set_tempo_control_value(float knob_value);
 
-  /**
-   * @brief Get the current speed modifier.
-   */
-  [[nodiscard]] SpeedModifier get_speed_modifier() const {
-    return current_speed_modifier_;
-  }
+  [[nodiscard]] SpeedModifier get_speed_modifier() const;
 
-  /**
-   * @brief Set the current playback state.
-   * @param new_state The new playback state.
-   */
   void set_playback_state(PlaybackState new_state);
+  [[nodiscard]] PlaybackState get_playback_state() const;
 
-  /**
-   * @brief Get the current playback state.
-   * @return The current playback state (PLAYING or STOPPED).
-   */
-  [[nodiscard]] PlaybackState get_playback_state() const {
-    return _playback_state;
-  }
-
-  /**
-   * @brief Periodically called to update internal state, like auto-switching
-   * clock source.
-   */
-  void update();
-
-  /**
-   * @brief Trigger manual sync behavior when using external clock sources.
-   * Sends resync event to observers for immediate phase alignment.
-   */
   void trigger_manual_sync();
 
+  void notification(musin::timing::ClockEvent event) override;
+
 private:
-  /**
-   * @brief Calculate aligned phase for musical boundary snapping.
-   * @return Target phase (0 or 12) closest to current phase without large
-   * jumps.
-   */
   [[nodiscard]] uint8_t calculate_aligned_phase() const;
-
-  /**
-   * @brief Advance internal phase counter and emit tempo event.
-   * This is the central method that advances phase_24_ and tick_count_,
-   * then emits a TempoEvent with the current phase information.
-   */
-  void advance_phase_and_emit_event();
-
-  /**
-   * @brief Emit a manual resync event directly to observers.
-   * @param anchor_phase The phase to align to.
-   */
   void emit_manual_resync_event(uint8_t anchor_phase);
 
-  InternalClock &_internal_clock_ref;
-  MidiClockProcessor &_midi_clock_processor_ref;
-  SyncIn &_sync_in_ref;
-  SyncOut &_sync_out_ref;
   ClockRouter &_clock_router_ref;
   SpeedAdapter &_speed_adapter_ref;
 
-  ClockSource current_source_;
   PlaybackState _playback_state;
   SpeedModifier current_speed_modifier_;
-  uint8_t phase_24_;    // 24 PPQN phase counter (0-23)
-  uint64_t tick_count_; // Running tick count
+  uint8_t phase_24_;
+  uint64_t tick_count_;
   const bool _send_midi_clock_when_stopped;
-
-  // Tracks whether set_clock_source has performed initial attachment/setup.
   bool initialized_ = false;
-
-  // Last tempo knob position for re-evaluation on clock source changes
   float last_tempo_knob_value_ = 0.5f;
 };
 

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -53,8 +53,7 @@ TEST_CASE("SpeedAdapter NORMAL forwards all ticks") {
   }
 }
 
-TEST_CASE("SpeedAdapter HALF passes through all ticks (half-speed now handled "
-          "by sources)") {
+TEST_CASE("SpeedAdapter HALF emits every 2nd tick") {
   reset_test_state();
 
   SpeedAdapter adapter(SpeedModifier::HALF_SPEED);
@@ -71,9 +70,8 @@ TEST_CASE("SpeedAdapter HALF passes through all ticks (half-speed now handled "
     advance_time_us(8000);
   }
 
-  // Expect all 6 ticks forwarded (half-speed is now handled by individual
-  // sources)
-  REQUIRE(rec.events.size() == 6);
+  // SpeedAdapter now handles HALF_SPEED by emitting every 2nd tick
+  REQUIRE(rec.events.size() == 3);
 }
 
 TEST_CASE("SpeedAdapter DOUBLE inserts mid ticks with non-physical flag") {


### PR DESCRIPTION
- Add control API to ClockRouter (set_bpm, trigger_resync, set_sync_out)
- Remove speed handling from SyncIn and MidiClockProcessor
- Centralize all speed modification in SpeedAdapter (HALF, NORMAL, DOUBLE)
- Simplify TempoHandler to delegate to ClockRouter and SpeedAdapter
- Move auto-switching logic to ClockRouter
- Update tests to match new architecture