### PR TITLE
fix: preserve sample color during SDS transfer cooldown

### DIFF
--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -58,8 +58,10 @@ void SysExHandler::update(absolute_time_t now) {
       last_notified_sample_slot_ = current_sample_slot;
     } else {
       logger_.info("SysEx file transfer finished.");
+      // Pass through the last known sample slot so the display can preserve
+      // the sample color during the debounce/cooldown period (issue #550).
       drum::Events::SysExTransferStateChangeEvent event{
-          .is_active = false, .sample_slot = std::nullopt};
+          .is_active = false, .sample_slot = last_notified_sample_slot_};
       this->notify_observers(event);
       last_notified_sample_slot_ = std::nullopt;
     }

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -425,7 +425,11 @@ SequencerDisplayMode::calculate_trace_color(const PizzaDisplay &display,
 
 void FileTransferDisplayMode::on_enter(PizzaDisplay &display) {
   display.clear();
-  _chaser_position = 0;
+  // Only reset animation position when entering fresh (not re-entering while
+  // still in a transfer chain), to avoid blink-timing jumps (issue #550).
+  if (is_nil_time(_last_update_time)) {
+    _chaser_position = 0;
+  }
   _last_update_time = nil_time;
 }
 

--- a/drum/ui/pizza_display.cpp
+++ b/drum/ui/pizza_display.cpp
@@ -48,7 +48,14 @@ void PizzaDisplay::notification(
     transfer_mode_.set_sample_slot(event.sample_slot);
     transfer_mode_.set_progress(event.progress);
   } else {
-    transfer_mode_.set_sample_slot(std::nullopt);
+    // Preserve the sample slot so the cooldown period keeps the sample color
+    // instead of falling back to green (issue #550). Only clear if the slot
+    // was never set (e.g. non-SDS transfer where slot is always nullopt).
+    if (event.sample_slot.has_value()) {
+      transfer_mode_.set_sample_slot(event.sample_slot);
+    } else {
+      transfer_mode_.set_sample_slot(std::nullopt);
+    }
     transfer_mode_.set_progress(std::nullopt);
   }
 }

