### PR TITLE
Fix #508: Prevent audio blip during flash save

### DIFF
--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(${EXECUTABLE_NAME}
   sequencer_effect_swing.cpp
   sequencer_effect_random.cpp
   save_timing_manager.cpp
+  flash_access_coordinator.cpp
   configuration_manager.cpp
   message_router.cpp
   audio_engine.cpp

--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(${EXECUTABLE_NAME}
   state_implementations.cpp
   usb_descriptors.c
   ../musin/midi/midi_sender.cpp
+  flash_safety_override.c
 )
 
 target_compile_features(${EXECUTABLE_NAME} PRIVATE cxx_std_20)

--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -1,6 +1,7 @@
 #include "audio_engine.h"
 
 #include "config.h"
+#include "flash_access_coordinator.h"
 #include "musin/audio/audio_output.h"
 #include "musin/hal/debug_utils.h"
 #include "sample_repository.h"
@@ -49,12 +50,13 @@ AudioEngine::Voice::Voice()
 }
 
 AudioEngine::AudioEngine(const SampleRepository &repository,
-                         musin::Logger &logger)
+                         musin::Logger &logger,
+                         FlashAccessCoordinator &flash_coordinator)
     : sample_repository_(repository), logger_(logger),
       voice_sources_{&voices_[0].sound, &voices_[1].sound, &voices_[2].sound,
                      &voices_[3].sound},
       mixer_(voice_sources_), crusher_(mixer_), lowpass_(crusher_),
-      highpass_(lowpass_) {
+      highpass_(lowpass_), flash_coordinator_(flash_coordinator) {
   // Initialize to a known, silent state.
   set_volume(1.0f); // Set master volume to full.
 
@@ -204,6 +206,22 @@ void AudioEngine::notification(drum::Events::NoteEvent event) {
   // Direct mapping: MIDI note = sample slot
   size_t sample_id = event.note;
   play_on_voice(event.track_index, sample_id, event.velocity);
+}
+
+void AudioEngine::prepare_for_flash_write() {
+  // Pre-fill all active voice buffers for flash blackout survival
+  for (auto &voice : voices_) {
+    if (voice.reader.has_value()) {
+      voice.reader->pre_fill_for_flash_write();
+    }
+  }
+  preparing_for_flash_write_ = false; // Buffers are now filled
+}
+
+bool AudioEngine::flash_write_buffers_ready() const {
+  // Buffers are ready immediately after prepare_for_flash_write() completes,
+  // as it synchronously pre-fills all buffers with ~116ms of audio.
+  return !preparing_for_flash_write_;
 }
 
 } // namespace drum

--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -122,14 +122,23 @@ void AudioEngine::play_on_voice(uint8_t voice_index, size_t sample_index,
     return;
   }
 
+  // Gate flash reads through the coordinator to prevent conflicts with writes
+  if (!flash_coordinator_.request_read()) {
+    // Flash write in progress — drop this note to avoid flash conflict
+    return;
+  }
+
   // Load the sample from the file path.
   if (!voice.reader->load(*path_opt)) {
     // Failed to load the file (e.g., file not found, corrupted).
+    flash_coordinator_.read_complete();
     logger_.error("Failed to load sample from");
     logger_.error(*path_opt);
     // The reader is now in a safe state (SourceType::NONE).
     return;
   }
+
+  flash_coordinator_.read_complete();
 
   const float normalized_velocity = static_cast<float>(velocity) / 127.0f;
   const float gain = map_value_linear(normalized_velocity, 0.0f, 1.0f);
@@ -209,19 +218,18 @@ void AudioEngine::notification(drum::Events::NoteEvent event) {
 }
 
 void AudioEngine::prepare_for_flash_write() {
-  // Pre-fill all active voice buffers for flash blackout survival
+  // Pre-fill all active voice buffers for flash blackout survival.
+  // This is synchronous — buffers are ready when this returns.
   for (auto &voice : voices_) {
     if (voice.reader.has_value()) {
       voice.reader->pre_fill_for_flash_write();
     }
   }
-  preparing_for_flash_write_ = false; // Buffers are now filled
 }
 
 bool AudioEngine::flash_write_buffers_ready() const {
-  // Buffers are ready immediately after prepare_for_flash_write() completes,
-  // as it synchronously pre-fills all buffers with ~116ms of audio.
-  return !preparing_for_flash_write_;
+  // Always ready — prepare_for_flash_write() fills buffers synchronously.
+  return true;
 }
 
 } // namespace drum

