### PR TITLE
Feature/anchor phase from sequencer

### DIFF
--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -191,7 +191,6 @@ void SequencerController<NumTracks, NumSteps>::start() {
   }
 
   _just_played_step_per_track.fill(std::nullopt);
-  last_phase_12_ = 0;
 
   tempo_source.add_observer(*this);
   tempo_source.set_playback_state(musin::timing::PlaybackState::PLAYING);
@@ -199,8 +198,10 @@ void SequencerController<NumTracks, NumSteps>::start() {
   _running = true;
 
   // Resync the clock on start for better phase alignment
-  // This will trigger a resync event that marks the first step due
-  tempo_source.trigger_manual_sync();
+  // Use the last played anchor phase (0 or 6) to maintain swing timing
+  uint8_t anchor_phase = (last_phase_12_ < 6) ? 0 : 6;
+  last_phase_12_ = (anchor_phase == 0) ? 11 : 5;
+  tempo_source.trigger_manual_sync(anchor_phase);
 }
 
 template <size_t NumTracks, size_t NumSteps>

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -12,14 +12,6 @@
 
 namespace drum {
 
-namespace musical_timing {
-constexpr uint8_t PPQN = 12;
-constexpr uint8_t DOWNBEAT = 0;
-constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2;      // 6
-constexpr uint8_t TRIPLET_SUBDIVISION = PPQN / 3;   // 4
-constexpr uint8_t SIXTEENTH_SUBDIVISION = PPQN / 4; // 3
-} // namespace musical_timing
-
 namespace {
 constexpr std::uint32_t SIXTEENTH_MASK =
     (1u << 0) | (1u << 3) | (1u << 6) | (1u << 9);
@@ -197,10 +189,10 @@ void SequencerController<NumTracks, NumSteps>::start() {
 
   _running = true;
 
-  // Resync the clock on start for better phase alignment
-  // Use the last played anchor phase (0 or 6) to maintain swing timing
-  uint8_t anchor_phase = (last_phase_12_ < 6) ? 0 : 6;
-  last_phase_12_ = (anchor_phase == 0) ? 11 : 5;
+  // To maintain swing timing, align the clock phase on restart.
+  const auto [anchor_phase, primed_phase] =
+      align_to_last_anchor(last_phase_12_);
+  last_phase_12_ = primed_phase;
   tempo_source.trigger_manual_sync(anchor_phase);
 }
 

--- a/musin/timing/clock_event.h
+++ b/musin/timing/clock_event.h
@@ -31,11 +31,6 @@ struct ClockEvent {
   bool is_resync = false; // True when clock resumes after timeout
   // True for a SyncIn rising edge that aligns to the external downbeat.
   bool is_downbeat = false;
-  // Optional anchor instruction for this tick. When set, TempoHandler should
-  // set its phase to this exact value (0..23) on this tick. A sentinel value
-  // indicates that no anchoring is requested.
-  static constexpr uint8_t ANCHOR_PHASE_NONE = 0xFF;
-  uint8_t anchor_to_phase = ANCHOR_PHASE_NONE;
 };
 
 } // namespace musin::timing

--- a/musin/timing/clock_event.h
+++ b/musin/timing/clock_event.h
@@ -31,9 +31,6 @@ struct ClockEvent {
   bool is_resync = false; // True when clock resumes after timeout
   // True for a SyncIn rising edge that aligns to the external downbeat.
   bool is_downbeat = false;
-  // Timestamp in microseconds since boot when the source tick occurred.
-  // 0 means unset; consumers may fall back to local time if needed.
-  uint32_t timestamp_us = 0;
   // Optional anchor instruction for this tick. When set, TempoHandler should
   // set its phase to this exact value (0..23) on this tick. A sentinel value
   // indicates that no anchoring is requested.

--- a/musin/timing/clock_router.cpp
+++ b/musin/timing/clock_router.cpp
@@ -85,7 +85,6 @@ void ClockRouter::trigger_resync() {
 
   ClockEvent resync_event{current_source_};
   resync_event.is_resync = true;
-  resync_event.anchor_to_phase = ClockEvent::ANCHOR_PHASE_NONE;
   notify_observers(resync_event);
 
   if (sync_out_ != nullptr) {

--- a/musin/timing/internal_clock.cpp
+++ b/musin/timing/internal_clock.cpp
@@ -66,8 +66,6 @@ void InternalClock::update(absolute_time_t now) {
   }
 
   musin::timing::ClockEvent tick_event{musin::timing::ClockSource::INTERNAL};
-  // Stamp with the scheduled tick time for determinism
-  tick_event.timestamp_us = to_us_since_boot(_next_tick_time);
   notify_observers(tick_event);
 
   // Schedule the next tick.

--- a/musin/timing/midi_clock_processor.cpp
+++ b/musin/timing/midi_clock_processor.cpp
@@ -39,8 +39,6 @@ void MidiClockProcessor::on_midi_clock_tick_received() {
   // Forward MIDI clock tick to observers
   musin::timing::ClockEvent raw_tick_event{
       .source = musin::timing::ClockSource::MIDI, .is_resync = false};
-  raw_tick_event.timestamp_us =
-      static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   notify_observers(raw_tick_event);
 
   if (forward_echo_enabled_) {

--- a/musin/timing/sync_in.cpp
+++ b/musin/timing/sync_in.cpp
@@ -109,7 +109,6 @@ bool SyncIn::is_cable_connected() const {
 void SyncIn::emit_clock_event(absolute_time_t timestamp, bool is_physical) {
   ClockEvent event{ClockSource::EXTERNAL_SYNC};
   event.is_downbeat = is_physical;
-  event.timestamp_us = static_cast<uint32_t>(to_us_since_boot(timestamp));
   notify_observers(event);
 }
 

--- a/musin/timing/tempo_event.h
+++ b/musin/timing/tempo_event.h
@@ -10,7 +10,6 @@ namespace musin::timing {
  * This is emitted by TempoHandler and potentially consumed by TempoMultiplier.
  */
 struct TempoEvent {
-  uint64_t tick_count;
   uint8_t phase_12 = 0; // Phase value 0-11 at 12 PPQN
   bool is_resync = false;
 };

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -60,14 +60,15 @@ uint8_t TempoHandler::calculate_aligned_phase() const {
 }
 
 void TempoHandler::notification(musin::timing::ClockEvent event) {
+  constexpr uint8_t NO_ANCHOR = 0xFF;
+  uint8_t anchor_phase = NO_ANCHOR;
+
   if (event.source == ClockSource::EXTERNAL_SYNC && event.is_downbeat) {
-    event.anchor_to_phase = calculate_aligned_phase();
+    anchor_phase = calculate_aligned_phase();
   }
 
   if (event.is_resync) {
-    phase_12_ = (event.anchor_to_phase != ClockEvent::ANCHOR_PHASE_NONE)
-                    ? event.anchor_to_phase
-                    : 0;
+    phase_12_ = (anchor_phase != NO_ANCHOR) ? anchor_phase : 0;
     tick_count_++;
     musin::timing::TempoEvent tempo_event{.phase_12 = phase_12_,
                                           .is_resync = true};
@@ -75,8 +76,8 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
     return;
   }
 
-  uint8_t next_phase = (event.anchor_to_phase != ClockEvent::ANCHOR_PHASE_NONE)
-                           ? event.anchor_to_phase
+  uint8_t next_phase = (anchor_phase != NO_ANCHOR)
+                           ? anchor_phase
                            : (phase_12_ + 1) % musin::timing::DEFAULT_PPQN;
 
   tick_count_++;

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -128,7 +128,7 @@ void TempoHandler::set_playback_state(PlaybackState new_state) {
   _playback_state = new_state;
 }
 
-void TempoHandler::trigger_manual_sync() {
+void TempoHandler::trigger_manual_sync(uint8_t target_phase) {
   if (!drum::config::RETRIGGER_SYNC_ON_PLAYBUTTON) {
     return;
   }
@@ -137,7 +137,7 @@ void TempoHandler::trigger_manual_sync() {
   case ClockSource::INTERNAL:
   case ClockSource::MIDI:
     _clock_router_ref.trigger_resync();
-    emit_manual_resync_event(calculate_aligned_phase());
+    emit_manual_resync_event(target_phase);
     break;
   case ClockSource::EXTERNAL_SYNC:
     break;

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -69,8 +69,8 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
                     ? event.anchor_to_phase
                     : 0;
     tick_count_++;
-    musin::timing::TempoEvent tempo_event{
-        .tick_count = tick_count_, .phase_12 = phase_12_, .is_resync = true};
+    musin::timing::TempoEvent tempo_event{.phase_12 = phase_12_,
+                                          .is_resync = true};
     notify_observers(tempo_event);
     return;
   }
@@ -81,8 +81,8 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
 
   tick_count_++;
   phase_12_ = next_phase;
-  musin::timing::TempoEvent tempo_event{
-      .tick_count = tick_count_, .phase_12 = phase_12_, .is_resync = false};
+  musin::timing::TempoEvent tempo_event{.phase_12 = phase_12_,
+                                        .is_resync = false};
   notify_observers(tempo_event);
 }
 
@@ -147,8 +147,8 @@ void TempoHandler::trigger_manual_sync(uint8_t target_phase) {
 void TempoHandler::emit_manual_resync_event(uint8_t anchor_phase) {
   phase_12_ = anchor_phase;
   tick_count_++;
-  musin::timing::TempoEvent tempo_event{
-      .tick_count = tick_count_, .phase_12 = phase_12_, .is_resync = true};
+  musin::timing::TempoEvent tempo_event{.phase_12 = phase_12_,
+                                        .is_resync = true};
   notify_observers(tempo_event);
 }
 

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -56,7 +56,7 @@ public:
   void set_playback_state(PlaybackState new_state);
   [[nodiscard]] PlaybackState get_playback_state() const;
 
-  void trigger_manual_sync();
+  void trigger_manual_sync(uint8_t target_phase = 0);
 
   void notification(musin::timing::ClockEvent event) override;
 

--- a/test/musin/timing/clock_router_test.cpp
+++ b/test/musin/timing/clock_router_test.cpp
@@ -99,8 +99,6 @@ TEST_CASE("ClockRouter routes external sync directly and preserves "
   // Simulate an external physical pulse arriving directly via SyncIn
   ClockEvent pulse{ClockSource::EXTERNAL_SYNC};
   pulse.is_downbeat = true;
-  pulse.timestamp_us =
-      static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   router.notification(
       pulse); // Direct notification since SyncIn connects to router
 
@@ -126,8 +124,7 @@ TEST_CASE("ClockRouter auto switching stays on MIDI once selected") {
   InternalClock internal_clock(120.0f);
   MidiClockProcessor midi_proc;
   SyncIn sync_in(0, 1);
-  ClockRouter router(internal_clock, midi_proc, sync_in,
-                     ClockSource::INTERNAL);
+  ClockRouter router(internal_clock, midi_proc, sync_in, ClockSource::INTERNAL);
 
   REQUIRE(router.get_clock_source() == ClockSource::INTERNAL);
 

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -40,8 +40,6 @@ TEST_CASE("SpeedAdapter NORMAL emits every 2nd tick (24→12 PPQN)") {
   for (int i = 0; i < 6; ++i) {
     ClockEvent e{ClockSource::MIDI};
     e.is_downbeat = false;
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     adapter.notification(e);
     advance_time_us(10000);
   }
@@ -65,8 +63,6 @@ TEST_CASE("SpeedAdapter HALF emits every 4th tick (24→6 PPQN)") {
   for (int i = 0; i < 8; ++i) {
     ClockEvent e{ClockSource::EXTERNAL_SYNC};
     e.is_downbeat = (i % 3) == 0; // mix of physical/non-physical
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     adapter.notification(e);
     advance_time_us(8000);
   }
@@ -86,8 +82,6 @@ TEST_CASE("SpeedAdapter DOUBLE passes through all ticks (24 PPQN)") {
   for (int i = 0; i < 5; ++i) {
     ClockEvent e{ClockSource::MIDI};
     e.is_downbeat = (i % 2) == 0;
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     adapter.notification(e);
     advance_time_us(10000);
   }
@@ -109,19 +103,15 @@ TEST_CASE("SpeedAdapter resync forwards and clears counter") {
 
   // Send one tick (odd counter, won't emit)
   ClockEvent e{ClockSource::MIDI};
-  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   adapter.notification(e);
 
   // Send resync event - should forward and reset counter
   ClockEvent res{ClockSource::MIDI};
   res.is_resync = true;
-  res.timestamp_us =
-      static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   adapter.notification(res);
 
   // After resync, counter is reset, so next tick should emit (even counter)
   advance_time_us(8000);
-  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   adapter.notification(e);
 
   // Events seen: resync, then nothing on first post-resync tick

--- a/test/musin/timing/tempo_handler_test.cpp
+++ b/test/musin/timing/tempo_handler_test.cpp
@@ -73,8 +73,6 @@ TEST_CASE("TempoHandler internal clock emits tempo events and MIDI clock") {
   // Generate 6 internal ticks; SpeedAdapter in NORMAL emits every 2nd tick
   for (int i = 0; i < 6; ++i) {
     ClockEvent tick{ClockSource::INTERNAL};
-    tick.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     clock_router.notification(tick);
   }
 
@@ -127,8 +125,6 @@ TEST_CASE("TempoHandler external sync passes through ticks (half-speed now "
   for (int i = 0; i < 8; ++i) {
     ClockEvent e{ClockSource::EXTERNAL_SYNC};
     e.is_downbeat = true;
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     clock_router.notification(e);
   }
 
@@ -188,8 +184,6 @@ TEST_CASE("TempoHandler DOUBLE_SPEED with MIDI source forwards every tick") {
   for (int i = 0; i < 3; ++i) {
     ClockEvent e{ClockSource::MIDI};
     e.is_downbeat = false;
-    e.timestamp_us =
-        static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
     speed_adapter.notification(e);
   }
 
@@ -232,7 +226,6 @@ TEST_CASE("TempoHandler DOUBLE_SPEED maintains phase progression") {
   // Send one more tick to see the aligned phase
   ClockEvent e{ClockSource::MIDI};
   e.is_downbeat = false;
-  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   speed_adapter.notification(e);
 
   REQUIRE(rec.events.size() >= 1);
@@ -357,7 +350,6 @@ TEST_CASE(
   // Send a MIDI tick to establish some history
   ClockEvent e{ClockSource::MIDI};
   e.is_downbeat = false;
-  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   speed_adapter_lb.notification(e);
   rec.clear();
 
@@ -393,7 +385,6 @@ TEST_CASE("TempoHandler manual sync with MIDI emits immediate resync") {
   // Send a MIDI tick to establish some history
   ClockEvent e{ClockSource::MIDI};
   e.is_downbeat = false;
-  e.timestamp_us = static_cast<uint32_t>(to_us_since_boot(get_absolute_time()));
   speed_adapter_def.notification(e);
   rec.clear();
 


### PR DESCRIPTION
On a sequencer initiated resync, supply a desired phase as well so that TempoHandler and SequencerController are on the same phase. Fixes #512 