--- a/test/drum/sysex_test.cpp
+++ b/test/drum/sysex_test.cpp
@@ -74,12 +74,14 @@ TEST_CASE("Protocol receives file data") {
     Protocol protocol(file_ops);
     MockSender sender;
 
-    // TODO: Simplify building of SysEx messages, so we don't have to repeat the header in each one
+    // TODO: Simplify building of SysEx messages, so we don't have to repeat the
+    // header in each one
 
     const uint8_t begin_file_write[] = {
         0, 0x7D, 0x65, 0, 0, Protocol::BeginFileWrite,
         0, 0,    64}; // Represents a file-name with ASCII character '@'
-    protocol.handle_chunk(sysex::Chunk(begin_file_write, sizeof(begin_file_write)), sender);
+    protocol.handle_chunk(
+        sysex::Chunk(begin_file_write, sizeof(begin_file_write)), sender);
 
     REQUIRE(protocol.__get_state() == State::FileTransfer);
     REQUIRE(file_ops.file_is_open == true);
@@ -89,8 +91,10 @@ TEST_CASE("Protocol receives file data") {
 
     sender.sent_tags.clear();
 
-    const uint8_t byte_transfer[] = {0, 0x7D, 0x65, 0, 0, Protocol::FileBytes, 0, 0, 127};
-    protocol.handle_chunk(sysex::Chunk(byte_transfer, sizeof(byte_transfer)), sender);
+    const uint8_t byte_transfer[] = {0, 0x7D, 0x65, 0, 0, Protocol::FileBytes,
+                                     0, 0,    127};
+    protocol.handle_chunk(sysex::Chunk(byte_transfer, sizeof(byte_transfer)),
+                          sender);
     REQUIRE(file_ops.byte_count == 2);
     REQUIRE(file_ops.content[0] == 127);
     REQUIRE(file_ops.content[1] == 0);
@@ -99,7 +103,8 @@ TEST_CASE("Protocol receives file data") {
 
     sender.sent_tags.clear();
 
-    const uint8_t end_write[] = {0, 0x7D, 0x65, 0, 0, Protocol::EndFileTransfer};
+    const uint8_t end_write[] = {0, 0x7D, 0x65,
+                                 0, 0,    Protocol::EndFileTransfer};
     protocol.handle_chunk(sysex::Chunk(end_write, sizeof(end_write)), sender);
     REQUIRE(protocol.__get_state() == State::Idle);
     REQUIRE(file_ops.file_is_open == false);
@@ -126,8 +131,9 @@ TEST_CASE("decoder decodes a byte") {
     const auto v2 = 0;
     const auto v3 = 127;
 
-    const uint8_t sysex[9] = {syx_pack1(v1), syx_pack2(v1), syx_pack3(v1), v2, v2, v2,
-                              syx_pack1(v3), syx_pack2(v3), syx_pack3(v3)};
+    const uint8_t sysex[9] = {
+        syx_pack1(v1), syx_pack2(v1), syx_pack3(v1), v2, v2, v2,
+        syx_pack1(v3), syx_pack2(v3), syx_pack3(v3)};
     array<uint16_t, 9> bytes;
     const auto byte_count = sysex::codec::decode<9>(sysex, sysex + 9, bytes);
 
@@ -136,4 +142,133 @@ TEST_CASE("decoder decodes a byte") {
     REQUIRE(bytes[1] == 0);
     REQUIRE(bytes[2] == 127);
   }));
+}
+
+// ---------------------------------------------------------------------------
+// SDS Protocol tests (for issue #550: sample slot tracking)
+// ---------------------------------------------------------------------------
+//
+// SysExHandler::update() reads sds_protocol_.current_sample_number_opt() to
+// determine the sample slot for display events.  When a transfer completes
+// (Result::SampleComplete), the protocol resets to Idle and
+// current_sample_number_opt() returns nullopt.
+//
+// Our fix in sysex_handler.cpp captures `last_notified_sample_slot_` *before*
+// the protocol goes Idle, so the "transfer finished" event can carry the last
+// known slot instead of nullopt.  These tests verify the protocol's slot
+// reporting behavior that makes that capture necessary.
+
+#include "drum/sysex/sds_protocol.h"
+#include "musin/hal/null_logger.h"
+
+struct SdsTestFileOps {
+  static const unsigned BlockSize = 4096;
+
+  struct Handle {
+    SdsTestFileOps &parent;
+    constexpr Handle(SdsTestFileOps &parent) : parent(parent) {
+      parent.file_is_open = true;
+    }
+    constexpr void close() {
+      parent.file_is_open = false;
+    }
+    constexpr size_t write(const etl::span<const uint8_t> &bytes) {
+      parent.bytes_written += bytes.size();
+      return bytes.size();
+    }
+  };
+
+  constexpr etl::optional<Handle> open(const etl::string_view &) {
+    return Handle(*this);
+  }
+
+  bool file_is_open = false;
+  size_t bytes_written = 0;
+};
+
+// Build a minimal SDS Dump Header for sample_number, bit_depth=16,
+// one 16-bit word long (so a single data packet completes the transfer).
+static etl::array<uint8_t, 19> make_dump_header(uint16_t sample_number) {
+  // SDS DUMP_HEADER layout (after 0x7E channel byte stripped by SysExHandler):
+  // [0] msg type 0x01, [1] sample_num_lsb, [2] sample_num_msb,
+  // [3] bit_depth, [4-6] period_ns (21-bit), [7-9] length_words (21-bit),
+  // [10-12] loop_start, [13-15] loop_end, [16] loop_type, [17] checksum
+  etl::array<uint8_t, 19> h{};
+  h[0] = sds::DUMP_HEADER;
+  h[1] = sample_number & 0x7F;        // LSB
+  h[2] = (sample_number >> 7) & 0x7F; // MSB
+  h[3] = 16;                          // bit depth
+  // period: 22676 ns ≈ 44100 Hz => 22676 = 0x587C
+  h[4] = 0x7C & 0x7F;
+  h[5] = (0x587C >> 7) & 0x7F;
+  h[6] = (0x587C >> 14) & 0x7F;
+  // length_words = 1 (smallest valid transfer)
+  h[7] = 1;
+  h[8] = 0;
+  h[9] = 0;
+  // loop points & type: 0
+  h[10] = h[11] = h[12] = h[13] = h[14] = h[15] = h[16] = 0;
+  // No checksum needed for header in sds_protocol.h (it's not validated)
+  return h;
+}
+
+// Build a valid SDS Data Packet for a single sample word (2 bytes = 1 word).
+// The protocol expects exactly 123 bytes: [type][packet_num][120
+// data][checksum]
+static etl::array<uint8_t, 123> make_data_packet(uint8_t packet_num) {
+  etl::array<uint8_t, 123> pkt{};
+  pkt[0] = sds::DATA_PACKET;
+  pkt[1] = packet_num;
+  // data bytes [2..121] all zero (silence)
+  // checksum = XOR of (0x7E ^ 0x65 ^ 0x02 ^ packet_num ^ all_data)
+  uint8_t cs = 0x7E ^ 0x65 ^ sds::DATA_PACKET ^ packet_num;
+  for (size_t i = 2; i < 122; ++i)
+    cs ^= pkt[i];
+  pkt[122] = cs & 0x7F;
+  return pkt;
+}
+
+TEST_CASE(
+    "SDS: sample slot is reported during transfer and cleared on complete",
+    "[sds][issue-550]") {
+  SdsTestFileOps file_ops;
+  musin::NullLogger logger;
+
+  sds::Protocol<SdsTestFileOps> protocol(file_ops, logger);
+
+  auto sender = [](sds::MessageType, uint8_t) {};
+  absolute_time_t t{};
+
+  // Initially no slot
+  REQUIRE_FALSE(protocol.current_sample_number_opt().has_value());
+  REQUIRE_FALSE(protocol.is_busy());
+
+  // Send Dump Header for sample 7
+  auto header = make_dump_header(7);
+  protocol.process_message(
+      etl::span<const uint8_t>{header.data(), header.size()}, sender, t);
+
+  REQUIRE(protocol.is_busy());
+  REQUIRE(protocol.current_sample_number_opt().has_value());
+  REQUIRE(protocol.current_sample_number_opt().value() == 7);
+
+  // Send Data Packet to complete the 1-word transfer
+  auto pkt = make_data_packet(0);
+  auto result = protocol.process_message(
+      etl::span<const uint8_t>{pkt.data(), pkt.size()}, sender, t);
+
+  REQUIRE(result == sds::Result::SampleComplete);
+  // Protocol is now Idle; slot is cleared
+  REQUIRE_FALSE(protocol.is_busy());
+  REQUIRE_FALSE(protocol.current_sample_number_opt().has_value());
+  // SysExHandler captures last_notified_sample_slot_ *before* this point,
+  // which is what our fix relies on.
+}
+
+TEST_CASE("SDS: slot nullopt when never started", "[sds][issue-550]") {
+  SdsTestFileOps file_ops;
+  musin::NullLogger logger;
+  sds::Protocol<SdsTestFileOps> protocol(file_ops, logger);
+
+  REQUIRE_FALSE(protocol.current_sample_number_opt().has_value());
 }


### PR DESCRIPTION
Fixes #550

## Problem
During the debounce/cooldown period after an SDS sample transfer, the play button LED was switching to green instead of keeping the sample's color. Additionally, a second transfer starting mid-debounce would reset the blink animation state, causing a visible timing jump.

## Root cause
- `SysExHandler::update()` sent `sample_slot = nullopt` with the transfer-complete event, causing `FileTransferDisplayMode` to fall back to `COLOR_GREEN`.
- `FileTransferDisplayMode::on_enter()` always reset `_chaser_position`, causing a blink jump on re-entry.

## Changes
- **`drum/sysex_handler.cpp`**: Pass `last_notified_sample_slot_` in the transfer-complete event instead of `nullopt`, so the display keeps the correct color during cooldown.
- **`drum/ui/pizza_display.cpp`**: Preserve the sample slot in `FileTransferDisplayMode` when `is_active = false` and a slot is present.
- **`drum/ui/display_mode.cpp`**: Guard `_chaser_position` reset in `on_enter()` to avoid blink timing jumps on re-entry.
- **`test/drum/sysex_test.cpp`**: Add SDS protocol tests verifying slot tracking behavior.
