### PR TITLE
feat: replace DAC volume mute with hardware mute control

### DIFF
--- a/musin/audio/audio_output.cpp
+++ b/musin/audio/audio_output.cpp
@@ -147,19 +147,20 @@ bool AudioOutput::volume(float volume) {
   }
 
   // --- DAC Volume (Output Stage) ---
-  // Map curved volume [0, 1024] to DAC register value [-127, 0]
-  int8_t dac_register_value;
-  // If volume is below 3% (31/1024), mute it to prevent noise at the lowest
-  // levels.
+  // If volume is below 3% (31/1024), use hardware mute to prevent noise.
+  bool dac_ok;
   if (curved_volume < 31) {
-    dac_register_value = -127;
+    dac_ok = codec->set_dac_muted(true) == musin::drivers::Aic3204Status::OK;
   } else {
-    // Maps [31, 1024] to DAC range [-63, 0]
-    int32_t mapped_dac_value = ((curved_volume - 31) * 63) / (1024 - 31);
-    dac_register_value = static_cast<int8_t>(mapped_dac_value - 63);
+    // Unmute and set volume: Maps [31, 1024] to DAC range [-63, 0]
+    dac_ok = codec->set_dac_muted(false) == musin::drivers::Aic3204Status::OK;
+    if (dac_ok) {
+      int32_t mapped_dac_value = ((curved_volume - 31) * 63) / (1024 - 31);
+      int8_t dac_register_value = static_cast<int8_t>(mapped_dac_value - 63);
+      dac_ok = codec->set_dac_volume(dac_register_value) ==
+               musin::drivers::Aic3204Status::OK;
+    }
   }
-  bool dac_ok = codec->set_dac_volume(dac_register_value) ==
-                musin::drivers::Aic3204Status::OK;
 
   // --- Mixer Volume (Input Stage) ---
   // Map curved volume [0, 1024] to Mixer register value [-40, 0]

--- a/musin/drivers/aic3204.hpp
+++ b/musin/drivers/aic3204.hpp
@@ -72,6 +72,7 @@ public:
   Aic3204Status set_headphone_enabled(bool enable);
   Aic3204Status set_dac_volume(int8_t volume);
   Aic3204Status set_mixer_volume(int8_t volume);
+  Aic3204Status set_dac_muted(bool muted);
   std::optional<bool> is_headphone_inserted();
   bool update_headphone_detection();
   Aic3204Status enter_sleep_mode();
@@ -101,6 +102,7 @@ private:
   uint8_t _current_page = 0xFF;
   int8_t _current_dac_volume = 0;
   int8_t _current_mixer_volume = 0;
+  bool _dac_muted = true;
   bool _headphone_inserted_state = false;
 };
 


### PR DESCRIPTION
Replace -127 pseudo-mute with proper DAC mute bits (register 0x40). Provides 119-122 dB attenuation vs ~63 dB with volume control.