--- a/drum/audio_engine.h
+++ b/drum/audio_engine.h
@@ -18,7 +18,8 @@
 
 namespace drum {
 
-class SampleRepository; // Forward declaration
+class FlashAccessCoordinator; // Forward declaration
+class SampleRepository;       // Forward declaration
 
 constexpr size_t NUM_VOICES = 4;
 
@@ -41,7 +42,8 @@ private:
 
 public:
   explicit AudioEngine(const SampleRepository &repository,
-                       musin::Logger &logger);
+                       musin::Logger &logger,
+                       FlashAccessCoordinator &flash_coordinator);
   ~AudioEngine() = default;
 
   // Delete copy and move operations
@@ -141,6 +143,18 @@ public:
    */
   void notification(drum::Events::NoteEvent event) override;
 
+  /**
+   * @brief Prepare for an upcoming flash write operation.
+   * Signals to fill audio buffers in preparation for flash blackout.
+   */
+  void prepare_for_flash_write();
+
+  /**
+   * @brief Check if audio buffers are sufficiently filled for flash write.
+   * @return true if buffers are ready, false if still filling.
+   */
+  bool flash_write_buffers_ready() const;
+
 private:
   const SampleRepository &sample_repository_;
   musin::Logger &logger_;
@@ -159,8 +173,10 @@ private:
     PLAY_ON_VOICE_UPDATE
   };
 
+  FlashAccessCoordinator &flash_coordinator_;
   bool is_initialized_ = false;
   bool muted_ = false;
+  bool preparing_for_flash_write_ = false;
   float current_volume_ = 1.0f;
 };
 

--- a/drum/audio_engine.h
+++ b/drum/audio_engine.h
@@ -176,7 +176,6 @@ private:
   FlashAccessCoordinator &flash_coordinator_;
   bool is_initialized_ = false;
   bool muted_ = false;
-  bool preparing_for_flash_write_ = false;
   float current_volume_ = 1.0f;
 };
 

--- a/drum/flash_access_coordinator.cpp
+++ b/drum/flash_access_coordinator.cpp
@@ -1,0 +1,166 @@
+#include "flash_access_coordinator.h"
+
+namespace drum {
+
+bool FlashAccessCoordinator::request_read() {
+  switch (state_) {
+  case FlashAccessState::Idle:
+  case FlashAccessState::Reading:
+    // Can start reading immediately
+    active_reads_++;
+    state_ = FlashAccessState::Reading;
+    return true;
+
+  case FlashAccessState::PendingWrite:
+    // Read already in progress, allow additional read
+    active_reads_++;
+    return true;
+
+  case FlashAccessState::PreparingWrite:
+  case FlashAccessState::Writing:
+    // Cannot read during write preparation or active write
+    pending_reads_++;
+    if (state_ == FlashAccessState::Writing) {
+      state_ = FlashAccessState::PendingRead;
+    }
+    return false;
+
+  case FlashAccessState::PendingRead:
+    // Already have pending reads, add to queue
+    pending_reads_++;
+    return false;
+  }
+
+  return false;
+}
+
+void FlashAccessCoordinator::read_complete() {
+  if (active_reads_ > 0) {
+    active_reads_--;
+  }
+
+  if (active_reads_ == 0) {
+    switch (state_) {
+    case FlashAccessState::Reading:
+      state_ = FlashAccessState::Idle;
+      break;
+
+    case FlashAccessState::PendingWrite:
+      // All reads done, can now prepare for write
+      state_ = FlashAccessState::PreparingWrite;
+      break;
+
+    default:
+      // Unexpected state, but safe to ignore
+      break;
+    }
+  }
+}
+
+bool FlashAccessCoordinator::request_write() {
+  switch (state_) {
+  case FlashAccessState::Idle:
+    // Can start write preparation immediately
+    state_ = FlashAccessState::PreparingWrite;
+    return true;
+
+  case FlashAccessState::Reading:
+    // Must wait for reads to complete
+    state_ = FlashAccessState::PendingWrite;
+    return false;
+
+  case FlashAccessState::PendingWrite:
+  case FlashAccessState::PreparingWrite:
+  case FlashAccessState::Writing:
+  case FlashAccessState::PendingRead:
+    // Write already pending or in progress
+    return false;
+  }
+
+  return false;
+}
+
+void FlashAccessCoordinator::buffers_ready() {
+  if (state_ == FlashAccessState::PreparingWrite) {
+    state_ = FlashAccessState::Writing;
+  }
+}
+
+void FlashAccessCoordinator::write_complete() {
+  switch (state_) {
+  case FlashAccessState::Writing:
+    state_ = FlashAccessState::Idle;
+    break;
+
+  case FlashAccessState::PendingRead:
+    // Process pending reads
+    if (pending_reads_ > 0) {
+      active_reads_ = pending_reads_;
+      pending_reads_ = 0;
+      state_ = FlashAccessState::Reading;
+    } else {
+      state_ = FlashAccessState::Idle;
+    }
+    break;
+
+  default:
+    // Unexpected state
+    state_ = FlashAccessState::Idle;
+    break;
+  }
+}
+
+void FlashAccessCoordinator::cancel_write() {
+  switch (state_) {
+  case FlashAccessState::PendingWrite:
+    // Return to reading state if reads are active
+    if (active_reads_ > 0) {
+      state_ = FlashAccessState::Reading;
+    } else {
+      state_ = FlashAccessState::Idle;
+    }
+    break;
+
+  case FlashAccessState::PreparingWrite:
+    state_ = FlashAccessState::Idle;
+    break;
+
+  default:
+    // Cannot cancel once writing has started
+    break;
+  }
+}
+
+bool FlashAccessCoordinator::can_read() const {
+  switch (state_) {
+  case FlashAccessState::Idle:
+  case FlashAccessState::Reading:
+  case FlashAccessState::PendingWrite:
+    return true;
+
+  case FlashAccessState::PreparingWrite:
+  case FlashAccessState::Writing:
+  case FlashAccessState::PendingRead:
+    return false;
+  }
+
+  return false;
+}
+
+bool FlashAccessCoordinator::is_write_pending() const {
+  switch (state_) {
+  case FlashAccessState::PendingWrite:
+  case FlashAccessState::PreparingWrite:
+  case FlashAccessState::Writing:
+  case FlashAccessState::PendingRead:
+    return true;
+
+  case FlashAccessState::Idle:
+  case FlashAccessState::Reading:
+    return false;
+  }
+
+  return false;
+}
+
+} // namespace drum

