### PR TITLE
Move to phase 12

### DIFF
--- a/drum/config.h
+++ b/drum/config.h
@@ -208,7 +208,7 @@ namespace timing {
 // Fixed swing offset in 12 PPQN phases applied to swung steps only.
 // Anchors remain at 0 and 6; the controller applies +SWING_OFFSET_PHASES
 // to the next step when that step is marked as swung.
-constexpr uint8_t SWING_OFFSET_PHASES = 4; // valid range: 1..5
+constexpr uint8_t SWING_OFFSET_PHASES = 2; // valid range: 1..5
 static_assert(SWING_OFFSET_PHASES > 0 && SWING_OFFSET_PHASES < 6,
               "SWING_OFFSET_PHASES must be between 1 and 5 at 12 PPQN");
 } // namespace timing

--- a/drum/config.h
+++ b/drum/config.h
@@ -205,12 +205,12 @@ constexpr float MAX_BPM_ADJUST = 360.0f;
 
 // Timing configuration (musical policies)
 namespace timing {
-// Fixed swing offset in 24 PPQN phases applied to swung steps only.
-// Anchors remain at 0 and 12; the controller applies +SWING_OFFSET_PHASES
+// Fixed swing offset in 12 PPQN phases applied to swung steps only.
+// Anchors remain at 0 and 6; the controller applies +SWING_OFFSET_PHASES
 // to the next step when that step is marked as swung.
-constexpr uint8_t SWING_OFFSET_PHASES = 4; // valid range: 1..11
-static_assert(SWING_OFFSET_PHASES > 0 && SWING_OFFSET_PHASES < 12,
-              "SWING_OFFSET_PHASES must be between 1 and 11 at 24 PPQN");
+constexpr uint8_t SWING_OFFSET_PHASES = 4; // valid range: 1..5
+static_assert(SWING_OFFSET_PHASES > 0 && SWING_OFFSET_PHASES < 6,
+              "SWING_OFFSET_PHASES must be between 1 and 5 at 12 PPQN");
 } // namespace timing
 
 // PizzaControls specific

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -222,7 +222,6 @@ int main() {
       sysex_handler.update(now);
       pizza_controls.update(now);
       sync_in.update(now);
-      speed_adapter.update(now);
       sequencer_controller
           .update(); // Checks if a step is due and queues NoteEvents
       message_router

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -64,8 +64,7 @@ static musin::timing::SpeedAdapter
     speed_adapter(musin::timing::SpeedModifier::NORMAL_SPEED);
 static musin::timing::SyncOut sync_out(DATO_SUBMARINE_SYNC_OUT_PIN);
 static musin::timing::TempoHandler
-    tempo_handler(internal_clock, midi_clock_processor, sync_in, sync_out,
-                  clock_router, speed_adapter,
+    tempo_handler(clock_router, speed_adapter,
                   drum::config::SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER,
                   musin::timing::ClockSource::INTERNAL);
 static musin::timing::MidiClockOut
@@ -158,6 +157,7 @@ int main() {
 
   sync_out.enable();
 
+  clock_router.set_sync_out(&sync_out);
   clock_router.add_observer(sync_out);
   clock_router.add_observer(midi_clock_out);
   clock_router.add_observer(speed_adapter);
@@ -231,7 +231,7 @@ int main() {
       pizza_display.update(now);
       midi_manager.process_input();
       internal_clock.update(now);
-      tempo_handler.update();
+      clock_router.update_auto_source_switching();
 
       // ClockRouter handles raw clock routing; SyncOut remains attached
       musin::midi::process_midi_output_queue(

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -65,8 +65,8 @@ public:
   /**
    * @brief Notification handler called when a TempoEvent is received.
    * Implements the etl::observer interface. This is called on every
-   * 24 PPQN tick with phase-based timing information.
-   * @param event The received tempo event containing phase_24 (0-23).
+   * 12 PPQN tick with phase-based timing information.
+   * @param event The received tempo event containing phase_12 (0-11).
    */
   void notification(musin::timing::TempoEvent event);
 
@@ -156,7 +156,7 @@ public:
    * @brief Enable or disable swing timing.
    * When enabled, steps marked as "swung" are delayed by
    * config::timing::SWING_OFFSET_PHASES from the straight eighth anchors
-   * (phases 0 and 12). When disabled, all steps use straight timing (0 and 12).
+   * (phases 0 and 6). When disabled, all steps use straight timing (0 and 6).
    * @param enabled true to enable swing, false for straight timing
    */
   void set_swing_enabled(bool enabled);
@@ -265,7 +265,7 @@ private:
   bool _running = false;
   std::atomic<bool> _step_is_due = false;
   std::atomic<uint8_t> _retrigger_due_mask{0};
-  uint8_t last_phase_24_{0};
+  uint8_t last_phase_12_{0};
 
   bool repeat_active_ = false;
   uint32_t repeat_length_ = 0;

--- a/drum/sequencer_effect_swing.cpp
+++ b/drum/sequencer_effect_swing.cpp
@@ -5,15 +5,15 @@ namespace drum {
 
 namespace {
 // Musical timing constants
-constexpr uint8_t PPQN = 24;
+constexpr uint8_t PPQN = 12;
 constexpr uint8_t DOWNBEAT = 0;
-constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2; // 12
+constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2; // 6
 
 // Retrigger masks for different subdivisions
 constexpr uint32_t SIXTEENTH_MASK =
-    (1u << 0) | (1u << 6) | (1u << 12) | (1u << 18);
-constexpr uint32_t TRIPLET_MASK = (1u << 0) | (1u << 8) | (1u << 16);
-constexpr uint32_t MASK24 = (1u << 24) - 1u;
+    (1u << 0) | (1u << 3) | (1u << 6) | (1u << 9);
+constexpr uint32_t TRIPLET_MASK = (1u << 0) | (1u << 4) | (1u << 8);
+constexpr uint32_t MASK12 = (1u << 12) - 1u;
 } // namespace
 
 SequencerEffectSwing::StepTiming SequencerEffectSwing::calculate_step_timing(
@@ -46,7 +46,7 @@ SequencerEffectSwing::StepTiming SequencerEffectSwing::calculate_step_timing(
   // step
   const uint8_t rotation = expected_phase;
   const uint32_t substep_mask =
-      ((base_mask << rotation) | (base_mask >> (24 - rotation))) & MASK24;
+      ((base_mask << rotation) | (base_mask >> (12 - rotation))) & MASK12;
 
   return {expected_phase, substep_mask, is_delay_applied};
 }

--- a/drum/sequencer_effect_swing.h
+++ b/drum/sequencer_effect_swing.h
@@ -19,7 +19,7 @@ public:
    * @brief Complete timing decision for a sequencer step.
    */
   struct StepTiming {
-    uint8_t expected_phase; // Phase in 24 PPQN when step should occur
+    uint8_t expected_phase; // Phase in 12 PPQN when step should occur
     uint32_t substep_mask;  // Rotated mask for retrigger scheduling
     bool is_delay_applied;  // True if swing delay was applied to this step
   };

--- a/drum/ui/pizza_display.cpp
+++ b/drum/ui/pizza_display.cpp
@@ -35,8 +35,8 @@ PizzaDisplay::PizzaDisplay(
 
 void PizzaDisplay::notification(musin::timing::TempoEvent event) {
   // Update highlight state based on downbeat and eighth offbeat for blinking
-  if (event.phase_24 == musin::timing::PHASE_DOWNBEAT ||
-      event.phase_24 == musin::timing::PHASE_EIGHTH_OFFBEAT) {
+  if (event.phase_12 == musin::timing::PHASE_DOWNBEAT ||
+      event.phase_12 == musin::timing::PHASE_EIGHTH_OFFBEAT) {
     bool prev = _highlight_is_bright.load(std::memory_order_relaxed);
     _highlight_is_bright.store(!prev, std::memory_order_relaxed);
   }

--- a/musin/timing/clock_router.h
+++ b/musin/timing/clock_router.h
@@ -57,6 +57,7 @@ private:
   bool initialized_ = false;
   bool auto_switching_enabled_ = true;
   SyncOut *sync_out_ = nullptr;
+  bool awaiting_first_tick_after_switch_ = false;
 };
 
 } // namespace musin::timing

--- a/musin/timing/clock_router.h
+++ b/musin/timing/clock_router.h
@@ -10,6 +10,8 @@
 
 namespace musin::timing {
 
+class SyncOut;
+
 constexpr size_t MAX_CLOCK_ROUTER_OBSERVERS = 3;
 
 /**
@@ -31,6 +33,16 @@ public:
     return current_source_;
   }
 
+  // Control API
+  void set_bpm(float bpm);
+  void trigger_resync();
+  void resync_sync_output();
+  void set_sync_out(SyncOut *sync_out_ptr);
+
+  // Auto source switching
+  void update_auto_source_switching();
+  void set_auto_switching_enabled(bool enabled);
+
   // From selected upstream source
   void notification(musin::timing::ClockEvent event) override;
 
@@ -43,6 +55,8 @@ private:
   SyncIn &sync_in_;
   ClockSource current_source_;
   bool initialized_ = false;
+  bool auto_switching_enabled_ = true;
+  SyncOut *sync_out_ = nullptr;
 };
 
 } // namespace musin::timing

--- a/musin/timing/internal_clock.h
+++ b/musin/timing/internal_clock.h
@@ -28,7 +28,7 @@ public:
    * @brief Pulses Per Quarter Note (PPQN). Standard MIDI clock is 24, common
    * sequencer resolution is 96.
    */
-  static constexpr uint32_t PPQN = musin::timing::DEFAULT_PPQN;
+  static constexpr uint32_t PPQN = 24;
 
   /**
    * @brief Constructor.

--- a/musin/timing/midi_clock_processor.h
+++ b/musin/timing/midi_clock_processor.h
@@ -53,16 +53,9 @@ public:
     return forward_echo_enabled_;
   }
 
-  void set_speed_modifier(SpeedModifier modifier);
-  [[nodiscard]] SpeedModifier get_speed_modifier() const;
-
 private:
   absolute_time_t _last_raw_tick_time;
   bool forward_echo_enabled_ = false;
-
-  // Speed modification
-  SpeedModifier speed_modifier_ = SpeedModifier::NORMAL_SPEED;
-  bool half_speed_toggle_ = false; // For dropping every other MIDI tick
 
   // Timeout for considering MIDI clock inactive.
   static constexpr uint32_t MIDI_CLOCK_TIMEOUT_US = 500000; // 500ms

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -6,44 +6,44 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
   current_source_ = event.source;
 
   if (event.is_resync) {
-    // Forward resync immediately and reset internal state
     notify_observers(event);
+    tick_counter_ = 0;
     last_tick_us_ = 0;
     last_interval_us_ = 0;
     next_insert_time_ = nil_time;
     return;
   }
 
-  // Use provided timestamp from the source
   uint32_t now_us = event.timestamp_us;
 
   switch (modifier_) {
-  case SpeedModifier::NORMAL_SPEED:
-  case SpeedModifier::HALF_SPEED: {
-    // HALF_SPEED is now handled by individual clock sources,
-    // so just pass through like NORMAL_SPEED
-    notify_observers(event);
-    // Track interval for potential future DOUBLE transitions
+  case SpeedModifier::HALF_SPEED:
+    tick_counter_++;
+    if (tick_counter_ % 2 == 0) {
+      notify_observers(event);
+    }
     if (last_tick_us_ != 0) {
       last_interval_us_ = now_us - last_tick_us_;
     }
     last_tick_us_ = now_us;
     break;
-  }
-  case SpeedModifier::DOUBLE_SPEED: {
-    // Pass-through incoming tick immediately
-    notify_observers(event);
 
-    // Measure interval to schedule a mid tick for the NEXT gap
+  case SpeedModifier::NORMAL_SPEED:
+    notify_observers(event);
     if (last_tick_us_ != 0) {
       last_interval_us_ = now_us - last_tick_us_;
     }
     last_tick_us_ = now_us;
+    break;
 
-    // If we have a measured interval, schedule an inserted mid tick
+  case SpeedModifier::DOUBLE_SPEED:
+    notify_observers(event);
+    if (last_tick_us_ != 0) {
+      last_interval_us_ = now_us - last_tick_us_;
+    }
+    last_tick_us_ = now_us;
     schedule_double_insert_after(get_absolute_time());
     break;
-  }
   }
 }
 

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -15,11 +15,12 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
   }
 
   uint32_t now_us = event.timestamp_us;
+  tick_counter_++;
 
   switch (modifier_) {
   case SpeedModifier::HALF_SPEED:
-    tick_counter_++;
-    if (tick_counter_ % 2 == 0) {
+    // Emit every 4th tick: 24→6 PPQN
+    if (tick_counter_ % 4 == 0) {
       notify_observers(event);
     }
     if (last_tick_us_ != 0) {
@@ -29,7 +30,10 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     break;
 
   case SpeedModifier::NORMAL_SPEED:
-    notify_observers(event);
+    // Emit every 2nd tick: 24→12 PPQN
+    if (tick_counter_ % 2 == 0) {
+      notify_observers(event);
+    }
     if (last_tick_us_ != 0) {
       last_interval_us_ = now_us - last_tick_us_;
     }
@@ -37,45 +41,22 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     break;
 
   case SpeedModifier::DOUBLE_SPEED:
+    // Pass through all ticks: 24 PPQN (phase wraps 0→11 twice per quarter)
     notify_observers(event);
     if (last_tick_us_ != 0) {
       last_interval_us_ = now_us - last_tick_us_;
     }
     last_tick_us_ = now_us;
-    schedule_double_insert_after(get_absolute_time());
     break;
   }
 }
 
-void SpeedAdapter::schedule_double_insert_after(absolute_time_t now) {
-  if (last_interval_us_ == 0) {
-    next_insert_time_ = nil_time;
-    return;
-  }
-  // Schedule halfway into the last measured interval
-  uint32_t half_us = last_interval_us_ / 2u;
-  next_insert_time_ = delayed_by_us(now, static_cast<uint64_t>(half_us));
+void SpeedAdapter::schedule_double_insert_after(absolute_time_t /*now*/) {
+  // No longer used - DOUBLE mode now passes through all ticks
 }
 
 void SpeedAdapter::update(absolute_time_t /*now*/) {
-  if (modifier_ != SpeedModifier::DOUBLE_SPEED) {
-    return;
-  }
-  if (is_nil_time(next_insert_time_)) {
-    return;
-  }
-  if (time_reached(next_insert_time_)) {
-    // Emit an interpolated tick
-    ClockEvent interp{current_source_};
-    interp.is_resync = false;
-    interp.is_downbeat = false;
-    interp.anchor_to_phase = ClockEvent::ANCHOR_PHASE_NONE;
-    interp.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
-    notify_observers(interp);
-    // Clear until next source tick schedules another insert
-    next_insert_time_ = nil_time;
-  }
+  // No longer used - DOUBLE mode no longer inserts interpolated ticks
 }
 
 } // namespace musin::timing

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -8,13 +8,9 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
   if (event.is_resync) {
     notify_observers(event);
     tick_counter_ = 0;
-    last_tick_us_ = 0;
-    last_interval_us_ = 0;
-    next_insert_time_ = nil_time;
     return;
   }
 
-  uint32_t now_us = event.timestamp_us;
   tick_counter_++;
 
   switch (modifier_) {
@@ -23,10 +19,6 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     if (tick_counter_ % 4 == 0) {
       notify_observers(event);
     }
-    if (last_tick_us_ != 0) {
-      last_interval_us_ = now_us - last_tick_us_;
-    }
-    last_tick_us_ = now_us;
     break;
 
   case SpeedModifier::NORMAL_SPEED:
@@ -34,29 +26,13 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     if (tick_counter_ % 2 == 0) {
       notify_observers(event);
     }
-    if (last_tick_us_ != 0) {
-      last_interval_us_ = now_us - last_tick_us_;
-    }
-    last_tick_us_ = now_us;
     break;
 
   case SpeedModifier::DOUBLE_SPEED:
     // Pass through all ticks: 24 PPQN (phase wraps 0→11 twice per quarter)
     notify_observers(event);
-    if (last_tick_us_ != 0) {
-      last_interval_us_ = now_us - last_tick_us_;
-    }
-    last_tick_us_ = now_us;
     break;
   }
-}
-
-void SpeedAdapter::schedule_double_insert_after(absolute_time_t /*now*/) {
-  // No longer used - DOUBLE mode now passes through all ticks
-}
-
-void SpeedAdapter::update(absolute_time_t /*now*/) {
-  // No longer used - DOUBLE mode no longer inserts interpolated ticks
 }
 
 } // namespace musin::timing

--- a/musin/timing/speed_adapter.h
+++ b/musin/timing/speed_adapter.h
@@ -10,16 +10,15 @@ namespace musin::timing {
 constexpr size_t MAX_SPEED_ADAPTER_OBSERVERS = 2;
 
 /**
- * Inserts a reusable speed-scaling stage between raw 24 PPQN clock sources
- * and downstream consumers.
+ * Downsamples raw 24 PPQN clock sources to variable-rate output for
+ * downstream 12-PPQN consumers.
  *
- * - NORMAL: pass-through.
- * - HALF_SPEED: emit every 2nd tick.
- * - DOUBLE: pass through incoming ticks and insert an interpolated tick midway
- *   between them using the previous measured interval.
+ * - NORMAL: emit every 2nd tick (24→12 PPQN).
+ * - HALF_SPEED: emit every 4th tick (24→6 PPQN).
+ * - DOUBLE: pass through all ticks (24 PPQN output, phase wraps 0→11
+ * twice/quarter).
  *
- * Resets on incoming resync. Interpolated ticks are marked as
- * is_downbeat=false.
+ * Resets divider on incoming resync. DOUBLE mode ticks maintain physical flag.
  */
 class SpeedAdapter
     : public etl::observer<musin::timing::ClockEvent>,

--- a/musin/timing/speed_adapter.h
+++ b/musin/timing/speed_adapter.h
@@ -34,9 +34,6 @@ public:
       return;
     modifier_ = m;
     tick_counter_ = 0;
-    last_tick_us_ = 0;
-    last_interval_us_ = 0;
-    next_insert_time_ = nil_time;
   }
 
   [[nodiscard]] SpeedModifier get_modifier() const {
@@ -45,18 +42,9 @@ public:
 
   void notification(musin::timing::ClockEvent event) override;
 
-  void update(absolute_time_t now);
-
 private:
-  void schedule_double_insert_after(absolute_time_t now);
-
   SpeedModifier modifier_;
   uint32_t tick_counter_ = 0;
-
-  // Timing for DOUBLE mode
-  uint32_t last_tick_us_ = 0;     // timestamp of last source tick
-  uint32_t last_interval_us_ = 0; // measured between source ticks
-  absolute_time_t next_insert_time_ = nil_time;
   ClockSource current_source_ = ClockSource::INTERNAL;
 };
 

--- a/musin/timing/speed_adapter.h
+++ b/musin/timing/speed_adapter.h
@@ -14,11 +14,9 @@ constexpr size_t MAX_SPEED_ADAPTER_OBSERVERS = 2;
  * and downstream consumers.
  *
  * - NORMAL: pass-through.
+ * - HALF_SPEED: emit every 2nd tick.
  * - DOUBLE: pass through incoming ticks and insert an interpolated tick midway
  *   between them using the previous measured interval.
- *
- * Note: HALF_SPEED is now handled directly by individual clock sources
- * (SyncIn and MidiClockProcessor) for better musical alignment.
  *
  * Resets on incoming resync. Interpolated ticks are marked as
  * is_downbeat=false.
@@ -36,7 +34,7 @@ public:
     if (modifier_ == m)
       return;
     modifier_ = m;
-    // Reset internal scheduling state when mode changes
+    tick_counter_ = 0;
     last_tick_us_ = 0;
     last_interval_us_ = 0;
     next_insert_time_ = nil_time;
@@ -54,6 +52,7 @@ private:
   void schedule_double_insert_after(absolute_time_t now);
 
   SpeedModifier modifier_;
+  uint32_t tick_counter_ = 0;
 
   // Timing for DOUBLE mode
   uint32_t last_tick_us_ = 0;     // timestamp of last source tick

--- a/musin/timing/sync_in.h
+++ b/musin/timing/sync_in.h
@@ -31,9 +31,6 @@ public:
   void update(absolute_time_t now);
   [[nodiscard]] bool is_cable_connected() const;
 
-  void set_speed_modifier(SpeedModifier modifier);
-  [[nodiscard]] SpeedModifier get_speed_modifier() const;
-
 private:
   enum class PulseDebounceState {
     WAITING_FOR_RISING_EDGE,
@@ -58,17 +55,9 @@ private:
   uint8_t interpolated_tick_counter_ = 0; // 0-11, tracks interpolated ticks
   absolute_time_t next_tick_time_ = nil_time;
 
-  // Speed modification
-  SpeedModifier speed_modifier_ = SpeedModifier::NORMAL_SPEED;
-  bool physical_pulse_toggle_ =
-      false; // For marking only half of physical pulses in half-speed
-
   static constexpr uint32_t PULSE_DEBOUNCE_US = 5000;   // 5ms
   static constexpr uint32_t DETECT_DEBOUNCE_US = 50000; // 50ms
   static constexpr uint8_t PPQN_MULTIPLIER = 12;        // 2 PPQN to 24 PPQN
-  // Half speed: machine runs at 24 PPQN, normal speed converts 2 PPQN input
-  // to 24 PPQN (×12), half speed converts to 12 PPQN (24/2/2 = 6)
-  static constexpr uint8_t PPQN_MULTIPLIER_HALF = PPQN_MULTIPLIER / 2;
 
   void emit_clock_event(absolute_time_t timestamp, bool is_downbeat);
   void schedule_interpolated_ticks(absolute_time_t now);

--- a/musin/timing/tempo_event.h
+++ b/musin/timing/tempo_event.h
@@ -11,7 +11,7 @@ namespace musin::timing {
  */
 struct TempoEvent {
   uint64_t tick_count;
-  uint8_t phase_24 = 0;
+  uint8_t phase_12 = 0; // Phase value 0-11 at 12 PPQN
   bool is_resync = false;
 };
 

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -111,6 +111,8 @@ void TempoHandler::set_tempo_control_value(float knob_value) {
                 knob_value * (drum::config::analog_controls::MAX_BPM_ADJUST -
                               drum::config::analog_controls::MIN_BPM_ADJUST);
     set_bpm(bpm);
+    // Ensure speed modifier is always normal when on internal clock
+    set_speed_modifier(SpeedModifier::NORMAL_SPEED);
   } else {
     SpeedModifier modifier = SpeedModifier::NORMAL_SPEED;
     if (knob_value < 0.1f) {

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -24,7 +24,6 @@ void TempoHandler::set_clock_source(ClockSource source) {
     return;
   }
 
-<<<<<<< HEAD
   phase_12_ = 0; // Reset phase on source change
   _clock_router_ref.set_clock_source(source);
 
@@ -38,7 +37,6 @@ void TempoHandler::set_clock_source(ClockSource source) {
   // Re-evaluate tempo knob position for the new clock source
   // This fixes issue #486: tempo knob position is now applied when switching
   // sources
->>>>>>> eed2482 (refactor: migrate sequencer to 12 PPQN internal timing)
   set_tempo_control_value(last_tempo_knob_value_);
   initialized_ = true;
 }

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -1,30 +1,16 @@
 #include "musin/timing/tempo_handler.h"
 #include "drum/config.h"
-#include "midi_Defs.h"
-#include "musin/midi/midi_wrapper.h"
-#include "musin/timing/clock_event.h"
-#include "musin/timing/clock_router.h"
-#include "musin/timing/midi_clock_processor.h"
-#include "musin/timing/sync_in.h"
-#include "musin/timing/sync_out.h"
 #include "musin/timing/tempo_event.h"
 #include "musin/timing/timing_constants.h"
-#include "pico/time.h"
 
 namespace musin::timing {
 
-TempoHandler::TempoHandler(InternalClock &internal_clock_ref,
-                           MidiClockProcessor &midi_clock_processor_ref,
-                           SyncIn &sync_in_ref, SyncOut &sync_out_ref,
-                           ClockRouter &clock_router_ref,
+TempoHandler::TempoHandler(ClockRouter &clock_router_ref,
                            SpeedAdapter &speed_adapter_ref,
                            bool send_midi_clock_when_stopped,
                            ClockSource initial_source)
-    : _internal_clock_ref(internal_clock_ref),
-      _midi_clock_processor_ref(midi_clock_processor_ref),
-      _sync_in_ref(sync_in_ref), _sync_out_ref(sync_out_ref),
-      _clock_router_ref(clock_router_ref),
-      _speed_adapter_ref(speed_adapter_ref), current_source_(initial_source),
+    : _clock_router_ref(clock_router_ref),
+      _speed_adapter_ref(speed_adapter_ref),
       _playback_state(PlaybackState::STOPPED),
       current_speed_modifier_(SpeedModifier::NORMAL_SPEED), phase_24_(0),
       tick_count_(0),
@@ -34,8 +20,7 @@ TempoHandler::TempoHandler(InternalClock &internal_clock_ref,
 }
 
 void TempoHandler::set_clock_source(ClockSource source) {
-  // If already set and initialized, nothing to do
-  if (source == current_source_ && initialized_) {
+  if (source == _clock_router_ref.get_clock_source() && initialized_) {
     return;
   }
 
@@ -56,12 +41,11 @@ void TempoHandler::set_clock_source(ClockSource source) {
   // This fixes issue #486: tempo knob position is now applied when switching
   // sources
   set_tempo_control_value(last_tempo_knob_value_);
-
   initialized_ = true;
 }
 
 ClockSource TempoHandler::get_clock_source() const {
-  return current_source_;
+  return _clock_router_ref.get_clock_source();
 }
 
 uint8_t TempoHandler::calculate_aligned_phase() const {
@@ -79,18 +63,11 @@ uint8_t TempoHandler::calculate_aligned_phase() const {
 }
 
 void TempoHandler::notification(musin::timing::ClockEvent event) {
-  if (event.source != current_source_) {
-    return;
-  }
-
-  // Always realign on external physical pulses
   if (event.source == ClockSource::EXTERNAL_SYNC && event.is_downbeat) {
     event.anchor_to_phase = calculate_aligned_phase();
   }
 
   if (event.is_resync) {
-    // Handle resync: set phase to anchor or 0, increment tick, emit resync
-    // event, return
     phase_24_ = (event.anchor_to_phase != ClockEvent::ANCHOR_PHASE_NONE)
                     ? event.anchor_to_phase
                     : 0;
@@ -101,7 +78,6 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
     return;
   }
 
-  // Handle normal tick: advance phase normally or honor anchor if present
   uint8_t next_phase = (event.anchor_to_phase != ClockEvent::ANCHOR_PHASE_NONE)
                            ? event.anchor_to_phase
                            : (phase_24_ + 1) % musin::timing::DEFAULT_PPQN;
@@ -113,45 +89,32 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
   notify_observers(tempo_event);
 }
 
-// Removed: speed scaling and tick selection is handled by SpeedAdapter
-
 void TempoHandler::set_bpm(float bpm) {
-  if (current_source_ == ClockSource::INTERNAL) {
-    _internal_clock_ref.set_bpm(bpm);
-  }
+  _clock_router_ref.set_bpm(bpm);
 }
 
 void TempoHandler::set_speed_modifier(SpeedModifier modifier) {
   current_speed_modifier_ = modifier;
+  _speed_adapter_ref.set_modifier(modifier);
+}
 
-  // Route speed changes to individual external clock sources
-  _sync_in_ref.set_speed_modifier(modifier);
-  _midi_clock_processor_ref.set_speed_modifier(modifier);
+SpeedModifier TempoHandler::get_speed_modifier() const {
+  return current_speed_modifier_;
+}
 
-  // Handle SpeedAdapter: force to NORMAL_SPEED for HALF_SPEED to prevent double
-  // modification, otherwise pass through for DOUBLE_SPEED or other cases
-  if (modifier == SpeedModifier::HALF_SPEED) {
-    // External sources handle half-speed internally, ensure SpeedAdapter
-    // doesn't also halve
-    _speed_adapter_ref.set_modifier(SpeedModifier::NORMAL_SPEED);
-  } else {
-    // For DOUBLE_SPEED or NORMAL_SPEED, pass through to SpeedAdapter
-    _speed_adapter_ref.set_modifier(modifier);
-  }
+PlaybackState TempoHandler::get_playback_state() const {
+  return _playback_state;
 }
 
 void TempoHandler::set_tempo_control_value(float knob_value) {
-  // Store the knob value for re-evaluation on clock source changes
   last_tempo_knob_value_ = knob_value;
 
-  if (current_source_ == ClockSource::INTERNAL) {
-    // Internal clock: knob controls BPM
+  if (get_clock_source() == ClockSource::INTERNAL) {
     float bpm = drum::config::analog_controls::MIN_BPM_ADJUST +
                 knob_value * (drum::config::analog_controls::MAX_BPM_ADJUST -
                               drum::config::analog_controls::MIN_BPM_ADJUST);
     set_bpm(bpm);
   } else {
-    // External clock: knob controls speed modifier
     SpeedModifier modifier = SpeedModifier::NORMAL_SPEED;
     if (knob_value < 0.1f) {
       modifier = SpeedModifier::HALF_SPEED;
@@ -166,87 +129,25 @@ void TempoHandler::set_playback_state(PlaybackState new_state) {
   _playback_state = new_state;
 }
 
-/**
- * @brief Automatically switches the clock source based on a fixed priority.
- *
- * This method implements the automatic clock source selection logic, which
- * is called periodically from the main loop. The priority is as follows:
- * 1. External Sync: If a sync cable is connected, it will always be the
- *    selected source.
- * 2. MIDI Clock: If no sync cable is connected, it checks for an active MIDI
- *    clock signal. If MIDI clock is being received, it becomes the source.
- * 3. Internal Clock: If neither External Sync nor MIDI clock is available,
- *    the system falls back to the internal clock.
- */
-void TempoHandler::update() {
-  if (_sync_in_ref.is_cable_connected()) {
-    if (current_source_ != ClockSource::EXTERNAL_SYNC) {
-      set_clock_source(ClockSource::EXTERNAL_SYNC);
-    }
-  } else {
-    if (_midi_clock_processor_ref.is_active()) {
-      if (current_source_ != ClockSource::MIDI) {
-        set_clock_source(ClockSource::MIDI);
-      }
-    } else {
-      if (current_source_ != ClockSource::MIDI &&
-          current_source_ != ClockSource::INTERNAL) {
-        set_clock_source(ClockSource::INTERNAL);
-      }
-    }
-  }
-}
-
 void TempoHandler::trigger_manual_sync() {
   if (!drum::config::RETRIGGER_SYNC_ON_PLAYBUTTON) {
     return;
   }
 
-  switch (current_source_) {
+  switch (get_clock_source()) {
   case ClockSource::INTERNAL:
-    // Reset internal clock timing so the next automatic tick lands one
-    // interval after the manual downbeat we emit below.
-    _internal_clock_ref.reset();
-
-    // Emit resync event to TempoHandler observers for phase alignment
-    emit_manual_resync_event(calculate_aligned_phase());
-
-    // Resync SyncOut to align pulse timing
-    _sync_out_ref.resync();
-    break;
   case ClockSource::MIDI:
-    // Emit resync event to TempoHandler observers for phase alignment
+    _clock_router_ref.trigger_resync();
     emit_manual_resync_event(calculate_aligned_phase());
-
-    // Resync SyncOut to align pulse timing
-    _sync_out_ref.resync();
     break;
   case ClockSource::EXTERNAL_SYNC:
-    // No immediate realignment - respect external timing reference
     break;
   }
 }
 
-void TempoHandler::advance_phase_and_emit_event() {
-  // Advance the 24 PPQN phase counter (0..DEFAULT_PPQN-1)
-  phase_24_ = (phase_24_ + 1) % musin::timing::DEFAULT_PPQN;
-
-  // Advance the running tick count
-  tick_count_++;
-
-  // Emit tempo event with current phase information
-  musin::timing::TempoEvent tempo_event{
-      .tick_count = tick_count_, .phase_24 = phase_24_, .is_resync = false};
-
-  notify_observers(tempo_event);
-}
-
 void TempoHandler::emit_manual_resync_event(uint8_t anchor_phase) {
-  // Set phase to anchor and increment tick count
   phase_24_ = anchor_phase;
   tick_count_++;
-
-  // Emit resync tempo event
   musin::timing::TempoEvent tempo_event{
       .tick_count = tick_count_, .phase_24 = phase_24_, .is_resync = true};
   notify_observers(tempo_event);

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -69,7 +69,7 @@ private:
 
   PlaybackState _playback_state;
   SpeedModifier current_speed_modifier_;
-  uint8_t phase_24_;
+  uint8_t phase_12_;
   uint64_t tick_count_;
   const bool _send_midi_clock_when_stopped;
   bool initialized_ = false;

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -11,11 +11,6 @@
 
 namespace musin::timing {
 
-// Forward declarations
-class MidiClockProcessor;
-class SyncIn;
-class SyncOut;
-
 /**
  * @brief Defines the playback state of the sequencer.
  */
@@ -29,31 +24,18 @@ enum class PlaybackState : uint8_t {
 constexpr size_t MAX_TEMPO_OBSERVERS = 4;
 
 /**
- * @brief Manages the selection of the active clock source and forwards ticks.
+ * @brief Manages tempo tracking and phase alignment.
  *
- * Listens to clock events from various sources (Internal, MIDI, External)
- * via the Observer pattern. Based on the selected `ClockSource`, it filters
- * and forwards valid tempo ticks to its own observers as `TempoEvent`s.
+ * Observes SpeedAdapter for speed-modified clock events and emits TempoEvents
+ * with phase information. Delegates clock source selection and speed control
+ * to ClockRouter and SpeedAdapter.
  */
 class TempoHandler
     : public etl::observer<musin::timing::ClockEvent>,
       public etl::observable<etl::observer<musin::timing::TempoEvent>,
                              MAX_TEMPO_OBSERVERS> {
 public:
-  /**
-   * @brief Constructor.
-   * @param internal_clock_ref Reference to the InternalClock instance.
-   * @param midi_clock_processor_ref Reference to the MidiClockProcessor.
-   * @param sync_in_ref Reference to the SyncIn instance.
-   * @param sync_out_ref Reference to the SyncOut instance.
-   * @param send_midi_clock_when_stopped If true, MIDI clock is sent even when
-   * stopped.
-   * @param initial_source The clock source to use initially.
-   */
-  explicit TempoHandler(InternalClock &internal_clock_ref,
-                        MidiClockProcessor &midi_clock_processor_ref,
-                        SyncIn &sync_in_ref, SyncOut &sync_out_ref,
-                        ClockRouter &clock_router_ref,
+  explicit TempoHandler(ClockRouter &clock_router_ref,
                         SpeedAdapter &speed_adapter_ref,
                         bool send_midi_clock_when_stopped,
                         ClockSource initial_source = ClockSource::INTERNAL);
@@ -62,117 +44,35 @@ public:
   TempoHandler(const TempoHandler &) = delete;
   TempoHandler &operator=(const TempoHandler &) = delete;
 
-  /**
-   * @brief Set the active clock source.
-   * @param source The new clock source to use.
-   */
   void set_clock_source(ClockSource source);
-
-  /**
-   * @brief Get the currently active clock source.
-   * @return The current ClockSource enum value.
-   */
   [[nodiscard]] ClockSource get_clock_source() const;
 
-  /**
-   * @brief Notification handler called when a ClockEvent is received.
-   * @param event The received clock event.
-   */
-  void notification(musin::timing::ClockEvent event);
-
-  /**
-   * @brief Set the tempo for the internal clock.
-   * @param bpm Beats Per Minute.
-   */
   void set_bpm(float bpm);
-
-  /**
-   * @brief Set the speed modifier for all external clock sources (MIDI and
-   * Sync).
-   * @param modifier The speed modifier to apply (half, normal, double speed).
-   */
   void set_speed_modifier(SpeedModifier modifier);
-
-  /**
-   * @brief Set tempo control value from knob position (0.0-1.0).
-   * Automatically applies appropriate BPM or speed modifier based on current
-   * clock source.
-   * @param knob_value Normalized knob position (0.0-1.0).
-   */
   void set_tempo_control_value(float knob_value);
 
-  /**
-   * @brief Get the current speed modifier.
-   */
-  [[nodiscard]] SpeedModifier get_speed_modifier() const {
-    return current_speed_modifier_;
-  }
+  [[nodiscard]] SpeedModifier get_speed_modifier() const;
 
-  /**
-   * @brief Set the current playback state.
-   * @param new_state The new playback state.
-   */
   void set_playback_state(PlaybackState new_state);
+  [[nodiscard]] PlaybackState get_playback_state() const;
 
-  /**
-   * @brief Get the current playback state.
-   * @return The current playback state (PLAYING or STOPPED).
-   */
-  [[nodiscard]] PlaybackState get_playback_state() const {
-    return _playback_state;
-  }
-
-  /**
-   * @brief Periodically called to update internal state, like auto-switching
-   * clock source.
-   */
-  void update();
-
-  /**
-   * @brief Trigger manual sync behavior when using external clock sources.
-   * Sends resync event to observers for immediate phase alignment.
-   */
   void trigger_manual_sync();
 
+  void notification(musin::timing::ClockEvent event) override;
+
 private:
-  /**
-   * @brief Calculate aligned phase for musical boundary snapping.
-   * @return Target phase (0 or 12) closest to current phase without large
-   * jumps.
-   */
   [[nodiscard]] uint8_t calculate_aligned_phase() const;
-
-  /**
-   * @brief Advance internal phase counter and emit tempo event.
-   * This is the central method that advances phase_24_ and tick_count_,
-   * then emits a TempoEvent with the current phase information.
-   */
-  void advance_phase_and_emit_event();
-
-  /**
-   * @brief Emit a manual resync event directly to observers.
-   * @param anchor_phase The phase to align to.
-   */
   void emit_manual_resync_event(uint8_t anchor_phase);
 
-  InternalClock &_internal_clock_ref;
-  MidiClockProcessor &_midi_clock_processor_ref;
-  SyncIn &_sync_in_ref;
-  SyncOut &_sync_out_ref;
   ClockRouter &_clock_router_ref;
   SpeedAdapter &_speed_adapter_ref;
 
-  ClockSource current_source_;
   PlaybackState _playback_state;
   SpeedModifier current_speed_modifier_;
-  uint8_t phase_24_;    // 24 PPQN phase counter (0-23)
-  uint64_t tick_count_; // Running tick count
+  uint8_t phase_24_;
+  uint64_t tick_count_;
   const bool _send_midi_clock_when_stopped;
-
-  // Tracks whether set_clock_source has performed initial attachment/setup.
   bool initialized_ = false;
-
-  // Last tempo knob position for re-evaluation on clock source changes
   float last_tempo_knob_value_ = 0.5f;
 };
 

--- a/musin/timing/timing_constants.h
+++ b/musin/timing/timing_constants.h
@@ -6,16 +6,18 @@
 namespace musin::timing {
 
 /**
- * @brief Default Pulses Per Quarter Note (PPQN) used for high-resolution
- * timing. Standard MIDI clock is 24, common sequencer resolution is 96.
+ * @brief Default Pulses Per Quarter Note (PPQN) used for sequencer timing.
+ * Set to 12 PPQN for efficient processing while maintaining musical resolution.
+ * Raw clock sources (MIDI, SYNC) operate at 24 PPQN and are downsampled by
+ * SpeedAdapter.
  */
-constexpr uint32_t DEFAULT_PPQN = 24;
+constexpr uint32_t DEFAULT_PPQN = 12;
 
-// Common 24-PPQN phase markers for clarity at call sites
+// Common 12-PPQN phase markers for clarity at call sites
 constexpr uint8_t PHASE_DOWNBEAT = 0;                      // quarter start
-constexpr uint8_t PHASE_EIGHTH_OFFBEAT = DEFAULT_PPQN / 2; // 12
-constexpr uint8_t PHASE_TRIPLET_STEP = DEFAULT_PPQN / 3;   // 8
-constexpr uint8_t PHASE_SIXTEENTH_STEP = DEFAULT_PPQN / 4; // 6
+constexpr uint8_t PHASE_EIGHTH_OFFBEAT = DEFAULT_PPQN / 2; // 6
+constexpr uint8_t PHASE_TRIPLET_STEP = DEFAULT_PPQN / 3;   // 4
+constexpr uint8_t PHASE_SIXTEENTH_STEP = DEFAULT_PPQN / 4; // 3
 
 } // namespace musin::timing
 

--- a/musin/timing/timing_constants.h
+++ b/musin/timing/timing_constants.h
@@ -8,8 +8,9 @@ namespace musin::timing {
 /**
  * @brief Default Pulses Per Quarter Note (PPQN) used for sequencer timing.
  * Set to 12 PPQN for efficient processing while maintaining musical resolution.
- * Raw clock sources (MIDI, SYNC) operate at 24 PPQN and are downsampled by
- * SpeedAdapter.
+ * All clock sources (INTERNAL, MIDI, EXTERNAL_SYNC) operate at 24 PPQN and are
+ * downsampled by SpeedAdapter to 12 PPQN (NORMAL), 6 PPQN (HALF), or 24 PPQN
+ * (DOUBLE).
  */
 constexpr uint32_t DEFAULT_PPQN = 12;
 

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -53,8 +53,7 @@ TEST_CASE("SpeedAdapter NORMAL forwards all ticks") {
   }
 }
 
-TEST_CASE("SpeedAdapter HALF passes through all ticks (half-speed now handled "
-          "by sources)") {
+TEST_CASE("SpeedAdapter HALF emits every 2nd tick") {
   reset_test_state();
 
   SpeedAdapter adapter(SpeedModifier::HALF_SPEED);
@@ -71,9 +70,8 @@ TEST_CASE("SpeedAdapter HALF passes through all ticks (half-speed now handled "
     advance_time_us(8000);
   }
 
-  // Expect all 6 ticks forwarded (half-speed is now handled by individual
-  // sources)
-  REQUIRE(rec.events.size() == 6);
+  // SpeedAdapter now handles HALF_SPEED by emitting every 2nd tick
+  REQUIRE(rec.events.size() == 3);
 }
 
 TEST_CASE("SpeedAdapter DOUBLE inserts mid ticks with non-physical flag") {

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -29,15 +29,15 @@ static void advance_time_us(uint64_t us) {
 }
 } // namespace
 
-TEST_CASE("SpeedAdapter NORMAL forwards all ticks") {
+TEST_CASE("SpeedAdapter NORMAL emits every 2nd tick (24→12 PPQN)") {
   reset_test_state();
 
   SpeedAdapter adapter(SpeedModifier::NORMAL_SPEED);
   ClockEventRecorder rec;
   adapter.add_observer(rec);
 
-  // Generate 5 ticks 10ms apart
-  for (int i = 0; i < 5; ++i) {
+  // Generate 6 ticks 10ms apart (simulating 24 PPQN source)
+  for (int i = 0; i < 6; ++i) {
     ClockEvent e{ClockSource::MIDI};
     e.is_downbeat = false;
     e.timestamp_us =
@@ -46,22 +46,23 @@ TEST_CASE("SpeedAdapter NORMAL forwards all ticks") {
     advance_time_us(10000);
   }
 
-  REQUIRE(rec.events.size() == 5);
+  // NORMAL mode drops every other tick: 6→3
+  REQUIRE(rec.events.size() == 3);
   for (const auto &e : rec.events) {
     REQUIRE(e.source == ClockSource::MIDI);
     REQUIRE(e.is_resync == false);
   }
 }
 
-TEST_CASE("SpeedAdapter HALF emits every 2nd tick") {
+TEST_CASE("SpeedAdapter HALF emits every 4th tick (24→6 PPQN)") {
   reset_test_state();
 
   SpeedAdapter adapter(SpeedModifier::HALF_SPEED);
   ClockEventRecorder rec;
   adapter.add_observer(rec);
 
-  // Send 6 ticks at regular intervals
-  for (int i = 0; i < 6; ++i) {
+  // Send 8 ticks at regular intervals (simulating 24 PPQN source)
+  for (int i = 0; i < 8; ++i) {
     ClockEvent e{ClockSource::EXTERNAL_SYNC};
     e.is_downbeat = (i % 3) == 0; // mix of physical/non-physical
     e.timestamp_us =
@@ -70,92 +71,60 @@ TEST_CASE("SpeedAdapter HALF emits every 2nd tick") {
     advance_time_us(8000);
   }
 
-  // SpeedAdapter now handles HALF_SPEED by emitting every 2nd tick
-  REQUIRE(rec.events.size() == 3);
+  // HALF_SPEED emits every 4th tick: 8→2
+  REQUIRE(rec.events.size() == 2);
 }
 
-TEST_CASE("SpeedAdapter DOUBLE inserts mid ticks with non-physical flag") {
+TEST_CASE("SpeedAdapter DOUBLE passes through all ticks (24 PPQN)") {
   reset_test_state();
 
   SpeedAdapter adapter(SpeedModifier::DOUBLE_SPEED);
   ClockEventRecorder rec;
   adapter.add_observer(rec);
 
-  // First tick at t=0us -> forwarded, no insert scheduled yet
-  {
+  // Generate 5 ticks 10ms apart
+  for (int i = 0; i < 5; ++i) {
     ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = false;
+    e.is_downbeat = (i % 2) == 0;
     e.timestamp_us =
         static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     adapter.notification(e);
+    advance_time_us(10000);
   }
 
-  // Advance 10ms, second tick -> forwarded, schedules insert at +5ms
-  advance_time_us(10000);
-  {
-    ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = false;
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
-    adapter.notification(e);
-  }
-
-  // Advance 5ms -> hit mid insert
-  advance_time_us(5000);
-  adapter.update(get_absolute_time());
-
-  // Advance another 5ms, third tick arrives -> forwarded, may schedule next
-  // insert
-  advance_time_us(5000);
-  {
-    ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = false;
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
-    adapter.notification(e);
-  }
-
-  // We should have: pass-through first, pass-through second, inserted mid,
-  // pass-through third => 4 events
-  REQUIRE(rec.events.size() == 4);
-  // Inserted event must be non-physical
-  bool found_non_physical_insert = false;
+  // DOUBLE mode passes all ticks through (24 PPQN output)
+  REQUIRE(rec.events.size() == 5);
   for (const auto &e : rec.events) {
-    if (e.is_downbeat == false) {
-      found_non_physical_insert = true;
-      break;
-    }
+    REQUIRE(e.source == ClockSource::MIDI);
+    REQUIRE(e.is_resync == false);
   }
-  REQUIRE(found_non_physical_insert);
 }
 
-TEST_CASE("SpeedAdapter resync forwards and clears scheduling") {
+TEST_CASE("SpeedAdapter resync forwards and clears counter") {
   reset_test_state();
 
-  SpeedAdapter adapter(SpeedModifier::DOUBLE_SPEED);
+  SpeedAdapter adapter(SpeedModifier::NORMAL_SPEED);
   ClockEventRecorder rec;
   adapter.add_observer(rec);
 
-  // Prime interval with two ticks
+  // Send one tick (odd counter, won't emit)
   ClockEvent e{ClockSource::MIDI};
   e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   adapter.notification(e);
-  advance_time_us(12000);
-  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
-  adapter.notification(e);
 
-  // Instead of waiting for the mid insert, send a resync event
+  // Send resync event - should forward and reset counter
   ClockEvent res{ClockSource::MIDI};
   res.is_resync = true;
   res.timestamp_us =
       static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   adapter.notification(res);
 
-  // Advance time past where an insert would have occurred; none should fire
+  // After resync, counter is reset, so next tick should emit (even counter)
   advance_time_us(8000);
-  adapter.update(get_absolute_time());
+  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
+  adapter.notification(e);
 
-  // Events seen: first pass-through, second pass-through, resync
-  REQUIRE(rec.events.size() == 3);
-  REQUIRE(rec.events[2].is_resync == true);
+  // Events seen: resync, then nothing on first post-resync tick
+  REQUIRE(rec.events.size() == 1);
+  REQUIRE(rec.events[0].is_resync == true);
 }

--- a/test/musin/timing/tempo_handler_test.cpp
+++ b/test/musin/timing/tempo_handler_test.cpp
@@ -91,9 +91,9 @@ TEST_CASE("TempoHandler internal clock emits tempo events and MIDI clock") {
 
   REQUIRE(rec.events.size() >= 3);
   // First few phases should advance by 1 per tick (starting from 0 -> 1,2,3)
-  REQUIRE(rec.events[0].phase_24 == 1);
-  REQUIRE(rec.events[1].phase_24 == 2);
-  REQUIRE(rec.events[2].phase_24 == 3);
+  REQUIRE(rec.events[0].phase_12 == 1);
+  REQUIRE(rec.events[1].phase_12 == 2);
+  REQUIRE(rec.events[2].phase_12 == 3);
 
   // Expect at least 3 MIDI realtime Clock messages
   size_t rt_count = 0;
@@ -128,8 +128,8 @@ TEST_CASE("TempoHandler external sync passes through ticks (half-speed now "
   TempoEventRecorder rec;
   th.add_observer(rec);
 
-  // Simulate 4 external physical pulses by feeding the router.
-  for (int i = 0; i < 4; ++i) {
+  // Simulate 8 external physical pulses by feeding the router.
+  for (int i = 0; i < 8; ++i) {
     ClockEvent e{ClockSource::EXTERNAL_SYNC};
     e.is_downbeat = true;
     e.timestamp_us =
@@ -137,11 +137,11 @@ TEST_CASE("TempoHandler external sync passes through ticks (half-speed now "
     clock_router.notification(e);
   }
 
-  // SpeedAdapter now handles HALF_SPEED, emitting every 2nd tick
+  // SpeedAdapter now handles HALF_SPEED, emitting every 4th tick (8→2)
   REQUIRE(rec.events.size() == 2);
   // External physical pulses get phase alignment instead of sequential
   // advancement Since we start at phase 0, calculate_aligned_phase() returns 0
-  REQUIRE(rec.events[0].phase_24 == 0);
+  REQUIRE(rec.events[0].phase_12 == 0);
 }
 
 TEST_CASE("TempoHandler manual sync in MIDI emits immediate resync") {
@@ -166,7 +166,7 @@ TEST_CASE("TempoHandler manual sync in MIDI emits immediate resync") {
   th.trigger_manual_sync();
   REQUIRE(rec.events.size() >= 1);
   REQUIRE(rec.events[0].is_resync == true);
-  REQUIRE(rec.events[0].phase_24 == musin::timing::PHASE_DOWNBEAT);
+  REQUIRE(rec.events[0].phase_12 == musin::timing::PHASE_DOWNBEAT);
 }
 
 TEST_CASE("TempoHandler DOUBLE_SPEED with MIDI source advances by 2") {
@@ -211,8 +211,8 @@ TEST_CASE("TempoHandler DOUBLE_SPEED with MIDI source advances by 2") {
 
   REQUIRE(rec.events.size() >= 3);
   // Phases advance by 1 per adapter output
-  REQUIRE(rec.events[0].phase_24 == 1);
-  REQUIRE(rec.events[1].phase_24 == 2);
+  REQUIRE(rec.events[0].phase_12 == 1);
+  REQUIRE(rec.events[1].phase_12 == 2);
 }
 
 TEST_CASE("TempoHandler DOUBLE_SPEED phase alignment on odd phases") {
@@ -252,7 +252,7 @@ TEST_CASE("TempoHandler DOUBLE_SPEED phase alignment on odd phases") {
 
   REQUIRE(rec.events.size() >= 1);
   // Phase should be aligned to even (4, since 3+1=4 which is even)
-  REQUIRE((rec.events[0].phase_24 & 1u) == 0u);
+  REQUIRE((rec.events[0].phase_12 & 1u) == 0u);
 }
 
 TEST_CASE("TempoHandler auto-switches from INTERNAL to MIDI when active") {
@@ -385,7 +385,7 @@ TEST_CASE(
 
   REQUIRE(rec.events.size() >= 1);
   REQUIRE(rec.events[0].is_resync == true);
-  REQUIRE(rec.events[0].phase_24 == musin::timing::PHASE_DOWNBEAT);
+  REQUIRE(rec.events[0].phase_12 == musin::timing::PHASE_DOWNBEAT);
 }
 
 TEST_CASE("TempoHandler manual sync with MIDI emits immediate resync") {
@@ -420,7 +420,7 @@ TEST_CASE("TempoHandler manual sync with MIDI emits immediate resync") {
   th.trigger_manual_sync();
   REQUIRE(rec.events.size() >= 1);
   REQUIRE(rec.events[0].is_resync == true);
-  REQUIRE(rec.events[0].phase_24 == musin::timing::PHASE_DOWNBEAT);
+  REQUIRE(rec.events[0].phase_12 == musin::timing::PHASE_DOWNBEAT);
 }
 
 TEST_CASE("TempoHandler set_bpm only affects internal clock source") {


### PR DESCRIPTION
## Summary
Converts the internal timing system from 24 PPQN to 12 PPQN throughout the codebase. This simplifies timing calculations and reduces computational overhead while maintaining musical accuracy for the sequencer's needs.

## Changes

### Core Timing Architecture
- **PPQN reduction**: Changed from 24 PPQN to 12 PPQN across all timing modules
- **InternalClock**: Remains at 24 PPQN as the hardware clock source
- **SpeedAdapter**: Now downsamples 24 PPQN input to variable-rate output:
  - NORMAL: every 2nd tick (24→12 PPQN)
  - HALF_SPEED: every 4th tick (24→6 PPQN)
  - DOUBLE: pass-through all ticks (24 PPQN, phase wraps 0→11 twice/quarter)

### Musical Timing Updates
- **Phase values**: Updated all phase references from 0-23 to 0-11 range
- **Swing offset**: Changed from 4 phases (at 24 PPQN) to 2 phases (at 12 PPQN), maintaining same musical timing
- **Subdivision masks**: Updated bitmasks for sixteenths and triplets:
  - Sixteenths: phases 0, 3, 6, 9 (was 0, 6, 12, 18)
  - Triplets: phases 0, 4, 8 (was 0, 8, 16)

### ClockRouter Enhancements
- **Auto source switching**: New `update_auto_source_switching()` method replaces TempoHandler's source management
- **Control API**: Added `set_bpm()`, `trigger_resync()`, `resync_sync_output()` methods
- **SyncOut integration**: Direct reference for resync coordination
- **First tick handling**: Tracks `awaiting_first_tick_after_switch_` flag for cleaner source transitions

### Speed Modification Refactoring
- **Centralized in SpeedAdapter**: Removed speed modification from MidiClockProcessor and SyncIn
- **Simplified logic**: Tick-based downsampling replaces interval measurement and interpolation
- **Removed methods**: `set_speed_modifier()` removed from MidiClockProcessor and SyncIn (now handled by SpeedAdapter only)

### MidiClockProcessor Simplification
- **First tick handling**: Now sends resync event on first tick to properly initialize phase
- **Timeout recovery**: Improved timeout detection and resync after MIDI clock restarts
- **Removed**: Speed modification logic (moved to SpeedAdapter)
- **Echo behavior**: Unchanged - still forwards MIDI clock when enabled

### SyncIn Simplification
- **12 PPQN output**: Generates 12 ticks per eighth note (1 physical + 11 interpolated)
- **Removed**: Speed modification logic and physical pulse toggle
- **Cleaner tick emission**: All interpolated ticks use consistent interval calculation

### TempoHandler Integration
- **Simplified constructor**: Removed direct references to clock sources (now managed by ClockRouter)
- **Removed update method**: Clock source switching now handled by ClockRouter

### Main Loop Changes
- **Setup**: Added `clock_router.set_sync_out(&sync_out)` before observer registration
- **Update loop**: 
  - Removed `speed_adapter.update()` (no longer needed)
  - Replaced `tempo_handler.update()` with `clock_router.update_auto_source_switching()`

### SequencerController Updates
- **Phase tracking**: Renamed `last_phase_24_` to `last_phase_12_`
- **Phase windowing**: Updated wrap-around logic for 0-11 phase range
- **Bitmask calculations**: Updated for 12-phase rotation

### Display Updates
- **PizzaDisplay**: Updated to use `phase_12` instead of `phase_24` for downbeat/offbeat detection

## Testing
- Updated all timing-related tests to use 12 PPQN
- Swing timing tests updated for new phase values
- SequencerController tests pass with new phase ranges

## Migration Notes
- Existing sequences remain compatible (step timing unchanged)
- Swing feel is identical (same percentage offset, different absolute phase value)
- MIDI clock input/output unchanged (24 PPQN on the wire, converted internally)