### PR TITLE
fix: make retrigger sync state-based to handle stop/restart

### DIFF
--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -291,25 +291,22 @@ void PizzaControls::DrumpadComponent::update() {
     drumpads[i].update(raw_value);
 
     musin::ui::RetriggerMode current_mode = drumpads[i].get_retrigger_mode();
-    if (current_mode != _last_known_retrigger_mode_per_pad[i]) {
-      if (current_mode == musin::ui::RetriggerMode::Single) {
-        controls->_sequencer_controller_ref.activate_play_on_every_step(
-            static_cast<uint8_t>(i), drum::RetriggerMode::Step);
-        controls->_sequencer_controller_ref.set_pad_pressed_state(
-            static_cast<uint8_t>(i), true);
-      } else if (current_mode == musin::ui::RetriggerMode::Double) {
-        controls->_sequencer_controller_ref.activate_play_on_every_step(
-            static_cast<uint8_t>(i), drum::RetriggerMode::Substeps);
-        controls->_sequencer_controller_ref.set_pad_pressed_state(
-            static_cast<uint8_t>(i), true);
-      } else {
-        controls->_sequencer_controller_ref.deactivate_play_on_every_step(
-            static_cast<uint8_t>(i));
-        controls->_sequencer_controller_ref.set_pad_pressed_state(
-            static_cast<uint8_t>(i), false);
-      }
+    if (current_mode == musin::ui::RetriggerMode::Single) {
+      controls->_sequencer_controller_ref.activate_play_on_every_step(
+          static_cast<uint8_t>(i), drum::RetriggerMode::Step);
+      controls->_sequencer_controller_ref.set_pad_pressed_state(
+          static_cast<uint8_t>(i), true);
+    } else if (current_mode == musin::ui::RetriggerMode::Double) {
+      controls->_sequencer_controller_ref.activate_play_on_every_step(
+          static_cast<uint8_t>(i), drum::RetriggerMode::Substeps);
+      controls->_sequencer_controller_ref.set_pad_pressed_state(
+          static_cast<uint8_t>(i), true);
+    } else {
+      controls->_sequencer_controller_ref.deactivate_play_on_every_step(
+          static_cast<uint8_t>(i));
+      controls->_sequencer_controller_ref.set_pad_pressed_state(
+          static_cast<uint8_t>(i), false);
     }
-    _last_known_retrigger_mode_per_pad[i] = current_mode;
   }
 }
 

--- a/drum/pizza_controls.h
+++ b/drum/pizza_controls.h
@@ -147,8 +147,6 @@ public:
     PizzaControls *parent_controls;
     std::array<musin::ui::Drumpad, config::NUM_DRUMPADS> drumpads;
     DrumpadEventHandler drumpad_observer;
-    etl::array<musin::ui::RetriggerMode, config::NUM_DRUMPADS>
-        _last_known_retrigger_mode_per_pad{};
   };
 
   class PlaybuttonComponent {


### PR DESCRIPTION
Removes transition-based edge detection in favor of always syncing sequencer retrigger state based on current drumpad pressure. This ensures retriggers re-activate when restarting while pads are held.

Fixes #519