--- a/drum/flash_access_coordinator.h
+++ b/drum/flash_access_coordinator.h
@@ -71,7 +71,9 @@ public:
   /**
    * @brief Get the current coordinator state.
    */
-  FlashAccessState get_state() const { return state_; }
+  FlashAccessState get_state() const {
+    return state_;
+  }
 
   /**
    * @brief Check if a flash read can start now.
@@ -86,12 +88,16 @@ public:
   /**
    * @brief Check if there are queued read requests.
    */
-  bool has_pending_reads() const { return pending_reads_ > 0; }
+  bool has_pending_reads() const {
+    return pending_reads_ > 0;
+  }
 
   /**
    * @brief Get count of active/pending read operations.
    */
-  uint8_t active_read_count() const { return active_reads_; }
+  uint8_t active_read_count() const {
+    return active_reads_;
+  }
 
 private:
   FlashAccessState state_ = FlashAccessState::Idle;

--- a/drum/flash_access_coordinator.h
+++ b/drum/flash_access_coordinator.h
@@ -1,0 +1,104 @@
+#ifndef DRUM_FLASH_ACCESS_COORDINATOR_H
+#define DRUM_FLASH_ACCESS_COORDINATOR_H
+
+#include <cstdint>
+
+namespace drum {
+
+/**
+ * @brief State of the flash access coordinator.
+ *
+ * Provides mutual exclusion between flash reads (sample loading) and
+ * flash writes (sequencer state persistence).
+ */
+enum class FlashAccessState : uint8_t {
+  Idle,           ///< No flash operations in progress
+  Reading,        ///< Sample load in progress
+  PendingWrite,   ///< Write requested, waiting for read to complete
+  PreparingWrite, ///< Pre-buffering audio before write
+  Writing,        ///< Flash write in progress
+  PendingRead     ///< Read requested, waiting for write to complete
+};
+
+/**
+ * @brief Coordinates flash read/write operations to prevent conflicts.
+ *
+ * Flash operations are mutually exclusive - you cannot read while erasing
+ * or programming. This coordinator ensures:
+ * 1. Sample loads don't start during flash writes
+ * 2. Flash writes don't start during sample loads
+ * 3. Audio buffers are pre-filled before writes begin
+ */
+class FlashAccessCoordinator {
+public:
+  FlashAccessCoordinator() = default;
+
+  /**
+   * @brief Request to begin a flash read operation (sample loading).
+   * @return true if read can start immediately, false if queued (write in
+   * progress)
+   */
+  bool request_read();
+
+  /**
+   * @brief Signal that a flash read operation has completed.
+   */
+  void read_complete();
+
+  /**
+   * @brief Request to begin a flash write operation (state save).
+   * @return true if write preparation can start, false if waiting for reads
+   */
+  bool request_write();
+
+  /**
+   * @brief Signal that audio buffers are filled and write can proceed.
+   * Call this after pre-buffering audio to survive the flash blackout.
+   */
+  void buffers_ready();
+
+  /**
+   * @brief Signal that a flash write operation has completed.
+   */
+  void write_complete();
+
+  /**
+   * @brief Cancel a pending write request.
+   * Use when write is no longer needed (e.g., state became clean).
+   */
+  void cancel_write();
+
+  /**
+   * @brief Get the current coordinator state.
+   */
+  FlashAccessState get_state() const { return state_; }
+
+  /**
+   * @brief Check if a flash read can start now.
+   */
+  bool can_read() const;
+
+  /**
+   * @brief Check if a flash write is pending or in progress.
+   */
+  bool is_write_pending() const;
+
+  /**
+   * @brief Check if there are queued read requests.
+   */
+  bool has_pending_reads() const { return pending_reads_ > 0; }
+
+  /**
+   * @brief Get count of active/pending read operations.
+   */
+  uint8_t active_read_count() const { return active_reads_; }
+
+private:
+  FlashAccessState state_ = FlashAccessState::Idle;
+  uint8_t active_reads_ = 0;  ///< Count of concurrent read operations
+  uint8_t pending_reads_ = 0; ///< Count of reads queued during write
+};
+
+} // namespace drum
+
+#endif // DRUM_FLASH_ACCESS_COORDINATOR_H

