### PR TITLE
fix: preserve retrigger mode through Falling state until Release

### DIFF
--- a/musin/ui/drumpad.cpp
+++ b/musin/ui/drumpad.cpp
@@ -95,7 +95,10 @@ void Drumpad::update_state_machine(std::uint16_t current_adc_value,
   case DrumpadState::Holding:
     if (current_adc_value >= _high_pressure_threshold) {
       _current_retrigger_mode = RetriggerMode::Double;
-    } else if (current_adc_value >= _trigger_threshold) {
+    } else if (_current_retrigger_mode == RetriggerMode::Off) {
+      // Reaching Holding means the pad has been pressed and held past
+      // _hold_time_us, so retrigger engages even if pressure has already
+      // settled below _trigger_threshold. High pressure upgrades to Double.
       _current_retrigger_mode = RetriggerMode::Single;
     }
     // Do not clear retrigger mode when pressure drops below trigger_threshold.

--- a/musin/ui/drumpad.cpp
+++ b/musin/ui/drumpad.cpp
@@ -5,8 +5,7 @@ namespace musin::ui {
 Drumpad::Drumpad(uint8_t pad_id, const DrumpadConfig &config)
     : _pad_id(pad_id), _noise_threshold(config.noise_threshold),
       _trigger_threshold(config.trigger_threshold),
-      _high_pressure_threshold(
-          config.high_pressure_threshold),
+      _high_pressure_threshold(config.high_pressure_threshold),
       _active_low(config.active_low),
       _debounce_time_us(config.debounce_time_us),
       _hold_time_us(config.hold_time_us),
@@ -82,7 +81,6 @@ void Drumpad::update_state_machine(std::uint16_t current_adc_value,
       notify_event(DrumpadEvent::Type::Hold, std::nullopt, current_adc_value);
     } else if (current_adc_value < _noise_threshold) {
       _current_state = DrumpadState::DebouncingRelease;
-      _current_retrigger_mode = RetriggerMode::Off;
       _state_transition_time = now;
     }
     break;
@@ -90,7 +88,6 @@ void Drumpad::update_state_machine(std::uint16_t current_adc_value,
   case DrumpadState::Falling:
     if (current_adc_value < _noise_threshold) {
       _current_state = DrumpadState::DebouncingRelease;
-      _current_retrigger_mode = RetriggerMode::Off;
       _state_transition_time = now;
     }
     break;
@@ -100,9 +97,10 @@ void Drumpad::update_state_machine(std::uint16_t current_adc_value,
       _current_retrigger_mode = RetriggerMode::Double;
     } else if (current_adc_value >= _trigger_threshold) {
       _current_retrigger_mode = RetriggerMode::Single;
-    } else {
-      _current_retrigger_mode = RetriggerMode::Off;
     }
+    // Do not clear retrigger mode when pressure drops below trigger_threshold.
+    // The mode is preserved through Falling and only cleared on Release,
+    // keeping it in sync with has_recent_velocity_hit (ring light lifetime).
 
     if (current_adc_value < _trigger_threshold) {
       _current_state = DrumpadState::Falling;

--- a/test/musin/CMakeLists.txt
+++ b/test/musin/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(${PROJECT_NAME}
   timing/speed_adapter_test.cpp
   timing/clock_router_test.cpp
   timing/tempo_handler_external_sync_test.cpp
+  ui/drumpad_test.cpp
 )
 
 if(${STATIC_TESTS})
@@ -40,6 +41,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/../../musin/timing/speed_adapter.cpp
   ${CMAKE_CURRENT_LIST_DIR}/../../musin/timing/midi_clock_out.cpp
   ${CMAKE_CURRENT_LIST_DIR}/../../musin/timing/tempo_handler.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/../../musin/ui/drumpad.cpp
   ${CMAKE_CURRENT_LIST_DIR}/../midi_test_support.cpp
 )
 

--- a/test/musin/include_overrides/pico/assert.h
+++ b/test/musin/include_overrides/pico/assert.h
@@ -1,0 +1,10 @@
+#ifndef TEST_MUSIN_INCLUDE_OVERRIDES_MOCK_PICO_ASSERT_H_
+#define TEST_MUSIN_INCLUDE_OVERRIDES_MOCK_PICO_ASSERT_H_
+
+#include <cassert>
+
+#ifndef hard_assert
+#define hard_assert(...) assert(__VA_ARGS__)
+#endif
+
+#endif // TEST_MUSIN_INCLUDE_OVERRIDES_MOCK_PICO_ASSERT_H_

--- a/test/musin/ui/drumpad_test.cpp
+++ b/test/musin/ui/drumpad_test.cpp
@@ -1,0 +1,116 @@
+#include "musin/ui/drumpad.h"
+#include "pico/time.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using musin::ui::Drumpad;
+using musin::ui::DrumpadState;
+using musin::ui::RetriggerMode;
+
+namespace {
+
+// active_low = false so the raw ADC value passed to update() is used directly,
+// keeping the threshold arithmetic in the tests easy to follow.
+constexpr musin::ui::DrumpadConfig test_config = {
+    .noise_threshold = 150,
+    .trigger_threshold = 800,
+    .high_pressure_threshold = 2500,
+    .active_low = false,
+    .debounce_time_us = 5000,
+    .hold_time_us = 50000,
+    .max_velocity_time_us = 50000,
+    .min_velocity_time_us = 100};
+
+// Drive the pad from Idle to Peaking, emitting a Press once trigger is crossed.
+void press_to_peaking(Drumpad &pad, uint16_t adc) {
+  set_mock_time_us(1000);
+  pad.update(adc); // Idle -> Rising (adc >= noise_threshold)
+  pad.update(adc); // Rising -> Peaking, Press fired
+  REQUIRE(pad.get_current_state() == DrumpadState::Peaking);
+  REQUIRE(pad.was_pressed());
+}
+
+// Hold past hold_time_us so the pad enters Holding, then run one more update so
+// the Holding-state logic (which sets the retrigger mode) executes.
+void hold_until_mode_resolved(Drumpad &pad, uint16_t adc) {
+  advance_mock_time_us(60000);
+  pad.update(adc); // Peaking -> Holding (Hold event)
+  REQUIRE(pad.is_held());
+  pad.update(adc); // Holding-state logic resolves retrigger mode
+}
+
+} // namespace
+
+TEST_CASE("Drumpad starts with retrigger Off") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Off);
+  REQUIRE(pad.get_current_state() == DrumpadState::Idle);
+}
+
+TEST_CASE("Quick tap never engages retrigger") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 1000);
+
+  pad.update(0); // Peaking -> DebouncingRelease (below noise, before hold_time)
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Off);
+
+  advance_mock_time_us(6000);
+  pad.update(0); // DebouncingRelease -> Release -> Idle
+  REQUIRE(pad.was_released());
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Off);
+}
+
+TEST_CASE("Holding above trigger engages Single") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 1000);
+  hold_until_mode_resolved(pad, 1000);
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Single);
+}
+
+TEST_CASE("Holding above high pressure engages Double") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 3000);
+  hold_until_mode_resolved(pad, 3000);
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Double);
+}
+
+// Regression test for the bug where a pad crossed trigger (lighting the ring)
+// but then settled below trigger before reaching Holding, leaving retrigger Off
+// while the ring stayed lit.
+TEST_CASE("Holding below trigger after a press still engages Single") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 1000);        // crosses trigger, Press fired
+  hold_until_mode_resolved(pad, 500); // settles to 150..799 range while held
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Single);
+}
+
+TEST_CASE("Double is preserved when pressure drops below trigger") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 3000);
+  hold_until_mode_resolved(pad, 3000);
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Double);
+
+  pad.update(500); // pressure relaxes below trigger; mode must not downgrade
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Double);
+}
+
+TEST_CASE("Retrigger clears on Release") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 1000);
+  hold_until_mode_resolved(pad, 1000);
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Single);
+
+  pad.update(0); // Holding -> Falling
+  pad.update(0); // Falling -> DebouncingRelease
+  advance_mock_time_us(6000);
+  pad.update(0); // DebouncingRelease -> Release -> Idle
+  REQUIRE(pad.was_released());
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Off);
+}


### PR DESCRIPTION
Previously, `_current_retrigger_mode` was cleared to `Off` in three places before the Release event fired:
- Peaking fast-exit path to DebouncingRelease
- Holding when ADC dropped below `_trigger_threshold` (→ Falling)
- Falling when ADC dropped below `_noise_threshold` (→ DebouncingRelease)

This caused a mismatch: the ring light (driven by `has_recent_velocity_hit`) stayed on until Release, but retrigger deactivated as soon as pressure dropped below `_trigger_threshold`. A user holding a pad at 150–800 ADC would see the lit ring but get no retrigger hits.

Fix: remove the premature clears. The mode is now frozen at Single/Double from the moment it's set in Holding until DebouncingRelease completes and the Release event fires, keeping retrigger lifetime in sync with the ring light lifetime.

Closes #533