### PR TITLE
Feature/defer sync

### DIFF
--- a/musin/timing/clock_event.h
+++ b/musin/timing/clock_event.h
@@ -30,7 +30,7 @@ struct ClockEvent {
   musin::timing::ClockSource source;
   bool is_resync = false; // True when clock resumes after timeout
   // True for a SyncIn rising edge that aligns to the external downbeat.
-  bool is_downbeat = false;
+  bool is_beat = false;
 };
 
 } // namespace musin::timing

--- a/musin/timing/clock_router.cpp
+++ b/musin/timing/clock_router.cpp
@@ -28,6 +28,7 @@ void ClockRouter::set_clock_source(ClockSource source) {
   }
 
   ClockSource old_source = current_source_;
+  bool was_initialized = initialized_;
 
   if (initialized_) {
     detach_current_source();
@@ -40,6 +41,14 @@ void ClockRouter::set_clock_source(ClockSource source) {
   // Notify listener after source is fully changed
   if (source_change_listener_) {
     source_change_listener_->on_clock_source_changed(old_source, source);
+  }
+
+  // Emit resync event when switching to non-EXTERNAL_SYNC sources
+  // to immediately reset phase and clear any pending state
+  if (was_initialized && source != ClockSource::EXTERNAL_SYNC) {
+    ClockEvent resync_event{source};
+    resync_event.is_resync = true;
+    notify_observers(resync_event);
   }
 }
 

--- a/musin/timing/clock_router.cpp
+++ b/musin/timing/clock_router.cpp
@@ -27,6 +27,8 @@ void ClockRouter::set_clock_source(ClockSource source) {
     return;
   }
 
+  ClockSource old_source = current_source_;
+
   if (initialized_) {
     detach_current_source();
   }
@@ -34,6 +36,11 @@ void ClockRouter::set_clock_source(ClockSource source) {
   current_source_ = source;
   attach_source(source);
   initialized_ = true;
+
+  // Notify listener after source is fully changed
+  if (source_change_listener_) {
+    source_change_listener_->on_clock_source_changed(old_source, source);
+  }
 }
 
 void ClockRouter::detach_current_source() {
@@ -134,6 +141,10 @@ void ClockRouter::update_auto_source_switching() {
 
 void ClockRouter::set_auto_switching_enabled(bool enabled) {
   auto_switching_enabled_ = enabled;
+}
+
+void ClockRouter::set_source_change_listener(ISourceChangeListener *listener) {
+  source_change_listener_ = listener;
 }
 
 } // namespace musin::timing

--- a/musin/timing/clock_router.h
+++ b/musin/timing/clock_router.h
@@ -15,6 +15,19 @@ class SyncOut;
 constexpr size_t MAX_CLOCK_ROUTER_OBSERVERS = 3;
 
 /**
+ * @brief Interface for receiving clock source change notifications.
+ *
+ * Implement this interface to be notified when ClockRouter switches between
+ * INTERNAL, MIDI, or EXTERNAL_SYNC sources.
+ */
+class ISourceChangeListener {
+public:
+  virtual ~ISourceChangeListener() = default;
+  virtual void on_clock_source_changed(ClockSource old_source,
+                                       ClockSource new_source) = 0;
+};
+
+/**
  * Selects the active raw 24 PPQN clock source and fans it out to observers.
  * Starts/stops internal clock, enables/disables MIDI forward echo,
  * and handles sync source management on source changes.
@@ -43,6 +56,9 @@ public:
   void update_auto_source_switching();
   void set_auto_switching_enabled(bool enabled);
 
+  // Source change notification
+  void set_source_change_listener(ISourceChangeListener *listener);
+
   // From selected upstream source
   void notification(musin::timing::ClockEvent event) override;
 
@@ -57,6 +73,7 @@ private:
   bool initialized_ = false;
   bool auto_switching_enabled_ = true;
   SyncOut *sync_out_ = nullptr;
+  ISourceChangeListener *source_change_listener_ = nullptr;
   bool awaiting_first_tick_after_switch_ = false;
 };
 

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -12,6 +12,11 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
   }
 
   if (event.is_downbeat) {
+    // Apply pending modifier on downbeat for external sync alignment
+    if (has_pending_modifier_) {
+      modifier_ = pending_modifier_;
+      has_pending_modifier_ = false;
+    }
     notify_observers(event);
     tick_counter_ = 0;
     return;

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -11,6 +11,12 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     return;
   }
 
+  if (event.is_downbeat) {
+    notify_observers(event);
+    tick_counter_ = 0;
+    return;
+  }
+
   tick_counter_++;
 
   switch (modifier_) {

--- a/musin/timing/speed_adapter.cpp
+++ b/musin/timing/speed_adapter.cpp
@@ -11,7 +11,7 @@ void SpeedAdapter::notification(musin::timing::ClockEvent event) {
     return;
   }
 
-  if (event.is_downbeat) {
+  if (event.is_beat) {
     // Apply pending modifier on downbeat for external sync alignment
     if (has_pending_modifier_) {
       modifier_ = pending_modifier_;

--- a/musin/timing/speed_adapter.h
+++ b/musin/timing/speed_adapter.h
@@ -30,10 +30,19 @@ public:
   }
 
   void set_modifier(SpeedModifier m) {
-    if (modifier_ == m)
+    if (modifier_ == m && !has_pending_modifier_)
       return;
-    modifier_ = m;
-    tick_counter_ = 0;
+
+    // For EXTERNAL_SYNC, defer the modifier change until next downbeat
+    if (current_source_ == ClockSource::EXTERNAL_SYNC) {
+      pending_modifier_ = m;
+      has_pending_modifier_ = true;
+    } else {
+      // For INTERNAL/MIDI, apply immediately
+      modifier_ = m;
+      tick_counter_ = 0;
+      has_pending_modifier_ = false;
+    }
   }
 
   [[nodiscard]] SpeedModifier get_modifier() const {
@@ -46,6 +55,8 @@ private:
   SpeedModifier modifier_;
   uint32_t tick_counter_ = 0;
   ClockSource current_source_ = ClockSource::INTERNAL;
+  SpeedModifier pending_modifier_ = SpeedModifier::NORMAL_SPEED;
+  bool has_pending_modifier_ = false;
 };
 
 } // namespace musin::timing

--- a/musin/timing/sync_in.cpp
+++ b/musin/timing/sync_in.cpp
@@ -108,7 +108,7 @@ bool SyncIn::is_cable_connected() const {
 
 void SyncIn::emit_clock_event(absolute_time_t timestamp, bool is_physical) {
   ClockEvent event{ClockSource::EXTERNAL_SYNC};
-  event.is_downbeat = is_physical;
+  event.is_beat = is_physical;
   notify_observers(event);
 }
 

--- a/musin/timing/sync_in.h
+++ b/musin/timing/sync_in.h
@@ -59,7 +59,7 @@ private:
   static constexpr uint32_t DETECT_DEBOUNCE_US = 50000; // 50ms
   static constexpr uint8_t PPQN_MULTIPLIER = 12;        // 2 PPQN to 24 PPQN
 
-  void emit_clock_event(absolute_time_t timestamp, bool is_downbeat);
+  void emit_clock_event(absolute_time_t timestamp, bool is_beat);
   void schedule_interpolated_ticks(absolute_time_t now);
   void emit_scheduled_ticks(absolute_time_t now);
 };

--- a/musin/timing/sync_out.cpp
+++ b/musin/timing/sync_out.cpp
@@ -45,7 +45,7 @@ void SyncOut::notification(musin::timing::ClockEvent event) {
   }
 
   // Align SyncOut pulse timing to physical sync boundaries
-  if (event.is_downbeat) {
+  if (event.is_beat) {
     _ticks_until_pulse = 0;
   }
 

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -46,10 +46,22 @@ ClockSource TempoHandler::get_clock_source() const {
 }
 
 uint8_t TempoHandler::calculate_aligned_phase() const {
-  // Use quarter-cycle thresholds so we pick the closest half-cycle anchor
-  // without large backward jumps near wrap-around.
-  constexpr uint8_t alignment_lut[12] = {0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 9, 0};
-  return alignment_lut[phase_12_];
+  switch (current_speed_modifier_) {
+  case SpeedModifier::HALF_SPEED: {
+    // Align to quarter-note grid (0, 3, 6, 9)
+    constexpr uint8_t alignment_lut[12] = {0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 9, 0};
+    return alignment_lut[phase_12_];
+  }
+  case SpeedModifier::NORMAL_SPEED: {
+    // Align to eighth-note grid (0, 6)
+    constexpr uint8_t alignment_lut[12] = {0, 0, 0, 0, 0, 0, 6, 6, 6, 6, 6, 6};
+    return alignment_lut[phase_12_];
+  }
+  case SpeedModifier::DOUBLE_SPEED:
+    // Always align to downbeat (0)
+    return 0;
+  }
+  return 0;
 }
 
 void TempoHandler::notification(musin::timing::ClockEvent event) {

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -47,14 +47,10 @@ ClockSource TempoHandler::get_clock_source() const {
 
 uint8_t TempoHandler::calculate_aligned_phase() const {
   switch (current_speed_modifier_) {
-  case SpeedModifier::HALF_SPEED: {
+  case SpeedModifier::HALF_SPEED:
+  case SpeedModifier::NORMAL_SPEED: {
     // Align to quarter-note grid (0, 3, 6, 9)
     constexpr uint8_t alignment_lut[12] = {0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 9, 0};
-    return alignment_lut[phase_12_];
-  }
-  case SpeedModifier::NORMAL_SPEED: {
-    // Align to eighth-note grid (0, 6)
-    constexpr uint8_t alignment_lut[12] = {0, 0, 0, 0, 0, 0, 6, 6, 6, 6, 6, 6};
     return alignment_lut[phase_12_];
   }
   case SpeedModifier::DOUBLE_SPEED:
@@ -68,7 +64,7 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
   constexpr uint8_t NO_ANCHOR = 0xFF;
   uint8_t anchor_phase = NO_ANCHOR;
 
-  if (event.source == ClockSource::EXTERNAL_SYNC && event.is_downbeat) {
+  if (event.source == ClockSource::EXTERNAL_SYNC && event.is_beat) {
     anchor_phase = calculate_aligned_phase();
     waiting_for_external_downbeat_ = false;
   }

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -46,17 +46,10 @@ ClockSource TempoHandler::get_clock_source() const {
 }
 
 uint8_t TempoHandler::calculate_aligned_phase() const {
-  constexpr uint8_t half_cycle = musin::timing::DEFAULT_PPQN / 2;
-  constexpr uint8_t quarter_cycle = musin::timing::DEFAULT_PPQN / 4;
-
   // Use quarter-cycle thresholds so we pick the closest half-cycle anchor
   // without large backward jumps near wrap-around.
-  uint8_t target_phase = 0;
-  if (phase_12_ >= quarter_cycle &&
-      phase_12_ < static_cast<uint8_t>(half_cycle + quarter_cycle)) {
-    target_phase = half_cycle;
-  }
-  return target_phase;
+  constexpr uint8_t alignment_lut[12] = {0, 0, 0, 0, 0, 0, 6, 6, 6, 6, 6, 6};
+  return alignment_lut[phase_12_];
 }
 
 void TempoHandler::notification(musin::timing::ClockEvent event) {

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -49,10 +49,14 @@ ClockSource TempoHandler::get_clock_source() const {
 
 uint8_t TempoHandler::calculate_aligned_phase() const {
   switch (current_speed_modifier_) {
-  case SpeedModifier::HALF_SPEED:
-  case SpeedModifier::NORMAL_SPEED: {
+  case SpeedModifier::HALF_SPEED: {
     // Align to quarter-note grid (0, 3, 6, 9)
     constexpr uint8_t alignment_lut[12] = {0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 9, 0};
+    return alignment_lut[phase_12_];
+  }
+  case SpeedModifier::NORMAL_SPEED: {
+    // Align to half-note grid (0, 6)
+    constexpr uint8_t alignment_lut[12] = {0, 0, 0, 6, 6, 6, 6, 6, 6, 0, 0, 0};
     return alignment_lut[phase_12_];
   }
   case SpeedModifier::DOUBLE_SPEED:

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -59,13 +59,13 @@ void TempoHandler::notification(musin::timing::ClockEvent event) {
   constexpr uint8_t NO_ANCHOR = 0xFF;
   uint8_t anchor_phase = NO_ANCHOR;
 
-  if (sync_state_ == SyncState::WAITING_FOR_BEAT) {
-    return;
-  }
-
   if (event.source == ClockSource::EXTERNAL_SYNC && event.is_beat) {
     anchor_phase = calculate_aligned_phase();
     sync_state_ = SyncState::RUNNING;
+  }
+
+  if (sync_state_ == SyncState::WAITING_FOR_BEAT) {
+    return;
   }
 
   if (event.is_resync) {

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -74,6 +74,7 @@ private:
   const bool _send_midi_clock_when_stopped;
   bool initialized_ = false;
   float last_tempo_knob_value_ = 0.5f;
+  bool waiting_for_external_downbeat_ = false;
 };
 
 } // namespace musin::timing

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -79,8 +79,8 @@ private:
   [[nodiscard]] uint8_t calculate_aligned_phase() const;
   void emit_manual_resync_event(uint8_t anchor_phase);
 
-  ClockRouter &_clock_router_ref;
-  SpeedAdapter &_speed_adapter_ref;
+  ClockRouter &clock_router_ref_;
+  SpeedAdapter &speed_adapter_ref_;
 
   PlaybackState _playback_state;
   SpeedModifier current_speed_modifier_;

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -19,6 +19,18 @@ enum class PlaybackState : uint8_t {
   PLAYING
 };
 
+/**
+ * @brief Defines synchronization state for external sync.
+ *
+ * Controls event processing when using external sync clock source:
+ * - RUNNING: Normal operation, process all events
+ * - WAITING_FOR_BEAT: Suppress events until next is_beat=true arrives
+ */
+enum class SyncState : uint8_t {
+  RUNNING,
+  WAITING_FOR_BEAT
+};
+
 // Maximum number of observers TempoHandler can notify (e.g.,
 // SequencerController)
 constexpr size_t MAX_TEMPO_OBSERVERS = 4;
@@ -32,6 +44,7 @@ constexpr size_t MAX_TEMPO_OBSERVERS = 4;
  */
 class TempoHandler
     : public etl::observer<musin::timing::ClockEvent>,
+      public ISourceChangeListener,
       public etl::observable<etl::observer<musin::timing::TempoEvent>,
                              MAX_TEMPO_OBSERVERS> {
 public:
@@ -59,6 +72,8 @@ public:
   void trigger_manual_sync(uint8_t target_phase = 0);
 
   void notification(musin::timing::ClockEvent event) override;
+  void on_clock_source_changed(ClockSource old_source,
+                               ClockSource new_source) override;
 
 private:
   [[nodiscard]] uint8_t calculate_aligned_phase() const;
@@ -74,7 +89,7 @@ private:
   const bool _send_midi_clock_when_stopped;
   bool initialized_ = false;
   float last_tempo_knob_value_ = 0.5f;
-  bool waiting_for_external_downbeat_ = false;
+  SyncState sync_state_ = SyncState::RUNNING;
 };
 
 } // namespace musin::timing

--- a/test/musin/CMakeLists.txt
+++ b/test/musin/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(${PROJECT_NAME}
   timing/tempo_handler_test.cpp
   timing/speed_adapter_test.cpp
   timing/clock_router_test.cpp
+  timing/tempo_handler_external_sync_test.cpp
 )
 
 if(${STATIC_TESTS})

--- a/test/musin/timing/clock_router_test.cpp
+++ b/test/musin/timing/clock_router_test.cpp
@@ -98,7 +98,7 @@ TEST_CASE("ClockRouter routes external sync directly and preserves "
 
   // Simulate an external physical pulse arriving directly via SyncIn
   ClockEvent pulse{ClockSource::EXTERNAL_SYNC};
-  pulse.is_downbeat = true;
+  pulse.is_beat = true;
   router.notification(
       pulse); // Direct notification since SyncIn connects to router
 
@@ -110,7 +110,7 @@ TEST_CASE("ClockRouter routes external sync directly and preserves "
   bool found_physical = false;
   for (size_t i = base_events; i < rec.events.size(); ++i) {
     if (rec.events[i].source == ClockSource::EXTERNAL_SYNC &&
-        rec.events[i].is_downbeat == true) {
+        rec.events[i].is_beat == true) {
       found_physical = true;
       break;
     }

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -39,7 +39,7 @@ TEST_CASE("SpeedAdapter NORMAL emits every 2nd tick (24→12 PPQN)") {
   // Generate 6 ticks 10ms apart (simulating 24 PPQN source)
   for (int i = 0; i < 6; ++i) {
     ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = false;
+    e.is_beat = false;
     adapter.notification(e);
     advance_time_us(10000);
   }
@@ -62,7 +62,7 @@ TEST_CASE("SpeedAdapter HALF emits every 4th tick (24→6 PPQN)") {
   // Send 8 ticks at regular intervals (simulating 24 PPQN source)
   for (int i = 0; i < 8; ++i) {
     ClockEvent e{ClockSource::EXTERNAL_SYNC};
-    e.is_downbeat = (i % 3) == 0; // mix of physical/non-physical
+    e.is_beat = (i % 3) == 0; // mix of physical/non-physical
     adapter.notification(e);
     advance_time_us(8000);
   }
@@ -82,7 +82,7 @@ TEST_CASE("SpeedAdapter DOUBLE passes through all ticks (24 PPQN)") {
   // Generate 5 ticks 10ms apart
   for (int i = 0; i < 5; ++i) {
     ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = (i % 2) == 0;
+    e.is_beat = (i % 2) == 0;
     adapter.notification(e);
     advance_time_us(10000);
   }

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -67,8 +67,9 @@ TEST_CASE("SpeedAdapter HALF emits every 4th tick (24→6 PPQN)") {
     advance_time_us(8000);
   }
 
-  // HALF_SPEED emits every 4th tick: 8→2
-  REQUIRE(rec.events.size() == 2);
+  // Downbeats pass through immediately (ticks 0,3,6), plus tick 4 from divider:
+  // 3+1=4
+  REQUIRE(rec.events.size() == 4);
 }
 
 TEST_CASE("SpeedAdapter DOUBLE passes through all ticks (24 PPQN)") {

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -52,7 +52,8 @@ TEST_CASE("SpeedAdapter NORMAL emits every 2nd tick (24→12 PPQN)") {
   }
 }
 
-TEST_CASE("SpeedAdapter HALF emits every 4th tick (24→6 PPQN)") {
+TEST_CASE(
+    "SpeedAdapter HALF passes through all downbeats regardless of count") {
   reset_test_state();
 
   SpeedAdapter adapter(SpeedModifier::HALF_SPEED);

--- a/test/musin/timing/speed_adapter_test.cpp
+++ b/test/musin/timing/speed_adapter_test.cpp
@@ -67,9 +67,9 @@ TEST_CASE("SpeedAdapter HALF emits every 4th tick (24→6 PPQN)") {
     advance_time_us(8000);
   }
 
-  // Downbeats pass through immediately (ticks 0,3,6), plus tick 4 from divider:
-  // 3+1=4
-  REQUIRE(rec.events.size() == 4);
+  // Only downbeats pass through (ticks 0,3,6). Counter resets on each downbeat,
+  // so divider never reaches 4.
+  REQUIRE(rec.events.size() == 3);
 }
 
 TEST_CASE("SpeedAdapter DOUBLE passes through all ticks (24 PPQN)") {

--- a/test/musin/timing/tempo_handler_external_sync_test.cpp
+++ b/test/musin/timing/tempo_handler_external_sync_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
   REQUIRE(recorder.events.empty());
 
   ClockEvent physical_pulse{ClockSource::EXTERNAL_SYNC};
-  physical_pulse.is_downbeat = true;
+  physical_pulse.is_beat = true;
   clock_router.notification(physical_pulse);
 
   REQUIRE_FALSE(recorder.events.empty());

--- a/test/musin/timing/tempo_handler_external_sync_test.cpp
+++ b/test/musin/timing/tempo_handler_external_sync_test.cpp
@@ -52,9 +52,8 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
   InternalClock internal_clock(120.0f);
   MidiClockProcessor midi_processor;
   musin::timing::SyncIn sync_in_stub(0, 1);
-  musin::timing::ClockRouter clock_router(internal_clock, midi_processor,
-                                          sync_in_stub,
-                                          ClockSource::EXTERNAL_SYNC);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
@@ -67,7 +66,7 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
   tempo_handler.add_observer(recorder);
 
   // Simulate pressing PLAY: manual sync intent should prime the next SyncIn
-  // downbeat even when the adapter's divider would otherwise drop it.
+  // downbeat to pass through (clearing waiting_for_external_downbeat_).
   tempo_handler.trigger_manual_sync();
   REQUIRE(recorder.events.empty());
 
@@ -76,6 +75,8 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
   clock_router.notification(physical_pulse);
 
   REQUIRE_FALSE(recorder.events.empty());
-  REQUIRE(recorder.events.front().is_resync == true);
+  // Manual sync primes the downbeat but doesn't mark as resync for external
+  // sync
+  REQUIRE(recorder.events.front().is_resync == false);
   REQUIRE(recorder.events.front().phase_12 == musin::timing::PHASE_DOWNBEAT);
 }

--- a/test/musin/timing/tempo_handler_external_sync_test.cpp
+++ b/test/musin/timing/tempo_handler_external_sync_test.cpp
@@ -80,3 +80,217 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
   REQUIRE(recorder.events.front().is_resync == false);
   REQUIRE(recorder.events.front().phase_12 == musin::timing::PHASE_DOWNBEAT);
 }
+
+TEST_CASE("TempoHandler speed change with pending downbeat waits then aligns") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_processor;
+  musin::timing::SyncIn sync_in_stub(0, 1);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
+
+  musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
+  TempoHandler tempo_handler(clock_router, speed_adapter,
+                             /*send_midi_clock_when_stopped*/ false,
+                             ClockSource::EXTERNAL_SYNC);
+
+  clock_router.add_observer(speed_adapter);
+
+  TempoEventRecorder recorder;
+  tempo_handler.add_observer(recorder);
+
+  tempo_handler.trigger_manual_sync();
+  REQUIRE(recorder.events.empty());
+
+  // Change speed to DOUBLE while waiting for downbeat
+  tempo_handler.set_speed_modifier(SpeedModifier::DOUBLE_SPEED);
+  REQUIRE(recorder.events.empty());
+
+  // Regular ticks (not downbeats) should be suppressed
+  ClockEvent regular_tick{ClockSource::EXTERNAL_SYNC};
+  regular_tick.is_beat = false;
+  clock_router.notification(regular_tick);
+  REQUIRE(recorder.events.empty());
+
+  // Downbeat arrives - should align to phase 0 for DOUBLE_SPEED
+  ClockEvent downbeat{ClockSource::EXTERNAL_SYNC};
+  downbeat.is_beat = true;
+  clock_router.notification(downbeat);
+
+  REQUIRE(recorder.events.size() == 1);
+  REQUIRE(recorder.events.front().phase_12 == 0);
+  REQUIRE(recorder.events.front().is_resync == false);
+}
+
+TEST_CASE("TempoHandler cable disconnect during pending sync switches source") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_processor;
+  musin::timing::SyncIn sync_in_stub(0, 1);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
+
+  musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
+  TempoHandler tempo_handler(clock_router, speed_adapter,
+                             /*send_midi_clock_when_stopped*/ false,
+                             ClockSource::EXTERNAL_SYNC);
+
+  clock_router.add_observer(speed_adapter);
+
+  TempoEventRecorder recorder;
+  tempo_handler.add_observer(recorder);
+
+  sync_in_stub.set_cable_connected(true);
+  tempo_handler.trigger_manual_sync();
+  REQUIRE(recorder.events.empty());
+
+  // Cable disconnect triggers auto source switching
+  sync_in_stub.set_cable_connected(false);
+  clock_router.update_auto_source_switching();
+
+  // Should switch to INTERNAL and reset phase
+  REQUIRE(tempo_handler.get_clock_source() == ClockSource::INTERNAL);
+
+  // Internal clock tick should now produce events (not suppressed)
+  ClockEvent internal_tick{ClockSource::INTERNAL};
+  clock_router.notification(internal_tick);
+
+  REQUIRE_FALSE(recorder.events.empty());
+}
+
+TEST_CASE(
+    "TempoHandler manual source switch with pending downbeat clears wait") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_processor;
+  musin::timing::SyncIn sync_in_stub(0, 1);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
+
+  musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
+  TempoHandler tempo_handler(clock_router, speed_adapter,
+                             /*send_midi_clock_when_stopped*/ false,
+                             ClockSource::EXTERNAL_SYNC);
+
+  clock_router.add_observer(speed_adapter);
+
+  TempoEventRecorder recorder;
+  tempo_handler.add_observer(recorder);
+
+  tempo_handler.trigger_manual_sync();
+  REQUIRE(recorder.events.empty());
+
+  // Switch to INTERNAL before external downbeat arrives
+  tempo_handler.set_clock_source(ClockSource::INTERNAL);
+
+  // Internal ticks should now work immediately
+  ClockEvent internal_tick{ClockSource::INTERNAL};
+  clock_router.notification(internal_tick);
+
+  REQUIRE_FALSE(recorder.events.empty());
+}
+
+TEST_CASE("TempoHandler multiple speed changes before downbeat uses final "
+          "modifier") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_processor;
+  musin::timing::SyncIn sync_in_stub(0, 1);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
+
+  musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
+  TempoHandler tempo_handler(clock_router, speed_adapter,
+                             /*send_midi_clock_when_stopped*/ false,
+                             ClockSource::EXTERNAL_SYNC);
+
+  clock_router.add_observer(speed_adapter);
+
+  TempoEventRecorder recorder;
+  tempo_handler.add_observer(recorder);
+
+  tempo_handler.trigger_manual_sync();
+
+  // Rapid speed changes: HALF → DOUBLE → NORMAL
+  tempo_handler.set_speed_modifier(SpeedModifier::HALF_SPEED);
+  tempo_handler.set_speed_modifier(SpeedModifier::DOUBLE_SPEED);
+  tempo_handler.set_speed_modifier(SpeedModifier::NORMAL_SPEED);
+
+  REQUIRE(recorder.events.empty());
+
+  // Advance phase to non-zero for NORMAL alignment test
+  ClockEvent non_downbeat{ClockSource::EXTERNAL_SYNC};
+  non_downbeat.is_beat = false;
+  for (int i = 0; i < 5; ++i) {
+    clock_router.notification(non_downbeat);
+  }
+
+  // Downbeat with NORMAL speed should align to quarter-note grid (0,3,6,9)
+  ClockEvent downbeat{ClockSource::EXTERNAL_SYNC};
+  downbeat.is_beat = true;
+  clock_router.notification(downbeat);
+
+  REQUIRE(recorder.events.size() == 1);
+  // Phase 5 should align to 6 for NORMAL speed
+  uint8_t aligned_phase = recorder.events.front().phase_12;
+  REQUIRE((aligned_phase == 0 || aligned_phase == 3 || aligned_phase == 6 ||
+           aligned_phase == 9));
+}
+
+TEST_CASE("TempoHandler speed change without pending downbeat realigns on next "
+          "beat") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_processor;
+  musin::timing::SyncIn sync_in_stub(0, 1);
+  musin::timing::ClockRouter clock_router(
+      internal_clock, midi_processor, sync_in_stub, ClockSource::EXTERNAL_SYNC);
+
+  musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
+  TempoHandler tempo_handler(clock_router, speed_adapter,
+                             /*send_midi_clock_when_stopped*/ false,
+                             ClockSource::EXTERNAL_SYNC);
+
+  clock_router.add_observer(speed_adapter);
+
+  TempoEventRecorder recorder;
+  tempo_handler.add_observer(recorder);
+
+  // Establish initial sync with first downbeat
+  tempo_handler.trigger_manual_sync();
+  ClockEvent first_downbeat{ClockSource::EXTERNAL_SYNC};
+  first_downbeat.is_beat = true;
+  clock_router.notification(first_downbeat);
+
+  REQUIRE(recorder.events.size() == 1);
+  REQUIRE(recorder.events.back().phase_12 == 0);
+  recorder.clear();
+
+  // Advance several ticks
+  ClockEvent regular_tick{ClockSource::EXTERNAL_SYNC};
+  regular_tick.is_beat = false;
+  for (int i = 0; i < 7; ++i) {
+    clock_router.notification(regular_tick);
+  }
+
+  REQUIRE(recorder.events.size() == 3);
+  REQUIRE(recorder.events.back().phase_12 == 3);
+  recorder.clear();
+
+  // Change speed to DOUBLE (should align to downbeat on next beat)
+  tempo_handler.set_speed_modifier(SpeedModifier::DOUBLE_SPEED);
+
+  // Next downbeat should re-align to phase 0
+  ClockEvent second_downbeat{ClockSource::EXTERNAL_SYNC};
+  second_downbeat.is_beat = true;
+  clock_router.notification(second_downbeat);
+
+  REQUIRE(recorder.events.size() == 1);
+  REQUIRE(recorder.events.front().phase_12 == 0);
+  REQUIRE(recorder.events.front().is_resync == false);
+}

--- a/test/musin/timing/tempo_handler_test.cpp
+++ b/test/musin/timing/tempo_handler_test.cpp
@@ -124,7 +124,7 @@ TEST_CASE("TempoHandler external sync passes through ticks (half-speed now "
   // Simulate 8 external physical pulses by feeding the router.
   for (int i = 0; i < 8; ++i) {
     ClockEvent e{ClockSource::EXTERNAL_SYNC};
-    e.is_downbeat = true;
+    e.is_beat = true;
     clock_router.notification(e);
   }
 
@@ -184,7 +184,7 @@ TEST_CASE("TempoHandler DOUBLE_SPEED with MIDI source forwards every tick") {
   // Send 3 MIDI clock ticks; DOUBLE_SPEED now forwards every tick
   for (int i = 0; i < 3; ++i) {
     ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = false;
+    e.is_beat = false;
     speed_adapter.notification(e);
   }
 
@@ -214,7 +214,7 @@ TEST_CASE("TempoHandler DOUBLE_SPEED maintains phase progression") {
   // Advance to an odd phase (phase 3)
   for (int i = 0; i < 6; ++i) {
     ClockEvent e{ClockSource::MIDI};
-    e.is_downbeat = false;
+    e.is_beat = false;
     speed_adapter.notification(e);
   }
   REQUIRE(rec.events.size() == 3);
@@ -226,7 +226,7 @@ TEST_CASE("TempoHandler DOUBLE_SPEED maintains phase progression") {
 
   // Send one more tick to see the aligned phase
   ClockEvent e{ClockSource::MIDI};
-  e.is_downbeat = false;
+  e.is_beat = false;
   speed_adapter.notification(e);
 
   REQUIRE(rec.events.size() >= 1);
@@ -350,7 +350,7 @@ TEST_CASE(
 
   // Send a MIDI tick to establish some history
   ClockEvent e{ClockSource::MIDI};
-  e.is_downbeat = false;
+  e.is_beat = false;
   speed_adapter_lb.notification(e);
   rec.clear();
 
@@ -385,7 +385,7 @@ TEST_CASE("TempoHandler manual sync with MIDI emits immediate resync") {
 
   // Send a MIDI tick to establish some history
   ClockEvent e{ClockSource::MIDI};
-  e.is_downbeat = false;
+  e.is_beat = false;
   speed_adapter_def.notification(e);
   rec.clear();
 

--- a/test/musin/timing/tempo_handler_test.cpp
+++ b/test/musin/timing/tempo_handler_test.cpp
@@ -128,8 +128,9 @@ TEST_CASE("TempoHandler external sync passes through ticks (half-speed now "
     clock_router.notification(e);
   }
 
-  // SpeedAdapter now handles HALF_SPEED, emitting every 4th tick (8→2)
-  REQUIRE(rec.events.size() == 2);
+  // All downbeat events pass through immediately (no speed division on
+  // downbeats)
+  REQUIRE(rec.events.size() == 8);
   // External physical pulses get phase alignment instead of sequential
   // advancement Since we start at phase 0, calculate_aligned_phase() returns 0
   REQUIRE(rec.events[0].phase_12 == 0);


### PR DESCRIPTION
Defer sequencer start until an EXTERNAL_SYNC pulse comes in to align the sequencer with external sync pulses. Also, defer applying SpeedAdapter modifiers until a pulse comes in.

This branch also adds different anchor phases for different SpeedModifiers so that HalfSpeed/DoubleSpeed mode aren't too restrictive/lax in pulling the Sequencer straight.

Fixes #520 
Fixes #523 