--- a/drum/flash_safety_override.c
+++ b/drum/flash_safety_override.c
@@ -1,0 +1,102 @@
+/**
+ * @file flash_safety_override.c
+ * @brief Custom flash safety helper that keeps the audio DMA IRQ enabled
+ *        during flash erase/program operations.
+ *
+ * The default pico_flash safety helper disables ALL interrupts (via PRIMASK)
+ * during flash operations. This causes audio underruns because the DMA ISR
+ * cannot service audio buffers during the ~50ms sector erase window.
+ *
+ * This override uses NVIC-level interrupt masking instead of PRIMASK, which
+ * allows selectively keeping the audio DMA IRQ enabled while disabling all
+ * other interrupts. This is safe because:
+ *   - The audio DMA ISR and its call chain run from RAM
+ *   - The ISR only reads from pre-filled RAM buffers (producer pool)
+ *   - All other interrupts remain disabled for safety
+ *
+ * PRECONDITIONS:
+ *   - audio_i2s_dma_irq_handler must be __time_critical_func (RAM-resident)
+ *   - Audio buffer pool functions called from the ISR must be in RAM
+ *   - The FlashAccessCoordinator must have pre-buffered audio data before
+ *     any flash write is initiated
+ */
+
+#include "hardware/irq.h"
+#include "hardware/structs/nvic.h"
+#include "pico/audio_i2s.h"
+#include "pico/flash.h"
+
+/* RP2350 has 52 IRQs, requiring 2 NVIC ISER/ICER registers (0-31, 32-51) */
+#define NVIC_REG_COUNT 2
+
+/* Saved NVIC interrupt-enable state for restore after flash operation */
+static uint32_t saved_nvic_iser[NVIC_REG_COUNT];
+
+static bool __not_in_flash_func(selective_init_deinit)(bool init) {
+  (void)init;
+  return true;
+}
+
+/**
+ * Enter the flash-safe zone by disabling all NVIC interrupts except the
+ * audio DMA IRQ. Uses direct NVIC register writes (not irq_set_enabled)
+ * because irq_set_enabled itself may reside in flash.
+ */
+static int __not_in_flash_func(selective_enter_safe_zone)(uint32_t timeout_ms) {
+  (void)timeout_ms;
+
+  /* The audio DMA IRQ number: DMA_IRQ_0 + PICO_AUDIO_I2S_DMA_IRQ
+   * On RP2350: DMA_IRQ_0 = 10, PICO_AUDIO_I2S_DMA_IRQ is typically 0
+   * So audio_irq = 10, which is in NVIC register 0 (bit 10) */
+  const uint audio_irq = DMA_IRQ_0 + PICO_AUDIO_I2S_DMA_IRQ;
+  const uint audio_irq_reg = audio_irq / 32;
+  const uint32_t audio_irq_bit = 1u << (audio_irq % 32);
+
+  /* 1. Save current NVIC enable state */
+  for (int i = 0; i < NVIC_REG_COUNT; i++) {
+    saved_nvic_iser[i] = nvic_hw->iser[i];
+  }
+
+  /* 2. Disable ALL interrupts at NVIC level */
+  for (int i = 0; i < NVIC_REG_COUNT; i++) {
+    nvic_hw->icer[i] = 0xFFFFFFFF;
+  }
+
+  /* 3. Re-enable ONLY the audio DMA IRQ */
+  nvic_hw->icpr[audio_irq_reg] = audio_irq_bit; /* Clear any pending */
+  nvic_hw->iser[audio_irq_reg] = audio_irq_bit; /* Enable */
+
+  return PICO_OK;
+}
+
+/**
+ * Exit the flash-safe zone by restoring the original NVIC interrupt state.
+ */
+static int __not_in_flash_func(selective_exit_safe_zone)(uint32_t timeout_ms) {
+  (void)timeout_ms;
+
+  /* Restore original NVIC enable state:
+   * - First disable everything that wasn't originally enabled
+   * - Then enable everything that was originally enabled */
+  for (int i = 0; i < NVIC_REG_COUNT; i++) {
+    nvic_hw->icer[i] = ~saved_nvic_iser[i];
+    nvic_hw->iser[i] = saved_nvic_iser[i];
+  }
+
+  return PICO_OK;
+}
+
+static flash_safety_helper_t selective_helper = {
+    .core_init_deinit = selective_init_deinit,
+    .enter_safe_zone_timeout_ms = selective_enter_safe_zone,
+    .exit_safe_zone_timeout_ms = selective_exit_safe_zone,
+};
+
+/**
+ * Strong override of the SDK's weak get_flash_safety_helper().
+ * Returns our selective NVIC masking helper instead of the default
+ * PRIMASK-based helper.
+ */
+flash_safety_helper_t *get_flash_safety_helper(void) {
+  return &selective_helper;
+}

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "drum/drum_pizza_hardware.h"
 #include "drum/ui/pizza_display.h"
 #include "events.h"
