### PR TITLE
Feature/sync alignment hint

### DIFF
--- a/musin/timing/clock_event.h
+++ b/musin/timing/clock_event.h
@@ -31,6 +31,9 @@ struct ClockEvent {
   bool is_resync = false; // True when clock resumes after timeout
   // True for a SyncIn rising edge that aligns to the external downbeat.
   bool is_downbeat = false;
+  // Set when this event should be used to align phase, even if the tick is
+  // being dropped or treated specially downstream.
+  bool is_alignment_hint = false;
 };
 
 } // namespace musin::timing

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -18,6 +18,10 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     // Emit every 4th tick: 24→6 PPQN
     if (tick_counter_ % 4 == 0) {
       notify_observers(event);
+    } else if (event.is_alignment_hint) {
+      ClockEvent hint_event = event;
+      hint_event.is_downbeat = false;
+      notify_observers(hint_event);
     }
     break;
 
@@ -25,6 +29,10 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     // Emit every 2nd tick: 24→12 PPQN
     if (tick_counter_ % 2 == 0) {
       notify_observers(event);
+    } else if (event.is_alignment_hint) {
+      ClockEvent hint_event = event;
+      hint_event.is_downbeat = false;
+      notify_observers(hint_event);
     }
     break;
 

--- a/musin/timing/sync_in.cpp
+++ b/musin/timing/sync_in.cpp
@@ -109,6 +109,7 @@ bool SyncIn::is_cable_connected() const {
 void SyncIn::emit_clock_event(absolute_time_t timestamp, bool is_physical) {
   ClockEvent event{ClockSource::EXTERNAL_SYNC};
   event.is_downbeat = is_physical;
+  event.is_alignment_hint = is_physical;
   notify_observers(event);
 }
 

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -74,6 +74,7 @@ private:
   const bool _send_midi_clock_when_stopped;
   bool initialized_ = false;
   float last_tempo_knob_value_ = 0.5f;
+  bool pending_external_sync_ = false;
 };
 
 } // namespace musin::timing

--- a/test/musin/CMakeLists.txt
+++ b/test/musin/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${PROJECT_NAME}
   timing/tempo_handler_test.cpp
   timing/speed_adapter_test.cpp
   timing/clock_router_test.cpp
+  timing/tempo_handler_external_sync_test.cpp
 )
 
 if(${STATIC_TESTS})

--- a/test/musin/timing/tempo_handler_external_sync_test.cpp
+++ b/test/musin/timing/tempo_handler_external_sync_test.cpp
@@ -52,9 +52,8 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
   InternalClock internal_clock(120.0f);
   MidiClockProcessor midi_processor;
   musin::timing::SyncIn sync_in_stub(0, 1);
-  musin::timing::ClockRouter clock_router(internal_clock, midi_processor,
-                                          sync_in_stub,
-                                          ClockSource::EXTERNAL_SYNC);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
@@ -73,6 +72,7 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
 
   ClockEvent physical_pulse{ClockSource::EXTERNAL_SYNC};
   physical_pulse.is_downbeat = true;
+  physical_pulse.is_alignment_hint = true;
   clock_router.notification(physical_pulse);
 
   REQUIRE_FALSE(recorder.events.empty());


### PR DESCRIPTION
Adds alignment flag to the clock event so that alignment can be separately communicated from is_downbeat.

Fixes #520 