### PR TITLE
feat: implement polling-based headphone detection with software debounce

### DIFF
--- a/musin/audio/audio_output.cpp
+++ b/musin/audio/audio_output.cpp
@@ -33,7 +33,8 @@ absolute_time_t last_poll_time = nil_time; // Last time we polled the codec
 
 // Listener and policy
 AudioOutput::HeadphoneListener headphone_listener = nullptr;
-bool auto_speaker_mute_enabled = false;
+// Enabled by default to match the previous codec-managed behaviour
+bool auto_speaker_mute_enabled = true;
 
 } // namespace
 #endif

--- a/musin/audio/audio_output.h
+++ b/musin/audio/audio_output.h
@@ -2,6 +2,7 @@
 #define AUDIO_OUTPUT_H_5M07E3OB
 
 #include "buffer_source.h"
+#include <optional>
 
 namespace musin::drivers {
 class Aic3204;
@@ -9,6 +10,9 @@ class Aic3204;
 
 namespace AudioOutput {
 static const int SAMPLE_FREQUENCY = 44100;
+
+// Headphone detection listener callback type
+using HeadphoneListener = void (*)(bool inserted);
 
 /**
  * @brief Initializes the audio output system (I2S and Codec).
@@ -80,6 +84,41 @@ bool route_line_in_to_headphone(bool enable);
  * @brief Deinitializes the audio output system.
  */
 void deinit();
+
+/**
+ * @brief Returns the cached debounced headphone insertion state.
+ *
+ * @return std::optional<bool> containing true if headphones are inserted,
+ *         false if removed, or std::nullopt if state is unknown.
+ */
+std::optional<bool> headphones_inserted();
+
+/**
+ * @brief Registers a listener callback to be notified of headphone state
+ * changes.
+ *
+ * The callback is invoked from the update() context when the debounced state
+ * changes. Only one listener can be registered at a time.
+ *
+ * @param listener The callback function to invoke on state changes.
+ */
+void set_headphone_listener(HeadphoneListener listener);
+
+/**
+ * @brief Clears the registered headphone listener callback.
+ */
+void clear_headphone_listener();
+
+/**
+ * @brief Enables or disables automatic speaker muting when headphones are
+ * inserted.
+ *
+ * When enabled, the external amp is automatically disabled when headphones are
+ * detected and re-enabled when removed.
+ *
+ * @param enable true to enable auto-mute, false to disable.
+ */
+void enable_auto_speaker_mute(bool enable);
 
 } // namespace AudioOutput
 

--- a/musin/drivers/aic3204.cpp
+++ b/musin/drivers/aic3204.cpp
@@ -123,6 +123,9 @@ Aic3204::Aic3204(uint8_t sda_pin, uint8_t scl_pin, uint32_t baudrate,
   if (write_register(0x00, 0x19, 0x00) != Aic3204Status::OK) {
     return; // BCLK/WCLK inputs
   }
+  if (write_register(0x00, 0x38, 0x04) != Aic3204Status::OK) {
+    return; // Enable MFP3 as GPIO input
+  }
 
   // DAC Processing Block (Page 0)
   if (write_register(0x00, 0x3C, 0x08) != Aic3204Status::OK) {

--- a/musin/drivers/aic3204.cpp
+++ b/musin/drivers/aic3204.cpp
@@ -129,11 +129,6 @@ Aic3204::Aic3204(uint8_t sda_pin, uint8_t scl_pin, uint32_t baudrate,
     return; // DAC PRB_P8
   }
 
-  // Configure headphone jack detection
-  if (write_register(0x00, 0x43, 0x93) != Aic3204Status::OK) {
-    return; // HP detect Enable + 256ms debounce
-  }
-
   if (select_page(1) != Aic3204Status::OK) {
     return;
   }
@@ -500,35 +495,24 @@ std::optional<bool> Aic3204::is_headphone_inserted() {
     return std::nullopt;
   }
 
+  // Read MFP3 pin state directly from GPIO control register
+  // Page 0, Reg 0x36: MFP3 Pin Control/Status
+  // Bit 0 contains the pin level when configured as input
   const uint8_t PAGE = 0;
-  const uint8_t STATUS_REG = 0x2E; // Register 46
-  const uint8_t INSERTION_MASK = (1 << 4);
+  const uint8_t MFP3_REG = 0x36;
+  const uint8_t PIN_LEVEL_MASK = (1 << 0);
 
   uint8_t reg_val = 0;
-  Aic3204Status status = read_register(PAGE, STATUS_REG, reg_val);
+  Aic3204Status status = read_register(PAGE, MFP3_REG, reg_val);
   if (status != Aic3204Status::OK) {
-    AIC_LOG("AIC3204 Error: Failed to read headphone jack status.");
+    AIC_LOG("AIC3204 Error: Failed to read MFP3 pin state.");
     return std::nullopt;
   }
 
-  return (reg_val & INSERTION_MASK) != 0;
-}
-
-bool Aic3204::update_headphone_detection() {
-  if (auto inserted_opt = is_headphone_inserted()) {
-    // We successfully read the status
-    bool is_inserted = inserted_opt.value();
-    if (is_inserted != _headphone_inserted_state) {
-      AIC_LOG("Toggling headphone detect state");
-      _headphone_inserted_state = is_inserted;
-      return set_amp_enabled(_headphone_inserted_state == false) ==
-             Aic3204Status::OK;
-    }
-    return true;
-  } else {
-    // Failed to read status, return an error
-    return false;
-  }
+  // MFP3 pin is typically pulled HIGH by default and goes LOW when headphones
+  // are inserted (jack switch grounds the pin). Invert the logic.
+  bool pin_low = (reg_val & PIN_LEVEL_MASK) == 0;
+  return pin_low; // true = headphones inserted (pin LOW)
 }
 
 Aic3204Status Aic3204::enter_sleep_mode() {

--- a/musin/drivers/aic3204.cpp
+++ b/musin/drivers/aic3204.cpp
@@ -123,8 +123,8 @@ Aic3204::Aic3204(uint8_t sda_pin, uint8_t scl_pin, uint32_t baudrate,
   if (write_register(0x00, 0x19, 0x00) != Aic3204Status::OK) {
     return; // BCLK/WCLK inputs
   }
-  if (write_register(0x00, 0x38, 0x04) != Aic3204Status::OK) {
-    return; // Enable MFP3 as GPIO input
+  if (write_register(0x00, 0x38, 0x02) != Aic3204Status::OK) {
+    return; // SCLK/MFP3 as general-purpose input (jack detect)
   }
 
   // DAC Processing Block (Page 0)
@@ -149,6 +149,11 @@ Aic3204::Aic3204(uint8_t sda_pin, uint8_t scl_pin, uint32_t baudrate,
 
   if (write_register(0x01, 0x0A, 0x33) != Aic3204Status::OK) {
     return; // HP CM=1.65V, Lineout CM=0.9V, LDO=1.72V
+  }
+
+  // MICBIAS provides the pull-up for the jack detect switch on MFP3
+  if (write_register(0x01, 0x33, 0x40) != Aic3204Status::OK) {
+    return; // MICBIAS powered up, 1.25V
   }
 
   // DAC/ADC PTM modes (Page 1)
@@ -498,11 +503,10 @@ std::optional<bool> Aic3204::is_headphone_inserted() {
     return std::nullopt;
   }
 
-  // Read MFP3 pin state directly from GPIO control register
-  // Page 0, Reg 0x36: MFP3 Pin Control/Status
-  // Bit 0 contains the pin level when configured as input
+  // Page 0, Reg 0x38: SCLK/MFP3 control. Bit 0 reflects the pin level when
+  // configured as a general-purpose input.
   const uint8_t PAGE = 0;
-  const uint8_t MFP3_REG = 0x36;
+  const uint8_t MFP3_REG = 0x38;
   const uint8_t PIN_LEVEL_MASK = (1 << 0);
 
   uint8_t reg_val = 0;
@@ -512,10 +516,10 @@ std::optional<bool> Aic3204::is_headphone_inserted() {
     return std::nullopt;
   }
 
-  // MFP3 pin is typically pulled HIGH by default and goes LOW when headphones
-  // are inserted (jack switch grounds the pin). Invert the logic.
+  // Active low: pulled up to VMICBIAS when empty, grounded by the jack
+  // switch when a headphone is inserted.
   bool pin_low = (reg_val & PIN_LEVEL_MASK) == 0;
-  return pin_low; // true = headphones inserted (pin LOW)
+  return pin_low;
 }
 
 Aic3204Status Aic3204::enter_sleep_mode() {

--- a/musin/drivers/aic3204.cpp
+++ b/musin/drivers/aic3204.cpp
@@ -151,9 +151,11 @@ Aic3204::Aic3204(uint8_t sda_pin, uint8_t scl_pin, uint32_t baudrate,
     return; // HP CM=1.65V, Lineout CM=0.9V, LDO=1.72V
   }
 
-  // MICBIAS provides the pull-up for the jack detect switch on MFP3
-  if (write_register(0x01, 0x33, 0x40) != Aic3204Status::OK) {
-    return; // MICBIAS powered up, 1.25V
+  // MICBIAS provides the pull-up for the jack detect switch on MFP3.
+  // 2.5V so the released pin clears MFP3's input high threshold
+  // (0.7 x IOVDD = 2.31V at 3.3V).
+  if (write_register(0x01, 0x33, 0x60) != Aic3204Status::OK) {
+    return; // MICBIAS powered up, 2.5V
   }
 
   // DAC/ADC PTM modes (Page 1)

--- a/musin/drivers/aic3204.cpp
+++ b/musin/drivers/aic3204.cpp
@@ -152,10 +152,11 @@ Aic3204::Aic3204(uint8_t sda_pin, uint8_t scl_pin, uint32_t baudrate,
   }
 
   // MICBIAS provides the pull-up for the jack detect switch on MFP3.
-  // 2.5V so the released pin clears MFP3's input high threshold
-  // (0.7 x IOVDD = 2.31V at 3.3V).
-  if (write_register(0x01, 0x33, 0x60) != Aic3204Status::OK) {
-    return; // MICBIAS powered up, 2.5V
+  // Source from LDOIN (3.3V) so the released pin clears MFP3's input
+  // high threshold (0.7 x IOVDD = 2.31V); AVDD-derived settings top out
+  // below it.
+  if (write_register(0x01, 0x33, 0x78) != Aic3204Status::OK) {
+    return; // MICBIAS powered up, MICBIAS = LDOIN
   }
 
   // DAC/ADC PTM modes (Page 1)

--- a/musin/drivers/aic3204.hpp
+++ b/musin/drivers/aic3204.hpp
@@ -74,7 +74,6 @@ public:
   Aic3204Status set_mixer_volume(int8_t volume);
   Aic3204Status set_dac_muted(bool muted);
   std::optional<bool> is_headphone_inserted();
-  bool update_headphone_detection();
   Aic3204Status enter_sleep_mode();
 
 private:
@@ -103,7 +102,6 @@ private:
   int8_t _current_dac_volume = 0;
   int8_t _current_mixer_volume = 0;
   bool _dac_muted = true;
-  bool _headphone_inserted_state = false;
 };
 
 } // namespace musin::drivers


### PR DESCRIPTION
## Summary

Replaces hardware auto-detect with direct MFP3 pin reading and time-based software debouncing for headphone jack detection. This provides better control over detection behavior and centralizes policy logic in the AudioOutput HAL layer.

### Driver Layer Changes (Aic3204)
- Read MFP3 pin state directly from GPIO control register (Page 0, Reg 0x36) instead of hardware auto-detect result register
- Remove hardware auto-detect initialization from init() (Page 0, Reg 0x43 setup)
- Remove `update_headphone_detection()` method that embedded policy logic in the driver
- Remove `_headphone_inserted_state` member variable

### HAL Layer Changes (AudioOutput)
- Implement time-based software debouncing (20ms poll interval, 75ms debounce duration)
- Add debounce state machine with SDK time functions (`get_absolute_time()`, `absolute_time_diff_us()`)
- Cache debounced state and notify listeners only on confirmed state changes
- Add new public API:
  - `headphones_inserted()` - Returns cached debounced state
  - `set_headphone_listener()` - Register callback for state changes
  - `clear_headphone_listener()` - Clear callback
  - `enable_auto_speaker_mute()` - Toggle automatic amp control policy

### Architecture Benefits
- Clean separation: driver provides semantic read API, HAL orchestrates polling and policy
- Codec-agnostic: application layer accesses headphone state through AudioOutput
- Configurable: poll interval and debounce duration via build-time constants
- Testable: policy and debouncing logic isolated from hardware I/O

## Test Plan
- [ ] Verify headphone insertion/removal detected on hardware within ~75-95ms
- [ ] Confirm no false triggers from contact bounce
- [ ] Test auto-mute policy correctly toggles external amp
- [ ] Verify listener callbacks invoked on debounced state changes only
- [ ] Check no audible artifacts during amp toggling