+#include "flash_access_coordinator.h"
 #include "message_router.h"
 #include "pizza_controls.h"
 #include "sequencer_controller.h"
@@ -51,7 +52,9 @@ static drum::ConfigurationManager config_manager(logger);
 static drum::SampleRepository sample_repository(logger);
 static musin::filesystem::Filesystem filesystem(logger);
 static drum::SysExHandler sysex_handler(config_manager, logger, filesystem);
-static drum::AudioEngine audio_engine(sample_repository, logger);
+static drum::FlashAccessCoordinator flash_coordinator;
+static drum::AudioEngine audio_engine(sample_repository, logger,
+                                      flash_coordinator);
 static musin::timing::InternalClock internal_clock(120.0f);
 static musin::timing::MidiClockProcessor midi_clock_processor;
 static musin::timing::SyncIn sync_in(DATO_SUBMARINE_SYNC_IN_PIN,
@@ -189,13 +192,26 @@ int main() {
         pizza_display.switch_to_file_transfer_mode();
         break;
       case drum::SystemStateId::FallingAsleep:
-        // Force save sequencer state before sleep
+        // Force save sequencer state before sleep with flash coordination
         if (sequencer_controller.is_persistence_initialized()) {
+          // Request flash write access
+          flash_coordinator.request_write();
+
+          // Pre-buffer audio while waiting (even though we'll mute soon)
+          audio_engine.prepare_for_flash_write();
+          while (!audio_engine.flash_write_buffers_ready()) {
+            audio_engine.process();
+          }
+          flash_coordinator.buffers_ready();
+
+          // Now safe to write
           if (sequencer_controller.save_state_to_flash()) {
             logger.info("State saved successfully before sleep");
           } else {
             logger.warn("Failed to save state before sleep");
           }
+
+          flash_coordinator.write_complete();
         }
         audio_engine.mute();
         audio_engine.deinit();

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -197,11 +197,8 @@ int main() {
           // Request flash write access
           flash_coordinator.request_write();
 
-          // Pre-buffer audio while waiting (even though we'll mute soon)
+          // Pre-buffer audio (synchronous — ready when it returns)
           audio_engine.prepare_for_flash_write();
-          while (!audio_engine.flash_write_buffers_ready()) {
-            audio_engine.process();
-          }
           flash_coordinator.buffers_ready();
 
           // Now safe to write
@@ -240,6 +237,23 @@ int main() {
       sync_in.update(now);
       sequencer_controller
           .update(); // Checks if a step is due and queues NoteEvents
+
+      // Coordinated flash save: pre-buffer audio to survive flash erase
+      if (sequencer_controller.should_save_now()) {
+        flash_coordinator.request_write();
+        audio_engine.prepare_for_flash_write();
+        flash_coordinator.buffers_ready();
+
+        if (sequencer_controller.save_state_to_flash()) {
+          logger.debug("Coordinated periodic save completed");
+        } else {
+          logger.warn("Coordinated periodic save failed");
+        }
+
+        flash_coordinator.write_complete();
+        sequencer_controller.mark_save_complete();
+      }
+
       message_router
           .update(); // Drains NoteEvent queue, sending to observers and MIDI
       audio_engine.process();

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -551,17 +551,6 @@ void SequencerController<NumTracks, NumSteps>::deactivate_play_on_every_step(
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::update() {
-  // Periodic save logic with debouncing (runs regardless of step timing)
-  if (storage_.has_value() && storage_->should_save_now()) {
-    SequencerPersistentState state;
-    create_persistent_state(state);
-    if (storage_->save_state_to_flash(state)) {
-      logger_.debug("Periodic save completed successfully");
-    } else {
-      logger_.warn("Periodic save failed");
-    }
-  }
-
   uint8_t current_retrigger_mask = _retrigger_due_mask.load();
   if (current_retrigger_mask > 0) {
     uint8_t processed_mask = 0;
@@ -901,6 +890,21 @@ SequencerController<NumTracks, NumSteps>::get_highlighted_random_step_for_track(
     size_t track_idx) const {
   auto step_opt = random_effect_.get_highlighted_step_for_track(track_idx);
   return step_opt.value_or(get_current_step());
+}
+
+template <size_t NumTracks, size_t NumSteps>
+bool SequencerController<NumTracks, NumSteps>::should_save_now() const {
+  if (!storage_.has_value()) {
+    return false;
+  }
+  return storage_->should_save_now();
+}
+
+template <size_t NumTracks, size_t NumSteps>
+void SequencerController<NumTracks, NumSteps>::mark_save_complete() {
+  if (storage_.has_value()) {
+    storage_->mark_state_clean();
+  }
 }
 
 template class SequencerController<config::NUM_TRACKS,

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -368,6 +368,19 @@ public:
    * Call this after modifying sequencer patterns via get_sequencer().
    */
   void mark_state_dirty_public();
+
+  /**
+   * @brief Check if the sequencer state should be saved now.
+   * Delegates to the storage's debounce timing logic.
+   * @return true if a save should be performed now, false otherwise
+   */
+  [[nodiscard]] bool should_save_now() const;
+
+  /**
+   * @brief Mark the save as complete (state is clean).
+   * Call after a successful coordinated save.
+   */
+  void mark_save_complete();
 };
 
 } // namespace drum

--- a/musin/audio/attack_buffering_sample_reader.h
+++ b/musin/audio/attack_buffering_sample_reader.h
@@ -267,6 +267,18 @@ public:
     return flash_data_buffered_reader_.read_next(out);
   }
 
+  /**
+   * @brief Pre-fills audio buffers to survive flash write blackout.
+   *
+   * Call this before a flash erase operation. With 20 blocks per slot,
+   * this buffers ~116ms of audio to survive a ~50ms flash blackout.
+   *
+   * @return Total samples buffered for playback.
+   */
+  uint32_t pre_fill_for_flash_write() {
+    return flash_data_buffered_reader_.pre_fill_both_buffers();
+  }
+
 private:
   // State for both memory and file-based sources
   uint32_t ram_read_pos_; // Current read position within the RAM attack buffer

--- a/musin/audio/buffered_reader.h
+++ b/musin/audio/buffered_reader.h
@@ -13,7 +13,10 @@ namespace musin {
 // buffers. Each block is AUDIO_BLOCK_SAMPLES (e.g., 128) samples. Total RAM = 2
 // * NumBlocksPerSlot * AUDIO_BLOCK_SAMPLES * sizeof(int16_t). E.g., 2 slots * 4
 // blocks/slot * 128 samples/block * 2 bytes/sample = 2048 bytes.
-constexpr size_t DEFAULT_AUDIO_BLOCKS_PER_BUFFER_SLOT = 1;
+//
+// Set to 20 blocks (~58ms buffer) to survive flash erase blackout (~50ms).
+// RAM impact: 2 * 20 * 128 * 2 = 10,240 bytes per voice (40KB for 4 voices).
+constexpr size_t DEFAULT_AUDIO_BLOCKS_PER_BUFFER_SLOT = 20;
 
 template <size_t NumBlocksPerSlot = DEFAULT_AUDIO_BLOCKS_PER_BUFFER_SLOT,
           typename CopierPolicy = CpuCopier>
@@ -43,6 +46,30 @@ struct BufferedReader {
     return (current_read_position_in_active_buffer <
             samples_in_active_buffer) ||
            reader.has_data();
+  }
+
+  /**
+   * @brief Pre-fills both ping-pong buffers for flash write survival.
+   *
+   * Call this before a flash erase operation to ensure maximum buffered
+   * audio is available. With default 20 blocks per slot, this buffers
+   * ~116ms of audio (2 slots × 20 blocks × 128 samples ÷ 44.1kHz).
+   *
+   * @return Total samples buffered across both slots.
+   */
+  uint32_t pre_fill_both_buffers() {
+    // Fill the inactive buffer first (it may be partially consumed)
+    uint32_t inactive_samples = 0;
+    fill_buffer_slot(*inactive_buffer_ptr, inactive_samples);
+
+    // If active buffer has been consumed, refill it too
+    if (current_read_position_in_active_buffer >= samples_in_active_buffer) {
+      fill_buffer_slot(*active_buffer_ptr, samples_in_active_buffer);
+      current_read_position_in_active_buffer = 0;
+    }
+
+    return (samples_in_active_buffer - current_read_position_in_active_buffer) +
+           inactive_samples;
   }
 
 private:

--- a/test/drum/CMakeLists.txt
+++ b/test/drum/CMakeLists.txt
@@ -64,7 +64,26 @@ target_link_libraries(drum-test-swing PRIVATE
     etl::etl
 )
 
+# Test target: Flash Access Coordinator (state machine tests)
+add_executable(drum-test-flash-coordinator
+    flash_access_coordinator_test.cpp
+)
+
+target_sources(drum-test-flash-coordinator PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../../drum/flash_access_coordinator.cpp
+)
+
+target_include_directories(drum-test-flash-coordinator PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../../
+)
+
+target_link_libraries(drum-test-flash-coordinator PRIVATE
+    Catch2::Catch2WithMain
+    etl::etl
+)
+
 include(CTest)
 include(Catch)
 catch_discover_tests(drum-test-storage)
 catch_discover_tests(drum-test-swing)
+catch_discover_tests(drum-test-flash-coordinator)

--- a/test/drum/flash_access_coordinator_test.cpp
+++ b/test/drum/flash_access_coordinator_test.cpp
@@ -1,0 +1,202 @@
+#include "catch2/catch_test_macros.hpp"
+#include "drum/flash_access_coordinator.h"
+
+using drum::FlashAccessCoordinator;
+using drum::FlashAccessState;
+
+TEST_CASE("FlashAccessCoordinator starts in Idle state",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+  REQUIRE(coordinator.get_state() == FlashAccessState::Idle);
+  REQUIRE(coordinator.can_read());
+  REQUIRE_FALSE(coordinator.is_write_pending());
+  REQUIRE_FALSE(coordinator.has_pending_reads());
+}
+
+TEST_CASE("FlashAccessCoordinator allows read from Idle",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  REQUIRE(coordinator.request_read());
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+  REQUIRE(coordinator.active_read_count() == 1);
+}
+
+TEST_CASE("FlashAccessCoordinator allows multiple concurrent reads",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  REQUIRE(coordinator.request_read());
+  REQUIRE(coordinator.request_read());
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+  REQUIRE(coordinator.active_read_count() == 2);
+
+  coordinator.read_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+  REQUIRE(coordinator.active_read_count() == 1);
+
+  coordinator.read_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Idle);
+  REQUIRE(coordinator.active_read_count() == 0);
+}
+
+TEST_CASE("FlashAccessCoordinator allows write from Idle",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  REQUIRE(coordinator.request_write());
+  REQUIRE(coordinator.get_state() == FlashAccessState::PreparingWrite);
+  REQUIRE(coordinator.is_write_pending());
+  REQUIRE_FALSE(coordinator.can_read());
+}
+
+TEST_CASE("FlashAccessCoordinator write waits for active reads",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  // Start a read
+  REQUIRE(coordinator.request_read());
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+
+  // Request write - should be queued
+  REQUIRE_FALSE(coordinator.request_write());
+  REQUIRE(coordinator.get_state() == FlashAccessState::PendingWrite);
+  REQUIRE(coordinator.is_write_pending());
+
+  // New read should still be allowed during PendingWrite
+  REQUIRE(coordinator.can_read());
+  REQUIRE(coordinator.request_read());
+  REQUIRE(coordinator.active_read_count() == 2);
+
+  // Complete first read
+  coordinator.read_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::PendingWrite);
+
+  // Complete second read - should transition to PreparingWrite
+  coordinator.read_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::PreparingWrite);
+}
+
+TEST_CASE("FlashAccessCoordinator buffers_ready transitions to Writing",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  coordinator.request_write();
+  REQUIRE(coordinator.get_state() == FlashAccessState::PreparingWrite);
+
+  coordinator.buffers_ready();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Writing);
+}
+
+TEST_CASE("FlashAccessCoordinator write_complete returns to Idle",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  coordinator.request_write();
+  coordinator.buffers_ready();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Writing);
+
+  coordinator.write_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Idle);
+  REQUIRE_FALSE(coordinator.is_write_pending());
+  REQUIRE(coordinator.can_read());
+}
+
+TEST_CASE("FlashAccessCoordinator read during write is queued",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  // Start write
+  coordinator.request_write();
+  coordinator.buffers_ready();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Writing);
+
+  // Request read during write - should be queued
+  REQUIRE_FALSE(coordinator.request_read());
+  REQUIRE(coordinator.get_state() == FlashAccessState::PendingRead);
+  REQUIRE(coordinator.has_pending_reads());
+
+  // Request another read
+  REQUIRE_FALSE(coordinator.request_read());
+
+  // Complete write - pending reads should become active
+  coordinator.write_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+  REQUIRE(coordinator.active_read_count() == 2);
+  REQUIRE_FALSE(coordinator.has_pending_reads());
+}
+
+TEST_CASE("FlashAccessCoordinator cancel_write from PendingWrite",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  // Start read
+  coordinator.request_read();
+
+  // Request write (will be pending)
+  coordinator.request_write();
+  REQUIRE(coordinator.get_state() == FlashAccessState::PendingWrite);
+
+  // Cancel write
+  coordinator.cancel_write();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+  REQUIRE_FALSE(coordinator.is_write_pending());
+}
+
+TEST_CASE("FlashAccessCoordinator cancel_write from PreparingWrite",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  coordinator.request_write();
+  REQUIRE(coordinator.get_state() == FlashAccessState::PreparingWrite);
+
+  coordinator.cancel_write();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Idle);
+}
+
+TEST_CASE("FlashAccessCoordinator cannot cancel during active write",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  coordinator.request_write();
+  coordinator.buffers_ready();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Writing);
+
+  // Cancel should be ignored during active write
+  coordinator.cancel_write();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Writing);
+}
+
+TEST_CASE("FlashAccessCoordinator full read-write-read cycle",
+          "[flash_access_coordinator]") {
+  FlashAccessCoordinator coordinator;
+
+  // Start with reads
+  REQUIRE(coordinator.request_read());
+  REQUIRE(coordinator.request_read());
+
+  // Request write (queued)
+  REQUIRE_FALSE(coordinator.request_write());
+  REQUIRE(coordinator.get_state() == FlashAccessState::PendingWrite);
+
+  // Complete reads
+  coordinator.read_complete();
+  coordinator.read_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::PreparingWrite);
+
+  // Buffers ready, start write
+  coordinator.buffers_ready();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Writing);
+
+  // New read requested during write
+  REQUIRE_FALSE(coordinator.request_read());
+  REQUIRE(coordinator.get_state() == FlashAccessState::PendingRead);
+
+  // Complete write
+  coordinator.write_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Reading);
+
+  // Complete the pending read
+  coordinator.read_complete();
+  REQUIRE(coordinator.get_state() == FlashAccessState::Idle);
+}


