### PR TITLE
Fix step skip on restart by deferring counter increment

### DIFF
--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -615,7 +615,6 @@ void PizzaControls::AnalogControlComponent::PressureButtonEventHandler::
       if (event.state == musin::ui::PressureState::LightPress &&
           event.previous_state == musin::ui::PressureState::Released) {
         controls->_sequencer_controller_ref.mark_step_due();
-        controls->_sequencer_controller_ref.increment_step_position();
         parent->repeat_stopped_mode_active_ = true;
       } else if (event.state == musin::ui::PressureState::Released) {
         parent->repeat_stopped_mode_active_ = false;

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -127,12 +127,6 @@ public:
   void mark_step_due();
 
   /**
-   * @brief Increment the step position counter.
-   * Advances scheduled_step_counter_ to move to the next step.
-   */
-  void increment_step_position();
-
-  /**
    * @brief Start the sequencer by connecting to the tempo source.
    * Does not reset the step index.
    */
@@ -287,7 +281,6 @@ private:
   musin::timing::Sequencer<NumTracks, NumSteps> random_sequencer_;
   std::reference_wrapper<musin::timing::Sequencer<NumTracks, NumSteps>>
       sequencer_;
-  std::atomic<uint32_t> current_step_counter;
   uint32_t scheduled_step_counter_;
   etl::array<std::optional<uint8_t>, NumTracks> last_played_note_per_track;
   etl::array<std::optional<size_t>, NumTracks> _just_played_step_per_track;

--- a/drum/sequencer_effect_random.cpp
+++ b/drum/sequencer_effect_random.cpp
@@ -16,9 +16,10 @@ SequencerEffectRandom::SequencerEffectRandom() {
 }
 
 SequencerEffectRandom::RandomizedStep
-SequencerEffectRandom::calculate_randomized_step(
-    size_t base_step_index, size_t track_idx, size_t num_steps,
-    bool repeat_active, [[maybe_unused]] uint64_t transport_step) const {
+SequencerEffectRandom::calculate_randomized_step(size_t base_step_index,
+                                                 size_t track_idx,
+                                                 size_t num_steps,
+                                                 bool repeat_active) const {
   RandomizedStep result{base_step_index, false};
 
   if (track_idx >= MAX_TRACKS || num_steps == 0) {

--- a/drum/sequencer_effect_random.h
+++ b/drum/sequencer_effect_random.h
@@ -27,8 +27,7 @@ public:
 
   RandomizedStep calculate_randomized_step(size_t base_step_index,
                                            size_t track_idx, size_t num_steps,
-                                           bool repeat_active,
-                                           uint64_t transport_step) const;
+                                           bool repeat_active) const;
 
   void set_random_intensity(float intensity);
 


### PR DESCRIPTION
## Summary
Fixes #526 - Resolves the issue where the first odd step is skipped after a manual resync/restart.

## Changes
- **Separated timing detection from state mutation**: `notification()` (ISR) now only sets the `_step_is_due` flag without incrementing the counter
- **Refactored `update()` flow**: Captures the step index at the start, processes all tracks, then increments `scheduled_step_counter_` at the end
- **Eliminated `current_step_counter`**: Removed redundant atomic counter, `get_current_step()` now reads directly from `scheduled_step_counter_`
- **Removed `increment_step_position()`**: Obsolete method deleted, including its call site in stopped repeat jog logic
- **Cleaned up random effect signature**: Removed unused `transport_step` parameter from `calculate_randomized_step()`

## Root Cause
The bug occurred because `notification()` incremented the counter when marking a step due, then `update()` would process using that already-incremented value, causing the first step to be skipped.

## Test Plan
- [x] Build successful
- [ ] Manual testing: Restart on steps 0, 2, 4, 6 with internal clock
- [ ] Verify swing timing still works correctly
- [ ] Test repeat mode activation during restart
- [ ] Test stopped repeat jog behavior
- [ ] Test random offset/probability modes

## Files Changed
- `drum/sequencer_controller.h` - Removed `current_step_counter` member and `increment_step_position()` declaration
- `drum/sequencer_controller.cpp` - Refactored `notification()` and `update()` methods
- `drum/sequencer_effect_random.h/cpp` - Removed unused parameter
- `drum/pizza_controls.cpp` - Removed manual counter increment call