### PR DESCRIPTION
## Summary

Fixes issue #508 — audio blips/underruns caused by flash erase operations blocking the audio ISR.

## Approach

The fix has three layers:

**1. Keep the audio IRQ alive during flash writes**
Override the SDK's `flash_safe_execute()` with a custom implementation that uses NVIC-level interrupt masking instead of `PRIMASK`. This keeps the audio DMA IRQ enabled during flash erase/program operations (~50ms), preventing underruns at the source.

**2. Buffer enough audio to survive the blackout**
`BufferedReader` is expanded from 1 to 20 blocks/slot (~58ms per buffer), and a `pre_fill_for_flash_write()` path is added so buffers are fully pre-loaded before any flash operation begins. A new `FlashAccessCoordinator` provides mutual exclusion between flash reads and writes.

**3. Coordinate all flash access through the coordinator**
- Sample loads in `AudioEngine::play_on_voice()` are now gated through `request_read()` / `read_complete()`, dropping notes if a flash write is in progress.
- Periodic auto-save is moved out of `SequencerController::update()` and into the main loop, wrapped with coordinator calls.
- `prepare_for_flash_write()` is simplified to be fully synchronous; the old async busy-wait loop is removed.

## Changes

- `drum/audio_engine.cpp/h` — read-side coordinator gating; remove `preparing_for_flash_write_` flag
- `drum/main.cpp` — coordinated periodic save; remove busy-wait loop
- `drum/sequencer_controller.cpp/h` — expose `should_save_now()` / `mark_save_complete()` hooks; remove inline save from `update()`
- Custom `flash_safe_execute()` override with NVIC masking
- `FlashAccessCoordinator` with 12 unit tests / 60 assertions

## RAM impact
BSS increased from 160 KB → 199 KB (+38 KB for 4 voice pre-fill buffers).