### PR TITLE
feat: firmware updates over MIDI SysEx with A/B try-before-you-buy

### DIFF
--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(${EXECUTABLE_NAME}
   main.cpp
   midi_manager.cpp
   sysex_handler.cpp
+  firmware_update_buyer.cpp
+  ../musin/flash/firmware_writer.cpp
   pizza_controls.cpp
   ui/pizza_display.cpp
   sequencer_controller.cpp
@@ -87,7 +89,14 @@ target_compile_definitions(${EXECUTABLE_NAME} PRIVATE
   PICO_PROGRAM_VERSION_STRING="${VERSION_STRING}"
   SWAP_AUDIO_CLOCK=1
   PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_MS_OS_20_DESCRIPTOR=0
+  # Mark the image try-before-you-buy: any flash-update boot (SysEx update,
+  # picotool load, UF2 drag-drop) must be committed by FirmwareUpdateBuyer or
+  # the bootrom reverts to the previous image on the next reboot.
+  PICO_CRT0_IMAGE_TYPE_TBYB=1
 )
+
+# Embed the image version in the IMAGE_DEF so the bootrom can compare A/B.
+pico_set_binary_version(${EXECUTABLE_NAME} MAJOR ${VERSION_MAJOR} MINOR ${VERSION_MINOR})
 
 if (SWAP_AUDIO_CLOCK)
   target_compile_definitions(${EXECUTABLE_NAME} PRIVATE PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED=1)
@@ -136,6 +145,7 @@ target_link_libraries(${EXECUTABLE_NAME} PRIVATE
   musin::audio
   musin::filesystem
   pico_rand
+  pico_sha256
 )
 
 # Enable filesystem for the pico (must be done after linking)

--- a/drum/README.md
+++ b/drum/README.md
@@ -186,3 +186,46 @@ Transferring files (like samples or `kit.bin`) to the device is a multi-step pro
     - **Command:** `EndFileTransfer` (0x12)
     - **Payload:** None.
     - After sending all data chunks, the sender sends this command. The device closes the file, finalizing the write, and sends a final `Ack`.
+
+### Firmware Update Protocol
+
+Firmware can be updated over SysEx without entering the bootloader. The device
+streams the standard `.uf2` build artifact into the inactive A/B partition and
+uses the RP2350 bootrom's try-before-you-buy (TBYB) mechanism, so a failed or
+broken update can never brick the device. `tools/drumtool/drumtool.js flash
+firmware.uf2` is the reference client.
+
+1.  **Begin Update:**
+    - **Command:** `BeginFirmwareUpdate` (0x20)
+    - **Payload (encoded like BeginFileWrite):** total UF2 size (32-bit LE),
+      SHA-256 of the UF2 stream (32 bytes), version major/minor/patch (3 bytes,
+      informational).
+    - The device resolves the inactive partition and replies `Ack`/`Nack`. The
+      request is refused while a previous update is still in its unbought trial
+      boot.
+
+2.  **Send Data Chunks:**
+    - **Command:** `FirmwareBytes` (0x21)
+    - **Payload:** raw UF2 stream bytes in the same 7-bytes-plus-MSBs encoding
+      as `FileBytes`. The device parses UF2 blocks (skipping the RP2350-A2
+      erratum "absolute" block), rebases addresses to the inactive partition
+      and programs flash one 4 KiB sector at a time. The `Ack` is sent only
+      after the data has been written, so the host self-throttles.
+
+3.  **End Update:**
+    - **Command:** `EndFirmwareUpdate` (0x22)
+    - The device verifies completeness and the SHA-256, replies `Ack`, then
+      reboots into the new image in trial mode. The new firmware commits itself
+      (`rom_explicit_buy`) after ~5 seconds of healthy operation; if it crashes
+      or hangs before that, the watchdog reboot falls back to the previous
+      firmware.
+    - `AbortFirmwareUpdate` (0x23) or a 5-second inactivity timeout cancels an
+      update in progress; only the inactive partition is affected.
+
+Notes:
+- Firmware images are built with the TBYB flag, so picotool/BOOTSEL loads also
+  self-commit on first boot via the same mechanism.
+- Only RAM builds (`PICO_COPY_TO_RAM`, the default) are relocatable between
+  partitions and safe to distribute for SysEx updates.
+- If both partitions ever hold invalid images, the bootrom falls back to the
+  USB (UF2) bootloader; LED indication is not possible in that mode.

--- a/drum/build.sh
+++ b/drum/build.sh
@@ -168,6 +168,9 @@ if [ "$COPY_TO_RAM" = true ]; then
   echo "Building for RAM execution..."
 else
   echo "Building for Flash execution..."
+  echo "WARNING: Flash (XIP) builds are linked to partition A's address and are"
+  echo "         NOT safe to distribute for SysEx firmware updates, which may"
+  echo "         place the image in partition B. Only RAM builds are relocatable."
 fi
 
 if [ "$VERBOSE" = true ]; then

--- a/drum/events.h
+++ b/drum/events.h
@@ -54,6 +54,9 @@ struct SysExTransferStateChangeEvent {
   bool is_active; // true when transfer starts, false when it ends
   // Optional active sample slot (SDS). Present when known and transfer active.
   std::optional<uint8_t> sample_slot;
+  // Optional transfer progress (0.0f to 1.0f). Present during firmware
+  // updates, absent for file/sample transfers.
+  std::optional<float> progress = std::nullopt;
 };
 
 } // namespace drum::Events

--- a/drum/firmware_update_buyer.cpp
+++ b/drum/firmware_update_buyer.cpp
@@ -1,0 +1,54 @@
+#include "drum/firmware_update_buyer.h"
+
+extern "C" {
+#include "pico/bootrom.h"
+}
+
+namespace drum {
+
+namespace {
+// rom_explicit_buy needs a word-aligned scratch buffer of at least one flash
+// sector to rewrite the sector holding the image's TBYB flag.
+alignas(4) uint8_t buy_workspace[4096];
+} // namespace
+
+FirmwareUpdateBuyer::FirmwareUpdateBuyer(musin::Logger &logger)
+    : logger_(logger) {
+  boot_info_t boot_info{};
+  if (rom_get_boot_info(&boot_info) != 0 &&
+      boot_info.boot_type == BOOT_TYPE_FLASH_UPDATE) {
+    trial_boot_pending_ = true;
+    logger_.info("FirmwareUpdateBuyer: Trial boot detected, partition",
+                 static_cast<int32_t>(boot_info.partition));
+  }
+}
+
+void FirmwareUpdateBuyer::update(absolute_time_t now) {
+  if (!trial_boot_pending_) {
+    return;
+  }
+
+  if (!healthy_since_valid_) {
+    healthy_since_ = now;
+    healthy_since_valid_ = true;
+    return;
+  }
+
+  if (absolute_time_diff_us(healthy_since_, now) <
+      static_cast<int64_t>(HEALTH_PERIOD_MS) * 1000) {
+    return;
+  }
+
+  const int result = rom_explicit_buy(buy_workspace, sizeof(buy_workspace));
+  if (result == 0) {
+    logger_.info("FirmwareUpdateBuyer: Firmware committed.");
+    trial_boot_pending_ = false;
+  } else {
+    logger_.error("FirmwareUpdateBuyer: explicit_buy failed",
+                  static_cast<int32_t>(result));
+    // Retry from a fresh health period rather than hammering the bootrom.
+    healthy_since_valid_ = false;
+  }
+}
+
+} // namespace drum

--- a/drum/firmware_update_buyer.h
+++ b/drum/firmware_update_buyer.h
@@ -17,7 +17,7 @@ namespace drum {
 class FirmwareUpdateBuyer {
 public:
   // Healthy main-loop time required before committing.
-  static constexpr uint32_t HEALTH_PERIOD_MS = 5000;
+  static constexpr uint32_t HEALTH_PERIOD_MS = 1000;
 
   explicit FirmwareUpdateBuyer(musin::Logger &logger);
 

--- a/drum/firmware_update_buyer.h
+++ b/drum/firmware_update_buyer.h
@@ -1,0 +1,41 @@
+#ifndef DRUM_FIRMWARE_UPDATE_BUYER_H
+#define DRUM_FIRMWARE_UPDATE_BUYER_H
+
+extern "C" {
+#include "pico/time.h"
+}
+
+#include "musin/hal/logger.h"
+
+namespace drum {
+
+// Commits ("buys") a try-before-you-buy firmware image once the system has
+// proven healthy. All images are built with the TBYB flag, so this runs after
+// every flash-update boot (SysEx updates, picotool loads and UF2 drag-drop
+// alike). If the image crashes or hangs before the buy, the watchdog reboot
+// is a normal boot and the bootrom falls back to the previous firmware.
+class FirmwareUpdateBuyer {
+public:
+  // Healthy main-loop time required before committing.
+  static constexpr uint32_t HEALTH_PERIOD_MS = 5000;
+
+  explicit FirmwareUpdateBuyer(musin::Logger &logger);
+
+  // True from a flash-update boot until rom_explicit_buy has succeeded.
+  bool is_trial_boot() const {
+    return trial_boot_pending_;
+  }
+
+  // Call from the main loop once normal operation has been reached.
+  void update(absolute_time_t now);
+
+private:
+  musin::Logger &logger_;
+  bool trial_boot_pending_ = false;
+  absolute_time_t healthy_since_{};
+  bool healthy_since_valid_ = false;
+};
+
+} // namespace drum
+
+#endif // DRUM_FIRMWARE_UPDATE_BUYER_H

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -14,6 +14,7 @@
 #include "musin/usb/usb.h"
 
 #include "drum/configuration_manager.h"
+#include "drum/firmware_update_buyer.h"
 #include "drum/midi_manager.h"
 #include "drum/sysex_handler.h"
 #include "musin/filesystem/filesystem.h"
@@ -166,6 +167,11 @@ int main() {
 
   // SystemStateMachine starts in Boot state.
 
+  // Commits a try-before-you-buy image once the main loop has proven healthy.
+  // Constructed here (not statically) so the bootrom query runs after SDK
+  // runtime init.
+  static drum::FirmwareUpdateBuyer firmware_update_buyer(logger);
+
   // Track state transitions for display management
   drum::SystemStateId previous_state = drum::SystemStateId::Boot;
   pizza_display.start_boot_animation(); // Initial boot animation
@@ -220,6 +226,9 @@ int main() {
     case drum::SystemStateId::Sequencer: {
       // Full sequencer operation - existing SequencerMode logic
       musin::usb::background_update();
+      firmware_update_buyer.update(now);
+      sysex_handler.set_firmware_update_allowed(
+          !firmware_update_buyer.is_trial_boot());
       sysex_handler.update(now);
       pizza_controls.update(now);
       sync_in.update(now);

--- a/drum/sysex/firmware_update.h
+++ b/drum/sysex/firmware_update.h
@@ -11,8 +11,8 @@ extern "C" {
 
 #include "musin/hal/logger.h"
 
-#include "./chunk.h"
 #include "./codec.h"
+#include "musin/midi/sysex_chunk.h"
 
 namespace sysex {
 

--- a/drum/sysex/firmware_update.h
+++ b/drum/sysex/firmware_update.h
@@ -1,0 +1,286 @@
+#ifndef SYSEX_FIRMWARE_UPDATE_H_KQ8WP4TR
+#define SYSEX_FIRMWARE_UPDATE_H_KQ8WP4TR
+
+#include "drum/config.h"
+#include "etl/array.h"
+#include "etl/span.h"
+
+extern "C" {
+#include "pico/time.h"
+}
+
+#include "musin/hal/logger.h"
+
+#include "./chunk.h"
+#include "./codec.h"
+
+namespace sysex {
+
+// State machine for firmware transfer to the inactive A/B partition.
+//
+// The Writer dependency receives the raw UF2 byte stream and owns parsing,
+// flash programming and SHA-256 verification:
+//   bool begin(uint32_t total_size, etl::span<const uint8_t> sha256);
+//   bool write(etl::span<const uint8_t> bytes);
+//   bool finalize();
+//   void abort();
+template <typename Writer> struct FirmwareUpdate {
+  static constexpr uint64_t TIMEOUT_US = 5000000; // 5 seconds
+  static constexpr size_t SHA256_SIZE = 32;
+  // total size (4 bytes) + SHA-256 + version major/minor/patch
+  static constexpr size_t BEGIN_PAYLOAD_SIZE = 4 + SHA256_SIZE + 3;
+
+  enum Tag {
+    BeginFirmwareUpdate = 0x20,
+    FirmwareBytes = 0x21,
+    EndFirmwareUpdate = 0x22,
+    AbortFirmwareUpdate = 0x23,
+    Ack = 0x13,
+    Nack = 0x14,
+  };
+
+  enum class Result {
+    OK,
+    UpdateReady, // EndFirmwareUpdate verified; caller may reboot into trial
+    NotFirmwareUpdate,
+    InvalidContent,
+    WriteError,
+    Aborted,
+  };
+
+  enum class State {
+    Idle,
+    Receiving,
+  };
+
+  constexpr FirmwareUpdate(Writer &writer, musin::Logger &logger)
+      : writer_(writer), logger_(logger), last_activity_time_{} {
+  }
+
+  // Returns true for chunks this state machine should handle (correct
+  // manufacturer/device header and a firmware-update tag).
+  static constexpr bool claims(const Chunk &chunk) {
+    if (chunk.size() < 5) {
+      return false;
+    }
+    if (chunk[0] != drum::config::sysex::MANUFACTURER_ID_0 ||
+        chunk[1] != drum::config::sysex::MANUFACTURER_ID_1 ||
+        chunk[2] != drum::config::sysex::MANUFACTURER_ID_2 ||
+        chunk[3] != drum::config::sysex::DEVICE_ID) {
+      return false;
+    }
+    const uint8_t tag = chunk[4];
+    return tag >= Tag::BeginFirmwareUpdate && tag <= Tag::AbortFirmwareUpdate;
+  }
+
+  template <typename Sender>
+  constexpr Result handle_chunk(const Chunk &chunk, Sender &&send_reply,
+                                absolute_time_t now) {
+    if (!claims(chunk)) {
+      return Result::NotFirmwareUpdate;
+    }
+
+    const uint8_t tag = chunk[4];
+    const auto body =
+        etl::span<const uint8_t>{chunk.cbegin() + 5, chunk.cend()};
+
+    switch (tag) {
+    case Tag::BeginFirmwareUpdate:
+      return handle_begin(body, send_reply, now);
+    case Tag::FirmwareBytes:
+      return handle_bytes(body, send_reply, now);
+    case Tag::EndFirmwareUpdate:
+      return handle_end(send_reply);
+    case Tag::AbortFirmwareUpdate:
+      return handle_abort(send_reply);
+    default:
+      return Result::NotFirmwareUpdate;
+    }
+  }
+
+  constexpr bool check_timeout(absolute_time_t now) {
+    if (state_ == State::Receiving &&
+        absolute_time_diff_us(last_activity_time_, now) >
+            static_cast<int64_t>(TIMEOUT_US)) {
+      logger_.warn("SysEx: Firmware update timed out.");
+      writer_.abort();
+      state_ = State::Idle;
+      return true;
+    }
+    return false;
+  }
+
+  constexpr bool busy() const {
+    return state_ != State::Idle;
+  }
+
+  constexpr State get_state() const {
+    return state_;
+  }
+
+  // Bytes accepted so far; with the total from BeginFirmwareUpdate this
+  // drives progress display.
+  constexpr uint32_t bytes_received() const {
+    return bytes_received_;
+  }
+
+  constexpr uint32_t total_size() const {
+    return total_size_;
+  }
+
+private:
+  template <typename Sender>
+  constexpr Result handle_begin(etl::span<const uint8_t> encoded_body,
+                                Sender &send_reply, absolute_time_t now) {
+    if (state_ != State::Idle) {
+      logger_.warn("SysEx: BeginFirmwareUpdate during active update; "
+                   "restarting.");
+      writer_.abort();
+      state_ = State::Idle;
+    }
+
+    // The Begin payload uses the same 3-byte-to-16-bit encoding as
+    // BeginFileWrite; each decoded value carries two payload bytes.
+    etl::array<uint16_t, BEGIN_PAYLOAD_SIZE / 2 + 1> values{};
+    const auto value_count = codec::decode_3_to_16bit(
+        encoded_body.begin(), encoded_body.end(), values.begin(), values.end());
+
+    etl::array<uint8_t, sizeof(values)> bytes{};
+    size_t byte_count = 0;
+    for (size_t i = 0; i < value_count; ++i) {
+      bytes[byte_count++] = static_cast<uint8_t>(values[i] & 0xFF);
+      bytes[byte_count++] = static_cast<uint8_t>(values[i] >> 8);
+    }
+
+    if (byte_count < BEGIN_PAYLOAD_SIZE) {
+      logger_.error("SysEx: BeginFirmwareUpdate payload too short",
+                    static_cast<uint32_t>(byte_count));
+      send_reply(Tag::Nack);
+      return Result::InvalidContent;
+    }
+
+    const uint32_t total_size = static_cast<uint32_t>(bytes[0]) |
+                                (static_cast<uint32_t>(bytes[1]) << 8) |
+                                (static_cast<uint32_t>(bytes[2]) << 16) |
+                                (static_cast<uint32_t>(bytes[3]) << 24);
+    const auto sha256 = etl::span<const uint8_t>{bytes.data() + 4, SHA256_SIZE};
+
+    if (total_size == 0 || !writer_.begin(total_size, sha256)) {
+      logger_.error("SysEx: BeginFirmwareUpdate rejected by writer");
+      send_reply(Tag::Nack);
+      return Result::WriteError;
+    }
+
+    total_size_ = total_size;
+    bytes_received_ = 0;
+    state_ = State::Receiving;
+    last_activity_time_ = now;
+    logger_.info("SysEx: Firmware update started, size", total_size);
+    send_reply(Tag::Ack);
+    return Result::OK;
+  }
+
+  template <typename Sender, typename InputIt>
+  constexpr Result decode_and_write(InputIt start, InputIt end,
+                                    Sender &send_reply) {
+    while (start != end) {
+      const auto result = codec::decode_8_to_7(
+          start, end, decode_buffer_.begin(), decode_buffer_.end());
+      const size_t bytes_read = result.first;
+      const size_t bytes_decoded = result.second;
+      if (bytes_decoded == 0) {
+        break;
+      }
+      start += bytes_read;
+
+      // The 8-to-7 codec decodes whole 7-byte groups, so the final group of
+      // the stream may carry up to 6 padding bytes beyond the announced size.
+      const size_t remaining = total_size_ - bytes_received_;
+      const size_t to_write = etl::min(bytes_decoded, remaining);
+      const size_t excess = bytes_decoded - to_write;
+      if (excess >= 7) {
+        logger_.error("SysEx: FirmwareBytes exceed announced size");
+        writer_.abort();
+        state_ = State::Idle;
+        send_reply(Tag::Nack);
+        return Result::WriteError;
+      }
+
+      if (to_write > 0 && !writer_.write(etl::span<const uint8_t>{
+                              decode_buffer_.data(), to_write})) {
+        logger_.error("SysEx: Firmware write failed, aborting update.");
+        writer_.abort();
+        state_ = State::Idle;
+        send_reply(Tag::Nack);
+        return Result::WriteError;
+      }
+      bytes_received_ += to_write;
+    }
+    return Result::OK;
+  }
+
+  template <typename Sender>
+  constexpr Result handle_bytes(etl::span<const uint8_t> body,
+                                Sender &send_reply, absolute_time_t now) {
+    if (state_ != State::Receiving) {
+      logger_.error("SysEx: FirmwareBytes received while not updating.");
+      send_reply(Tag::Nack);
+      return Result::InvalidContent;
+    }
+
+    const Result result =
+        decode_and_write(body.begin(), body.end(), send_reply);
+    if (result != Result::OK) {
+      return result;
+    }
+
+    last_activity_time_ = now;
+    // Ack only after the data has been written through to flash so the host
+    // self-throttles to the device's flash speed.
+    send_reply(Tag::Ack);
+    return Result::OK;
+  }
+
+  template <typename Sender> constexpr Result handle_end(Sender &send_reply) {
+    if (state_ != State::Receiving) {
+      logger_.error("SysEx: EndFirmwareUpdate received while not updating.");
+      send_reply(Tag::Nack);
+      return Result::InvalidContent;
+    }
+
+    state_ = State::Idle;
+    if (bytes_received_ != total_size_ || !writer_.finalize()) {
+      logger_.error("SysEx: Firmware verification failed.");
+      writer_.abort();
+      send_reply(Tag::Nack);
+      return Result::WriteError;
+    }
+
+    logger_.info("SysEx: Firmware update verified.");
+    send_reply(Tag::Ack);
+    return Result::UpdateReady;
+  }
+
+  template <typename Sender> constexpr Result handle_abort(Sender &send_reply) {
+    if (state_ == State::Receiving) {
+      writer_.abort();
+      state_ = State::Idle;
+    }
+    logger_.info("SysEx: Firmware update aborted by host.");
+    send_reply(Tag::Ack);
+    return Result::Aborted;
+  }
+
+  Writer &writer_;
+  musin::Logger &logger_;
+  State state_ = State::Idle;
+  absolute_time_t last_activity_time_;
+  uint32_t total_size_ = 0;
+  uint32_t bytes_received_ = 0;
+  // Large enough for a full 2048-byte SysEx message decoded 8-to-7.
+  etl::array<uint8_t, 1792> decode_buffer_{};
+};
+
+} // namespace sysex
+
+#endif /* end of include guard: SYSEX_FIRMWARE_UPDATE_H_KQ8WP4TR */

--- a/drum/sysex/protocol.h
+++ b/drum/sysex/protocol.h
@@ -70,6 +70,9 @@ template <typename FileOperations> struct Protocol {
     Ack = 0x13,
     Nack = 0x14,
     FormatFilesystem = 0x15,
+
+    // Firmware Update Commands (0x20-0x23) are handled by
+    // sysex::FirmwareUpdate in drum/sysex/firmware_update.h.
   };
 
   enum class Result {

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -2,6 +2,8 @@
 #include "events.h"
 #include "musin/midi/midi_wrapper.h"
 #include "version.h"
+#include <boot/picoboot_constants.h>
+#include <hardware/regs/addressmap.h>
 #include <pico/bootrom.h>
 #include <pico/unique_id.h>
 
@@ -12,11 +14,26 @@ SysExHandler::SysExHandler(ConfigurationManager &config_manager,
                            musin::filesystem::Filesystem &filesystem)
     : config_manager_(config_manager), logger_(logger), filesystem_(filesystem),
       file_ops_(logger, filesystem), protocol_(file_ops_, logger),
-      sds_protocol_(file_ops_, logger) {
+      sds_protocol_(file_ops_, logger), firmware_writer_(logger),
+      firmware_update_(firmware_writer_, logger) {
 }
 
 void SysExHandler::update(absolute_time_t now) {
   protocol_.check_timeout(now);
+  firmware_update_.check_timeout(now);
+
+  if (firmware_reboot_pending_ &&
+      absolute_time_diff_us(firmware_reboot_time_, now) > 0) {
+    if (const auto target = firmware_writer_.target_flash_offset();
+        target.has_value()) {
+      logger_.info("SysEx: Rebooting into new firmware for trial boot.");
+      rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_FLASH_UPDATE |
+                     REBOOT2_FLAG_NO_RETURN_ON_SUCCESS,
+                 100, XIP_BASE + target.value(), 0);
+    }
+    firmware_reboot_pending_ = false;
+  }
+
   bool current_busy_state = is_busy();
 
   // Get current sample slot if available
@@ -47,6 +64,10 @@ void SysExHandler::update(absolute_time_t now) {
       last_notified_sample_slot_ = std::nullopt;
     }
     was_busy_ = current_busy_state;
+  }
+  // Check for sample slot changes during active transfer
+  else if (current_busy_state && firmware_update_.busy()) {
+    notify_firmware_update_progress();
   }
   // Check for sample slot changes during active transfer
   else if (current_busy_state &&
@@ -115,6 +136,12 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
     return;
   }
 
+  // Firmware update messages have their own state machine
+  if (sysex::FirmwareUpdate<musin::flash::FirmwareWriter>::claims(chunk)) {
+    handle_firmware_update_message(chunk, get_absolute_time());
+    return;
+  }
+
   // Not an SDS message - route to existing custom protocol
   auto sender = [this](sysex::Protocol<StandardFileOps>::Tag tag) {
     uint8_t msg[] = {0xF0,
@@ -153,7 +180,61 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
 }
 
 bool SysExHandler::is_busy() const {
-  return protocol_.busy() || sds_protocol_.is_busy();
+  return protocol_.busy() || sds_protocol_.is_busy() ||
+         firmware_update_.busy();
+}
+
+void SysExHandler::set_firmware_update_allowed(bool allowed) {
+  firmware_update_allowed_ = allowed;
+}
+
+void SysExHandler::notify_firmware_update_progress() {
+  if (firmware_update_.total_size() == 0) {
+    return;
+  }
+  const float progress = static_cast<float>(firmware_update_.bytes_received()) /
+                         static_cast<float>(firmware_update_.total_size());
+  if (progress - last_notified_progress_ < 1.0f / 32.0f) {
+    return;
+  }
+  last_notified_progress_ = progress;
+  drum::Events::SysExTransferStateChangeEvent event{
+      .is_active = true, .sample_slot = std::nullopt, .progress = progress};
+  this->notify_observers(event);
+}
+
+void SysExHandler::handle_firmware_update_message(const sysex::Chunk &chunk,
+                                                  absolute_time_t now) {
+  auto sender = [](uint8_t tag) {
+    uint8_t msg[] = {0xF0,
+                     drum::config::sysex::MANUFACTURER_ID_0,
+                     drum::config::sysex::MANUFACTURER_ID_1,
+                     drum::config::sysex::MANUFACTURER_ID_2,
+                     drum::config::sysex::DEVICE_ID,
+                     tag,
+                     0xF7};
+    MIDI::sendSysEx(sizeof(msg), msg);
+  };
+
+  using Update = sysex::FirmwareUpdate<musin::flash::FirmwareWriter>;
+
+  if (chunk[4] == Update::Tag::BeginFirmwareUpdate &&
+      !firmware_update_allowed_) {
+    logger_.warn("SysEx: Firmware update refused during unbought trial boot.");
+    sender(Update::Tag::Nack);
+    return;
+  }
+
+  const auto result = firmware_update_.handle_chunk(chunk, sender, now);
+  if (result == Update::Result::UpdateReady) {
+    // Give the Ack time to drain through the MIDI output queue, then reboot
+    // into the new image for its trial boot.
+    firmware_reboot_pending_ = true;
+    firmware_reboot_time_ = make_timeout_time_ms(500);
+  }
+  if (chunk[4] == Update::Tag::BeginFirmwareUpdate) {
+    last_notified_progress_ = -1.0f;
+  }
 }
 
 void SysExHandler::on_file_received() {

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -65,7 +65,7 @@ void SysExHandler::update(absolute_time_t now) {
     }
     was_busy_ = current_busy_state;
   }
-  // Check for sample slot changes during active transfer
+  // Report progress during an active firmware update
   else if (current_busy_state && firmware_update_.busy()) {
     notify_firmware_update_progress();
   }
@@ -180,8 +180,7 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
 }
 
 bool SysExHandler::is_busy() const {
-  return protocol_.busy() || sds_protocol_.is_busy() ||
-         firmware_update_.busy();
+  return protocol_.busy() || sds_protocol_.is_busy() || firmware_update_.busy();
 }
 
 void SysExHandler::set_firmware_update_allowed(bool allowed) {

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -3,8 +3,10 @@
 
 #include "drum/configuration_manager.h"
 #include "drum/standard_file_ops.h"
+#include "drum/sysex/firmware_update.h"
 #include "drum/sysex/protocol.h"
 #include "drum/sysex/sds_protocol.h"
+#include "musin/flash/firmware_writer.h"
 #include "etl/observer.h"
 #include "musin/hal/logger.h"
 
@@ -41,7 +43,16 @@ public:
 
   void on_file_received();
 
+  /**
+   * @brief Gates BeginFirmwareUpdate. Disallowed while a trial-booted
+   * firmware has not yet committed itself.
+   */
+  void set_firmware_update_allowed(bool allowed);
+
 private:
+  void handle_firmware_update_message(const sysex::Chunk &chunk,
+                                      absolute_time_t now);
+  void notify_firmware_update_progress();
   void print_firmware_version() const;
   void print_serial_number() const;
   void send_storage_info() const;
@@ -54,9 +65,15 @@ private:
   StandardFileOps file_ops_;
   sysex::Protocol<StandardFileOps> protocol_;
   sds::Protocol<StandardFileOps> sds_protocol_;
+  musin::flash::FirmwareWriter firmware_writer_;
+  sysex::FirmwareUpdate<musin::flash::FirmwareWriter> firmware_update_;
   bool new_file_received_ = false;
   bool was_busy_ = false;
   std::optional<uint8_t> last_notified_sample_slot_ = std::nullopt;
+  bool firmware_update_allowed_ = true;
+  bool firmware_reboot_pending_ = false;
+  absolute_time_t firmware_reboot_time_{};
+  float last_notified_progress_ = -1.0f;
 };
 
 } // namespace drum

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -6,8 +6,8 @@
 #include "drum/sysex/firmware_update.h"
 #include "drum/sysex/protocol.h"
 #include "drum/sysex/sds_protocol.h"
-#include "musin/flash/firmware_writer.h"
 #include "etl/observer.h"
+#include "musin/flash/firmware_writer.h"
 #include "musin/hal/logger.h"
 
 extern "C" {

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -434,6 +434,10 @@ void FileTransferDisplayMode::set_sample_slot(
   _current_sample_slot = sample_slot;
 }
 
+void FileTransferDisplayMode::set_progress(std::optional<float> progress) {
+  _progress = progress;
+}
+
 void FileTransferDisplayMode::draw(PizzaDisplay &display, absolute_time_t now) {
   display.clear();
   // Flash the play button in sample color or green as fallback
@@ -453,6 +457,26 @@ void FileTransferDisplayMode::draw(PizzaDisplay &display, absolute_time_t now) {
   }
 
   display.set_play_button_led(pulse_color);
+
+  // During firmware updates, fill the sequencer LEDs as a progress bar.
+  if (_progress.has_value()) {
+    const float clamped = std::clamp(_progress.value(), 0.0f, 1.0f);
+    const size_t total_steps = config::NUM_TRACKS * config::NUM_STEPS_PER_TRACK;
+    const size_t lit = static_cast<size_t>(clamped * total_steps);
+    size_t count = 0;
+    for (size_t track = 0; track < config::NUM_TRACKS; ++track) {
+      for (size_t step = 0; step < config::NUM_STEPS_PER_TRACK; ++step) {
+        if (count >= lit) {
+          break;
+        }
+        if (auto led = display.get_sequencer_led_index(track, step);
+            led.has_value()) {
+          display.set_led(led.value(), PizzaDisplay::COLOR_GREEN);
+        }
+        count++;
+      }
+    }
+  }
 }
 
 // --- BootAnimationMode Implementation ---

--- a/drum/ui/display_mode.h
+++ b/drum/ui/display_mode.h
@@ -76,11 +76,13 @@ public:
   void draw(PizzaDisplay &display, absolute_time_t now) override;
   void on_enter(PizzaDisplay &display) override;
   void set_sample_slot(std::optional<uint8_t> sample_slot);
+  void set_progress(std::optional<float> progress);
 
 private:
   absolute_time_t _last_update_time = nil_time;
   uint8_t _chaser_position = 0;
   std::optional<uint8_t> _current_sample_slot;
+  std::optional<float> _progress;
 };
 
 // --- Concrete Strategy for Boot Animation ---

--- a/drum/ui/pizza_display.cpp
+++ b/drum/ui/pizza_display.cpp
@@ -46,8 +46,10 @@ void PizzaDisplay::notification(
     drum::Events::SysExTransferStateChangeEvent event) {
   if (event.is_active) {
     transfer_mode_.set_sample_slot(event.sample_slot);
+    transfer_mode_.set_progress(event.progress);
   } else {
     transfer_mode_.set_sample_slot(std::nullopt);
+    transfer_mode_.set_progress(std::nullopt);
   }
 }
 

--- a/musin/flash/firmware_writer.cpp
+++ b/musin/flash/firmware_writer.cpp
@@ -1,0 +1,227 @@
+#include "musin/flash/firmware_writer.h"
+
+extern "C" {
+#include "hardware/sync.h"
+#include "hardware/watchdog.h"
+#include "pico/bootrom.h"
+#include "pico/error.h"
+}
+
+#include "etl/algorithm.h"
+
+#include "musin/filesystem/partition_manager.h"
+
+namespace musin::flash {
+
+namespace {
+constexpr uint32_t sector_base(uint32_t flash_offset) {
+  return flash_offset & ~(FLASH_SECTOR_SIZE - 1u);
+}
+} // namespace
+
+FirmwareWriter::FirmwareWriter(musin::Logger &logger) : logger_(logger) {
+}
+
+bool FirmwareWriter::begin(uint32_t total_size,
+                           etl::span<const uint8_t> sha256) {
+  if (receiving_) {
+    abort();
+  }
+  image_ready_ = false;
+
+  if (sha256.size() != SHA256_SIZE) {
+    logger_.error("FirmwareWriter: Invalid SHA-256 length");
+    return false;
+  }
+
+  if (!resolve_target_partition()) {
+    return false;
+  }
+
+  // The UF2 stream is roughly twice the image size (512-byte blocks carrying
+  // 256-byte payloads); the parser range-checks the actual payload addresses
+  // against the partition, so only sanity-check the stream size here.
+  if (total_size > 2 * target_size_ + 2 * Uf2Parser::BLOCK_SIZE) {
+    logger_.error("FirmwareWriter: Announced size exceeds partition capacity");
+    return false;
+  }
+  if (total_size % Uf2Parser::BLOCK_SIZE != 0) {
+    logger_.error("FirmwareWriter: Size is not a multiple of UF2 block size");
+    return false;
+  }
+
+  // No DMA: avoids claiming a channel next to the LED/audio DMA users, and
+  // hashing speed is irrelevant against MIDI transfer speed.
+  if (pico_sha256_try_start(&sha_state_, SHA256_BIG_ENDIAN, false) != PICO_OK) {
+    logger_.error("FirmwareWriter: SHA-256 hardware unavailable");
+    return false;
+  }
+  sha_active_ = true;
+
+  parser_ = Uf2Parser{target_offset_, target_size_};
+  etl::copy(sha256.begin(), sha256.end(), expected_sha_.begin());
+  total_stream_size_ = total_size;
+  stream_bytes_seen_ = 0;
+  current_sector_base_ = NO_SECTOR;
+  receiving_ = true;
+
+  logger_.info("FirmwareWriter: Update started, target offset", target_offset_);
+  return true;
+}
+
+bool FirmwareWriter::write(etl::span<const uint8_t> bytes) {
+  if (!receiving_) {
+    return false;
+  }
+  if (stream_bytes_seen_ + bytes.size() > total_stream_size_) {
+    logger_.error("FirmwareWriter: Stream exceeds announced size");
+    return false;
+  }
+
+  pico_sha256_update_blocking(&sha_state_, bytes.data(), bytes.size());
+  stream_bytes_seen_ += bytes.size();
+
+  const auto result =
+      parser_.push(bytes, [this](const Uf2Parser::Block &block) {
+        return stage_payload(block.flash_offset, block.payload);
+      });
+
+  if (result != Uf2Parser::Result::Ok &&
+      result != Uf2Parser::Result::Complete) {
+    logger_.error("FirmwareWriter: UF2 parse error",
+                  static_cast<uint32_t>(result));
+    return false;
+  }
+  return true;
+}
+
+bool FirmwareWriter::finalize() {
+  if (!receiving_) {
+    return false;
+  }
+  receiving_ = false;
+
+  if (stream_bytes_seen_ != total_stream_size_ || !parser_.is_complete()) {
+    logger_.error("FirmwareWriter: Incomplete UF2 stream");
+    release_sha();
+    return false;
+  }
+
+  if (!flush_sector()) {
+    release_sha();
+    return false;
+  }
+
+  sha256_result_t result;
+  pico_sha256_finish(&sha_state_, &result);
+  sha_active_ = false;
+
+  if (!etl::equal(expected_sha_.begin(), expected_sha_.end(), result.bytes)) {
+    logger_.error("FirmwareWriter: SHA-256 mismatch");
+    return false;
+  }
+
+  logger_.info("FirmwareWriter: Image verified, bytes written",
+               parser_.bytes_emitted());
+  image_ready_ = true;
+  return true;
+}
+
+void FirmwareWriter::abort() {
+  receiving_ = false;
+  image_ready_ = false;
+  current_sector_base_ = NO_SECTOR;
+  release_sha();
+}
+
+std::optional<uint32_t> FirmwareWriter::target_flash_offset() const {
+  if (!image_ready_) {
+    return std::nullopt;
+  }
+  return target_offset_;
+}
+
+bool FirmwareWriter::resolve_target_partition() {
+  boot_info_t boot_info{};
+  if (rom_get_boot_info(&boot_info) == 0) {
+    logger_.error("FirmwareWriter: rom_get_boot_info failed");
+    return false;
+  }
+
+  uint32_t target_id;
+  if (boot_info.partition == FIRMWARE_A_PARTITION_ID) {
+    target_id = FIRMWARE_B_PARTITION_ID;
+  } else if (boot_info.partition == FIRMWARE_B_PARTITION_ID) {
+    target_id = FIRMWARE_A_PARTITION_ID;
+  } else {
+    logger_.error("FirmwareWriter: Not booted from an A/B partition",
+                  static_cast<int32_t>(boot_info.partition));
+    return false;
+  }
+
+  musin::filesystem::PartitionManager partition_manager(logger_);
+  const auto target = partition_manager.find_partition(target_id);
+  const auto booted = partition_manager.find_partition(boot_info.partition);
+  if (!target.has_value() || !booted.has_value()) {
+    logger_.error("FirmwareWriter: Failed to resolve firmware partitions");
+    return false;
+  }
+
+  // Never allow the target range to touch the running image.
+  if (target->offset == booted->offset) {
+    logger_.error("FirmwareWriter: Target partition equals booted partition");
+    return false;
+  }
+
+  target_offset_ = target->offset;
+  target_size_ = target->size;
+  return true;
+}
+
+bool FirmwareWriter::stage_payload(uint32_t flash_offset,
+                                   etl::span<const uint8_t> payload) {
+  const uint32_t base = sector_base(flash_offset);
+  if (base != current_sector_base_) {
+    if (!flush_sector()) {
+      return false;
+    }
+    current_sector_base_ = base;
+    sector_buffer_.fill(0xFF);
+  }
+
+  etl::copy(payload.begin(), payload.end(),
+            sector_buffer_.begin() + (flash_offset - base));
+  return true;
+}
+
+bool FirmwareWriter::flush_sector() {
+  if (current_sector_base_ == NO_SECTOR) {
+    return true;
+  }
+  if (current_sector_base_ < target_offset_ ||
+      current_sector_base_ + FLASH_SECTOR_SIZE >
+          target_offset_ + target_size_) {
+    logger_.error("FirmwareWriter: Sector outside target partition");
+    return false;
+  }
+
+  watchdog_update();
+  const uint32_t saved_irqs = save_and_disable_interrupts();
+  flash_range_erase(current_sector_base_, FLASH_SECTOR_SIZE);
+  flash_range_program(current_sector_base_, sector_buffer_.data(),
+                      FLASH_SECTOR_SIZE);
+  restore_interrupts(saved_irqs);
+  watchdog_update();
+
+  current_sector_base_ = NO_SECTOR;
+  return true;
+}
+
+void FirmwareWriter::release_sha() {
+  if (sha_active_) {
+    pico_sha256_cleanup(&sha_state_);
+    sha_active_ = false;
+  }
+}
+
+} // namespace musin::flash

--- a/musin/flash/firmware_writer.h
+++ b/musin/flash/firmware_writer.h
@@ -1,0 +1,76 @@
+#ifndef MUSIN_FLASH_FIRMWARE_WRITER_H_ZR7TQ2BD
+#define MUSIN_FLASH_FIRMWARE_WRITER_H_ZR7TQ2BD
+
+#include <cstdint>
+#include <optional>
+
+#include "etl/array.h"
+#include "etl/span.h"
+
+extern "C" {
+#include "hardware/flash.h"
+#include "pico/sha256.h"
+}
+
+#include "musin/flash/uf2_parser.h"
+#include "musin/hal/logger.h"
+
+namespace musin::flash {
+
+// Streams a UF2 image into the inactive A/B firmware partition.
+//
+// Receives the raw UF2 byte stream, feeds it through Uf2Parser (which rebases
+// payload addresses to the target partition), stages payloads into a
+// sector-sized buffer and erases/programs flash one sector at a time. A
+// running hardware SHA-256 over the raw stream is checked in finalize().
+class FirmwareWriter {
+public:
+  static constexpr size_t SHA256_SIZE = 32;
+  static constexpr uint32_t FIRMWARE_A_PARTITION_ID = 0;
+  static constexpr uint32_t FIRMWARE_B_PARTITION_ID = 1;
+
+  explicit FirmwareWriter(musin::Logger &logger);
+
+  // Resolves the inactive partition and prepares for a stream of total_size
+  // raw UF2 bytes whose SHA-256 must equal sha256 (32 bytes).
+  bool begin(uint32_t total_size, etl::span<const uint8_t> sha256);
+
+  // Consumes the next raw UF2 stream bytes; programs flash as sectors fill.
+  bool write(etl::span<const uint8_t> bytes);
+
+  // Flushes the final sector and verifies stream completeness and SHA-256.
+  // After a successful finalize, target_flash_offset() identifies the image
+  // to pass to rom_reboot for a flash-update (try-before-you-buy) boot.
+  bool finalize();
+
+  void abort();
+
+  std::optional<uint32_t> target_flash_offset() const;
+
+private:
+  bool resolve_target_partition();
+  bool stage_payload(uint32_t flash_offset, etl::span<const uint8_t> payload);
+  bool flush_sector();
+  void release_sha();
+
+  musin::Logger &logger_;
+  Uf2Parser parser_{0, 0};
+  pico_sha256_state_t sha_state_{};
+  bool sha_active_ = false;
+  bool receiving_ = false;
+  bool image_ready_ = false;
+
+  uint32_t target_offset_ = 0;
+  uint32_t target_size_ = 0;
+  uint32_t total_stream_size_ = 0;
+  uint32_t stream_bytes_seen_ = 0;
+  etl::array<uint8_t, SHA256_SIZE> expected_sha_{};
+
+  static constexpr uint32_t NO_SECTOR = 0xFFFFFFFF;
+  uint32_t current_sector_base_ = NO_SECTOR;
+  etl::array<uint8_t, FLASH_SECTOR_SIZE> sector_buffer_{};
+};
+
+} // namespace musin::flash
+
+#endif /* end of include guard: MUSIN_FLASH_FIRMWARE_WRITER_H_ZR7TQ2BD */

--- a/musin/flash/uf2_parser.h
+++ b/musin/flash/uf2_parser.h
@@ -1,0 +1,173 @@
+#ifndef MUSIN_FLASH_UF2_PARSER_H_QX3VN2LM
+#define MUSIN_FLASH_UF2_PARSER_H_QX3VN2LM
+
+#include <cstddef>
+#include <cstdint>
+
+#include "etl/array.h"
+#include "etl/span.h"
+
+namespace musin::flash {
+
+// Incremental UF2 stream parser. Consumes arbitrary-size byte spans,
+// validates each 512-byte UF2 block and emits its payload rebased from the
+// link-time flash base to a target partition offset.
+//
+// Blocks carrying a different family (e.g. the RP2350-A2 erratum "absolute"
+// block) or the NOT_MAIN_FLASH flag are skipped. Header-only with no SDK
+// dependencies so it can be tested on the host.
+class Uf2Parser {
+public:
+  static constexpr size_t BLOCK_SIZE = 512;
+  static constexpr size_t PAYLOAD_SIZE = 256;
+
+  static constexpr uint32_t MAGIC_START_0 = 0x0A324655;
+  static constexpr uint32_t MAGIC_START_1 = 0x9E5D5157;
+  static constexpr uint32_t MAGIC_END = 0x0AB16F30;
+
+  static constexpr uint32_t FLAG_NOT_MAIN_FLASH = 0x00000001;
+  static constexpr uint32_t FLAG_FAMILY_ID_PRESENT = 0x00002000;
+
+  static constexpr uint32_t FAMILY_RP2350_ARM_S = 0xE48BFF59;
+  static constexpr uint32_t FAMILY_ABSOLUTE = 0xE48BFF57;
+
+  static constexpr uint32_t FLASH_BASE = 0x10000000;
+
+  enum class Result {
+    Ok,             // All consumed bytes processed without error
+    Complete,       // Final block of the stream has been emitted
+    BadMagic,       // Block framing magics did not match
+    WrongFamily,    // No family ID present
+    BadPayloadSize, // Flash block payload was not PAYLOAD_SIZE bytes
+    OutOfRange,     // Target address outside the partition
+    NonSequential,  // Block numbering was not consecutive
+    EmitFailed,     // The emit callback reported failure (e.g. flash error)
+  };
+
+  struct Block {
+    uint32_t flash_offset; // Rebased offset within flash (not XIP-mapped)
+    etl::span<const uint8_t> payload;
+    uint32_t block_no;
+    uint32_t num_blocks;
+  };
+
+  // target_offset: flash offset of the partition the image is written to.
+  // partition_size: capacity of that partition in bytes.
+  constexpr Uf2Parser(uint32_t target_offset, uint32_t partition_size)
+      : target_offset_(target_offset), partition_size_(partition_size) {
+  }
+
+  // Feeds bytes into the parser. `emit` is called once per accepted flash
+  // block with a Block whose payload points into the parser's buffer; it must
+  // return false to abort (reported as EmitFailed).
+  // Returns Ok while more blocks are expected, Complete when the block with
+  // number num_blocks-1 has been processed, or an error. After an error or
+  // Complete the parser must be reset before reuse.
+  template <typename Emit>
+  constexpr Result push(etl::span<const uint8_t> bytes, Emit &&emit) {
+    for (const uint8_t byte : bytes) {
+      buffer_[buffer_pos_++] = byte;
+      if (buffer_pos_ == BLOCK_SIZE) {
+        buffer_pos_ = 0;
+        const Result result = process_block(emit);
+        if (result != Result::Ok) {
+          return result;
+        }
+        if (complete_) {
+          return Result::Complete;
+        }
+      }
+    }
+    return Result::Ok;
+  }
+
+  constexpr bool is_complete() const {
+    return complete_;
+  }
+
+  // Number of payload bytes emitted so far.
+  constexpr uint32_t bytes_emitted() const {
+    return bytes_emitted_;
+  }
+
+  constexpr void reset() {
+    buffer_pos_ = 0;
+    next_block_no_ = 0;
+    bytes_emitted_ = 0;
+    complete_ = false;
+  }
+
+private:
+  constexpr uint32_t read_u32(size_t offset) const {
+    return static_cast<uint32_t>(buffer_[offset]) |
+           (static_cast<uint32_t>(buffer_[offset + 1]) << 8) |
+           (static_cast<uint32_t>(buffer_[offset + 2]) << 16) |
+           (static_cast<uint32_t>(buffer_[offset + 3]) << 24);
+  }
+
+  template <typename Emit> constexpr Result process_block(Emit &emit) {
+    if (read_u32(0) != MAGIC_START_0 || read_u32(4) != MAGIC_START_1 ||
+        read_u32(BLOCK_SIZE - 4) != MAGIC_END) {
+      return Result::BadMagic;
+    }
+
+    const uint32_t flags = read_u32(8);
+    const uint32_t target_addr = read_u32(12);
+    const uint32_t payload_size = read_u32(16);
+    const uint32_t block_no = read_u32(20);
+    const uint32_t num_blocks = read_u32(24);
+    const uint32_t family_id = read_u32(28);
+
+    if ((flags & FLAG_FAMILY_ID_PRESENT) == 0) {
+      return Result::WrongFamily;
+    }
+
+    if (family_id != FAMILY_RP2350_ARM_S ||
+        (flags & FLAG_NOT_MAIN_FLASH) != 0) {
+      // Skip foreign-family blocks such as the RP2350-A2 erratum "absolute"
+      // block at 0x10FFFF00. These carry their own block numbering, so they
+      // do not participate in the sequence/completion tracking below.
+      return Result::Ok;
+    }
+
+    if (block_no != next_block_no_ || block_no >= num_blocks) {
+      return Result::NonSequential;
+    }
+    next_block_no_++;
+    if (block_no + 1 == num_blocks) {
+      complete_ = true;
+    }
+
+    if (payload_size != PAYLOAD_SIZE) {
+      return Result::BadPayloadSize;
+    }
+    if (target_addr < FLASH_BASE ||
+        target_addr + PAYLOAD_SIZE > FLASH_BASE + partition_size_) {
+      return Result::OutOfRange;
+    }
+
+    const Block block{
+        .flash_offset = target_addr - FLASH_BASE + target_offset_,
+        .payload = etl::span<const uint8_t>{buffer_.data() + 32, PAYLOAD_SIZE},
+        .block_no = block_no,
+        .num_blocks = num_blocks,
+    };
+    if (!emit(block)) {
+      return Result::EmitFailed;
+    }
+    bytes_emitted_ += PAYLOAD_SIZE;
+    return Result::Ok;
+  }
+
+  uint32_t target_offset_;
+  uint32_t partition_size_;
+  etl::array<uint8_t, BLOCK_SIZE> buffer_{};
+  size_t buffer_pos_ = 0;
+  uint32_t next_block_no_ = 0;
+  uint32_t bytes_emitted_ = 0;
+  bool complete_ = false;
+};
+
+} // namespace musin::flash
+
+#endif /* end of include guard: MUSIN_FLASH_UF2_PARSER_H_QX3VN2LM */

--- a/test/drum/CMakeLists.txt
+++ b/test/drum/CMakeLists.txt
@@ -64,7 +64,24 @@ target_link_libraries(drum-test-swing PRIVATE
     etl::etl
 )
 
+# Test target: Firmware Update SysEx protocol (uses inline FakeWriter)
+add_executable(drum-test-firmware-update
+    firmware_update_test.cpp
+)
+
+target_include_directories(drum-test-firmware-update PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../musin/include_overrides
+    ${CMAKE_CURRENT_LIST_DIR}/../../
+    ${CMAKE_CURRENT_LIST_DIR}/../
+)
+
+target_link_libraries(drum-test-firmware-update PRIVATE
+    Catch2::Catch2WithMain
+    etl::etl
+)
+
 include(CTest)
 include(Catch)
 catch_discover_tests(drum-test-storage)
 catch_discover_tests(drum-test-swing)
+catch_discover_tests(drum-test-firmware-update)

--- a/test/drum/firmware_update_test.cpp
+++ b/test/drum/firmware_update_test.cpp
@@ -1,0 +1,307 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#include "etl/span.h"
+#include "etl/vector.h"
+
+#include "musin/hal/null_logger.h"
+
+#include "drum/sysex/firmware_update.h"
+
+absolute_time_t mock_current_time = 0;
+
+namespace {
+
+struct FakeWriter {
+  bool begin_ok = true;
+  bool write_ok = true;
+  bool finalize_ok = true;
+
+  uint32_t begun_size = 0;
+  std::vector<uint8_t> begun_sha;
+  std::vector<uint8_t> written;
+  int abort_count = 0;
+  int finalize_count = 0;
+
+  bool begin(uint32_t total_size, etl::span<const uint8_t> sha256) {
+    begun_size = total_size;
+    begun_sha.assign(sha256.begin(), sha256.end());
+    written.clear();
+    return begin_ok;
+  }
+
+  bool write(etl::span<const uint8_t> bytes) {
+    if (!write_ok) {
+      return false;
+    }
+    written.insert(written.end(), bytes.begin(), bytes.end());
+    return true;
+  }
+
+  bool finalize() {
+    finalize_count++;
+    return finalize_ok;
+  }
+
+  void abort() {
+    abort_count++;
+  }
+};
+
+using Update = sysex::FirmwareUpdate<FakeWriter>;
+using Result = Update::Result;
+using Tag = Update::Tag;
+
+struct MockSender {
+  etl::vector<uint8_t, 16> sent;
+  void operator()(uint8_t tag) {
+    sent.push_back(tag);
+  }
+  uint8_t last() const {
+    return sent.back();
+  }
+};
+
+const std::vector<uint8_t> HEADER = {0x00, 0x22, 0x01, 0x65};
+
+std::vector<uint8_t> encode_8_to_7(const std::vector<uint8_t> &data) {
+  std::vector<uint8_t> out;
+  for (size_t i = 0; i < data.size(); i += 7) {
+    uint8_t msbs = 0;
+    size_t group = std::min<size_t>(7, data.size() - i);
+    // The decoder consumes full 8-byte groups only; pad the final group.
+    for (size_t j = 0; j < 7; ++j) {
+      const uint8_t byte = (j < group) ? data[i + j] : 0;
+      out.push_back(byte & 0x7F);
+      msbs |= static_cast<uint8_t>((byte >> 7) & 0x01) << j;
+    }
+    out.push_back(msbs);
+  }
+  return out;
+}
+
+std::vector<uint8_t> encode_3_to_16bit(const std::vector<uint8_t> &bytes) {
+  std::vector<uint8_t> out;
+  for (size_t i = 0; i < bytes.size(); i += 2) {
+    const uint16_t value =
+        static_cast<uint16_t>(bytes[i]) |
+        (i + 1 < bytes.size() ? static_cast<uint16_t>(bytes[i + 1]) << 8 : 0);
+    out.push_back((value >> 14) & 0x7F);
+    out.push_back((value >> 7) & 0x7F);
+    out.push_back(value & 0x7F);
+  }
+  return out;
+}
+
+std::vector<uint8_t> make_begin_chunk(uint32_t total_size,
+                                      uint8_t sha_fill = 0xAB) {
+  std::vector<uint8_t> payload;
+  payload.push_back(total_size & 0xFF);
+  payload.push_back((total_size >> 8) & 0xFF);
+  payload.push_back((total_size >> 16) & 0xFF);
+  payload.push_back((total_size >> 24) & 0xFF);
+  for (int i = 0; i < 32; ++i) {
+    payload.push_back(sha_fill);
+  }
+  payload.push_back(1); // version major
+  payload.push_back(2); // minor
+  payload.push_back(3); // patch
+
+  std::vector<uint8_t> chunk = HEADER;
+  chunk.push_back(Tag::BeginFirmwareUpdate);
+  const auto encoded = encode_3_to_16bit(payload);
+  chunk.insert(chunk.end(), encoded.begin(), encoded.end());
+  return chunk;
+}
+
+std::vector<uint8_t> make_bytes_chunk(const std::vector<uint8_t> &data) {
+  std::vector<uint8_t> chunk = HEADER;
+  chunk.push_back(Tag::FirmwareBytes);
+  const auto encoded = encode_8_to_7(data);
+  chunk.insert(chunk.end(), encoded.begin(), encoded.end());
+  return chunk;
+}
+
+std::vector<uint8_t> make_tag_chunk(uint8_t tag) {
+  std::vector<uint8_t> chunk = HEADER;
+  chunk.push_back(tag);
+  return chunk;
+}
+
+struct Fixture {
+  FakeWriter writer;
+  musin::NullLogger logger;
+  Update update{writer, logger};
+  MockSender sender;
+
+  Result handle(const std::vector<uint8_t> &chunk, absolute_time_t now = 0) {
+    return update.handle_chunk(sysex::Chunk{chunk.data(), chunk.size()}, sender,
+                               now);
+  }
+};
+
+} // namespace
+
+TEST_CASE("FirmwareUpdate full transfer happy path") {
+  Fixture f;
+
+  // 14 bytes => two 7-byte encode groups, no padding ambiguity
+  const std::vector<uint8_t> firmware = {0x00, 0x80, 0xFF, 0x7F, 0x01,
+                                         0x02, 0x03, 0x10, 0x20, 0x30,
+                                         0x40, 0x50, 0x60, 0x70};
+
+  REQUIRE(f.handle(make_begin_chunk(firmware.size())) == Result::OK);
+  REQUIRE(f.sender.last() == Tag::Ack);
+  REQUIRE(f.update.busy());
+  REQUIRE(f.writer.begun_size == firmware.size());
+  REQUIRE(f.writer.begun_sha == std::vector<uint8_t>(32, 0xAB));
+
+  REQUIRE(f.handle(make_bytes_chunk(firmware)) == Result::OK);
+  REQUIRE(f.sender.last() == Tag::Ack);
+  REQUIRE(f.writer.written == firmware);
+  REQUIRE(f.update.bytes_received() == firmware.size());
+
+  REQUIRE(f.handle(make_tag_chunk(Tag::EndFirmwareUpdate)) ==
+          Result::UpdateReady);
+  REQUIRE(f.sender.last() == Tag::Ack);
+  REQUIRE(f.writer.finalize_count == 1);
+  REQUIRE_FALSE(f.update.busy());
+}
+
+TEST_CASE("FirmwareUpdate tolerates codec padding in the final group") {
+  Fixture f;
+  // 10 bytes is not a multiple of 7, so the encoded stream carries 4 padding
+  // bytes in its final 8-byte group.
+  const std::vector<uint8_t> firmware(10, 0x42);
+  REQUIRE(f.handle(make_begin_chunk(firmware.size())) == Result::OK);
+  REQUIRE(f.handle(make_bytes_chunk(firmware)) == Result::OK);
+  REQUIRE(f.sender.last() == Tag::Ack);
+  REQUIRE(f.writer.written == firmware);
+  REQUIRE(f.handle(make_tag_chunk(Tag::EndFirmwareUpdate)) ==
+          Result::UpdateReady);
+}
+
+TEST_CASE("FirmwareUpdate rejects Begin with zero size") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(0)) == Result::WriteError);
+  REQUIRE(f.sender.last() == Tag::Nack);
+  REQUIRE_FALSE(f.update.busy());
+}
+
+TEST_CASE("FirmwareUpdate rejects Begin when writer refuses") {
+  Fixture f;
+  f.writer.begin_ok = false;
+  REQUIRE(f.handle(make_begin_chunk(1024)) == Result::WriteError);
+  REQUIRE(f.sender.last() == Tag::Nack);
+}
+
+TEST_CASE("FirmwareUpdate rejects truncated Begin payload") {
+  Fixture f;
+  std::vector<uint8_t> chunk = HEADER;
+  chunk.push_back(Tag::BeginFirmwareUpdate);
+  const auto encoded = encode_3_to_16bit({0x00, 0x04}); // only 2 bytes
+  chunk.insert(chunk.end(), encoded.begin(), encoded.end());
+  REQUIRE(f.handle(chunk) == Result::InvalidContent);
+  REQUIRE(f.sender.last() == Tag::Nack);
+}
+
+TEST_CASE("FirmwareUpdate rejects bytes without Begin") {
+  Fixture f;
+  REQUIRE(f.handle(make_bytes_chunk({1, 2, 3, 4, 5, 6, 7})) ==
+          Result::InvalidContent);
+  REQUIRE(f.sender.last() == Tag::Nack);
+}
+
+TEST_CASE("FirmwareUpdate rejects End without Begin") {
+  Fixture f;
+  REQUIRE(f.handle(make_tag_chunk(Tag::EndFirmwareUpdate)) ==
+          Result::InvalidContent);
+  REQUIRE(f.sender.last() == Tag::Nack);
+}
+
+TEST_CASE("FirmwareUpdate aborts on write failure") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(14)) == Result::OK);
+  f.writer.write_ok = false;
+  REQUIRE(f.handle(make_bytes_chunk(std::vector<uint8_t>(14, 0x55))) ==
+          Result::WriteError);
+  REQUIRE(f.sender.last() == Tag::Nack);
+  REQUIRE(f.writer.abort_count == 1);
+  REQUIRE_FALSE(f.update.busy());
+}
+
+TEST_CASE("FirmwareUpdate rejects overflow beyond announced size") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(7)) == Result::OK);
+  REQUIRE(f.handle(make_bytes_chunk(std::vector<uint8_t>(14, 0x55))) ==
+          Result::WriteError);
+  REQUIRE(f.sender.last() == Tag::Nack);
+  REQUIRE(f.writer.abort_count == 1);
+}
+
+TEST_CASE("FirmwareUpdate Nacks End on size mismatch") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(28)) == Result::OK);
+  REQUIRE(f.handle(make_bytes_chunk(std::vector<uint8_t>(14, 0x55))) ==
+          Result::OK);
+  REQUIRE(f.handle(make_tag_chunk(Tag::EndFirmwareUpdate)) ==
+          Result::WriteError);
+  REQUIRE(f.sender.last() == Tag::Nack);
+  REQUIRE(f.writer.abort_count == 1);
+}
+
+TEST_CASE("FirmwareUpdate Nacks End when verification fails") {
+  Fixture f;
+  f.writer.finalize_ok = false;
+  REQUIRE(f.handle(make_begin_chunk(14)) == Result::OK);
+  REQUIRE(f.handle(make_bytes_chunk(std::vector<uint8_t>(14, 0x55))) ==
+          Result::OK);
+  REQUIRE(f.handle(make_tag_chunk(Tag::EndFirmwareUpdate)) ==
+          Result::WriteError);
+  REQUIRE(f.sender.last() == Tag::Nack);
+}
+
+TEST_CASE("FirmwareUpdate host abort returns to idle") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(14)) == Result::OK);
+  REQUIRE(f.handle(make_tag_chunk(Tag::AbortFirmwareUpdate)) ==
+          Result::Aborted);
+  REQUIRE(f.sender.last() == Tag::Ack);
+  REQUIRE(f.writer.abort_count == 1);
+  REQUIRE_FALSE(f.update.busy());
+}
+
+TEST_CASE("FirmwareUpdate restarts on Begin during active transfer") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(14)) == Result::OK);
+  REQUIRE(f.handle(make_begin_chunk(28)) == Result::OK);
+  REQUIRE(f.writer.abort_count == 1);
+  REQUIRE(f.writer.begun_size == 28);
+  REQUIRE(f.update.busy());
+}
+
+TEST_CASE("FirmwareUpdate times out after inactivity") {
+  Fixture f;
+  REQUIRE(f.handle(make_begin_chunk(14), 0) == Result::OK);
+  REQUIRE_FALSE(f.update.check_timeout(Update::TIMEOUT_US));
+  REQUIRE(f.update.check_timeout(Update::TIMEOUT_US + 1));
+  REQUIRE(f.writer.abort_count == 1);
+  REQUIRE_FALSE(f.update.busy());
+}
+
+TEST_CASE("FirmwareUpdate claims only its tags") {
+  const auto begin = make_begin_chunk(14);
+  REQUIRE(Update::claims(sysex::Chunk{begin.data(), begin.size()}));
+
+  std::vector<uint8_t> file_bytes = HEADER;
+  file_bytes.push_back(0x11); // existing FileBytes tag
+  REQUIRE_FALSE(
+      Update::claims(sysex::Chunk{file_bytes.data(), file_bytes.size()}));
+
+  std::vector<uint8_t> wrong_mfr = {0x00, 0x21, 0x6B, 0x00,
+                                    Tag::BeginFirmwareUpdate};
+  REQUIRE_FALSE(
+      Update::claims(sysex::Chunk{wrong_mfr.data(), wrong_mfr.size()}));
+}

--- a/test/musin/CMakeLists.txt
+++ b/test/musin/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../../lib/test/Catch2 ${CMAKE_CURRENT
 
 add_executable(${PROJECT_NAME}
   audio/pitch_shifter_test.cpp
+  flash/uf2_parser_test.cpp
   audio/memory_reader_test.cpp
   midi/midi_message_queue_test.cpp
   timing/tempo_handler_test.cpp

--- a/test/musin/flash/uf2_parser_test.cpp
+++ b/test/musin/flash/uf2_parser_test.cpp
@@ -1,0 +1,222 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#include "etl/span.h"
+#include "etl/vector.h"
+
+#include "musin/flash/uf2_parser.h"
+
+using musin::flash::Uf2Parser;
+using Result = Uf2Parser::Result;
+
+namespace {
+
+constexpr uint32_t PARTITION_OFFSET = 0x100000; // Firmware B
+constexpr uint32_t PARTITION_SIZE = 0x100000;   // 1 MiB
+
+void write_u32(std::vector<uint8_t> &out, size_t offset, uint32_t value) {
+  out[offset] = value & 0xFF;
+  out[offset + 1] = (value >> 8) & 0xFF;
+  out[offset + 2] = (value >> 16) & 0xFF;
+  out[offset + 3] = (value >> 24) & 0xFF;
+}
+
+std::vector<uint8_t>
+make_block(uint32_t block_no, uint32_t num_blocks, uint32_t target_addr,
+           uint32_t family = Uf2Parser::FAMILY_RP2350_ARM_S,
+           uint32_t flags = Uf2Parser::FLAG_FAMILY_ID_PRESENT,
+           uint32_t payload_size = Uf2Parser::PAYLOAD_SIZE) {
+  std::vector<uint8_t> block(Uf2Parser::BLOCK_SIZE, 0);
+  write_u32(block, 0, Uf2Parser::MAGIC_START_0);
+  write_u32(block, 4, Uf2Parser::MAGIC_START_1);
+  write_u32(block, 8, flags);
+  write_u32(block, 12, target_addr);
+  write_u32(block, 16, payload_size);
+  write_u32(block, 20, block_no);
+  write_u32(block, 24, num_blocks);
+  write_u32(block, 28, family);
+  for (size_t i = 0; i < Uf2Parser::PAYLOAD_SIZE; ++i) {
+    block[32 + i] = static_cast<uint8_t>((block_no + i) & 0xFF);
+  }
+  write_u32(block, Uf2Parser::BLOCK_SIZE - 4, Uf2Parser::MAGIC_END);
+  return block;
+}
+
+struct EmittedBlock {
+  uint32_t flash_offset;
+  uint8_t first_byte;
+};
+
+struct Collector {
+  std::vector<EmittedBlock> blocks;
+  bool accept = true;
+
+  bool operator()(const Uf2Parser::Block &block) {
+    blocks.push_back({block.flash_offset, block.payload[0]});
+    return accept;
+  }
+};
+
+} // namespace
+
+TEST_CASE("Uf2Parser accepts a well-formed stream and rebases addresses") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+
+  auto block0 = make_block(0, 2, 0x10000000);
+  auto block1 = make_block(1, 2, 0x10000100);
+
+  REQUIRE(parser.push(etl::span<const uint8_t>{block0.data(), block0.size()},
+                      collector) == Result::Ok);
+  REQUIRE_FALSE(parser.is_complete());
+  REQUIRE(parser.push(etl::span<const uint8_t>{block1.data(), block1.size()},
+                      collector) == Result::Complete);
+  REQUIRE(parser.is_complete());
+
+  REQUIRE(collector.blocks.size() == 2);
+  REQUIRE(collector.blocks[0].flash_offset == PARTITION_OFFSET);
+  REQUIRE(collector.blocks[1].flash_offset == PARTITION_OFFSET + 0x100);
+  REQUIRE(parser.bytes_emitted() == 2 * Uf2Parser::PAYLOAD_SIZE);
+}
+
+TEST_CASE("Uf2Parser handles arbitrary chunk boundaries") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+
+  std::vector<uint8_t> stream = make_block(0, 2, 0x10000000);
+  auto block1 = make_block(1, 2, 0x10000100);
+  stream.insert(stream.end(), block1.begin(), block1.end());
+
+  // Feed in uneven slices that straddle block boundaries.
+  size_t pos = 0;
+  Result last = Result::Ok;
+  const size_t slice_sizes[] = {1, 7, 300, 511, 200, 5};
+  size_t slice_index = 0;
+  while (pos < stream.size()) {
+    const size_t n =
+        std::min(slice_sizes[slice_index % 6], stream.size() - pos);
+    slice_index++;
+    last = parser.push(etl::span<const uint8_t>{stream.data() + pos, n},
+                       collector);
+    REQUIRE((last == Result::Ok || last == Result::Complete));
+    pos += n;
+  }
+  REQUIRE(last == Result::Complete);
+  REQUIRE(collector.blocks.size() == 2);
+}
+
+TEST_CASE("Uf2Parser skips the erratum absolute block") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+
+  // picotool places the absolute-family erratum block (targeting 0x10FFFF00,
+  // outside any partition) first in the stream, with its OWN block numbering;
+  // the main image's numbering restarts at 0 afterwards.
+  auto abs_block = make_block(0, 2, 0x10FFFF00, Uf2Parser::FAMILY_ABSOLUTE);
+  auto fw_block = make_block(0, 1, 0x10000000);
+
+  REQUIRE(
+      parser.push(etl::span<const uint8_t>{abs_block.data(), abs_block.size()},
+                  collector) == Result::Ok);
+  REQUIRE(collector.blocks.empty());
+  REQUIRE(
+      parser.push(etl::span<const uint8_t>{fw_block.data(), fw_block.size()},
+                  collector) == Result::Complete);
+  REQUIRE(collector.blocks.size() == 1);
+  REQUIRE(parser.bytes_emitted() == Uf2Parser::PAYLOAD_SIZE);
+}
+
+TEST_CASE("Uf2Parser rejects bad magics") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  auto block = make_block(0, 1, 0x10000000);
+  block[0] ^= 0xFF;
+  REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                      collector) == Result::BadMagic);
+}
+
+TEST_CASE("Uf2Parser rejects blocks without family ID") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  auto block = make_block(0, 1, 0x10000000, Uf2Parser::FAMILY_RP2350_ARM_S, 0);
+  REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                      collector) == Result::WrongFamily);
+}
+
+TEST_CASE("Uf2Parser skips not-main-flash blocks") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  auto block = make_block(0, 2, 0x10000000, Uf2Parser::FAMILY_RP2350_ARM_S,
+                          Uf2Parser::FLAG_FAMILY_ID_PRESENT |
+                              Uf2Parser::FLAG_NOT_MAIN_FLASH);
+  REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                      collector) == Result::Ok);
+  REQUIRE(collector.blocks.empty());
+}
+
+TEST_CASE("Uf2Parser rejects out-of-range targets") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+
+  SECTION("below flash base") {
+    auto block = make_block(0, 1, 0x0FFFFF00);
+    REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                        collector) == Result::OutOfRange);
+  }
+  SECTION("beyond partition size") {
+    auto block = make_block(0, 1, 0x10000000 + PARTITION_SIZE);
+    REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                        collector) == Result::OutOfRange);
+  }
+  SECTION("straddling the partition end") {
+    auto block = make_block(0, 1, 0x10000000 + PARTITION_SIZE - 0x80);
+    REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                        collector) == Result::OutOfRange);
+  }
+}
+
+TEST_CASE("Uf2Parser rejects non-sequential block numbers") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  auto block0 = make_block(0, 3, 0x10000000);
+  auto block2 = make_block(2, 3, 0x10000200);
+  REQUIRE(parser.push(etl::span<const uint8_t>{block0.data(), block0.size()},
+                      collector) == Result::Ok);
+  REQUIRE(parser.push(etl::span<const uint8_t>{block2.data(), block2.size()},
+                      collector) == Result::NonSequential);
+}
+
+TEST_CASE("Uf2Parser rejects unexpected payload sizes") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  auto block = make_block(0, 1, 0x10000000, Uf2Parser::FAMILY_RP2350_ARM_S,
+                          Uf2Parser::FLAG_FAMILY_ID_PRESENT, 128);
+  REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                      collector) == Result::BadPayloadSize);
+}
+
+TEST_CASE("Uf2Parser reports emit failure") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  collector.accept = false;
+  auto block = make_block(0, 1, 0x10000000);
+  REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                      collector) == Result::EmitFailed);
+}
+
+TEST_CASE("Uf2Parser reset allows reuse after error") {
+  Uf2Parser parser(PARTITION_OFFSET, PARTITION_SIZE);
+  Collector collector;
+  auto bad = make_block(0, 1, 0x10000000);
+  bad[0] ^= 0xFF;
+  REQUIRE(parser.push(etl::span<const uint8_t>{bad.data(), bad.size()},
+                      collector) == Result::BadMagic);
+
+  parser.reset();
+  auto good = make_block(0, 1, 0x10000000);
+  REQUIRE(parser.push(etl::span<const uint8_t>{good.data(), good.size()},
+                      collector) == Result::Complete);
+  REQUIRE(parser.bytes_emitted() == Uf2Parser::PAYLOAD_SIZE);
+}

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -53,6 +53,16 @@ const FORMAT_FILESYSTEM = 0x15;
 const CUSTOM_ACK = 0x13;
 const CUSTOM_NACK = 0x14;
 
+// Firmware Update Commands (UF2 streamed to the inactive A/B partition)
+const BEGIN_FIRMWARE_UPDATE = 0x20;
+const FIRMWARE_BYTES = 0x21;
+const END_FIRMWARE_UPDATE = 0x22;
+const ABORT_FIRMWARE_UPDATE = 0x23;
+// Decoded bytes per FirmwareBytes message; must be a multiple of 7 so each
+// message contains whole 8-byte encoded groups.
+const FIRMWARE_CHUNK_SIZE = 7 * 146; // 1022 bytes
+const FIRMWARE_ACK_TIMEOUT = 5000;
+
 // Find and connect to DRUM device
 function find_dato_drum() {
   const output = new midi.Output();
@@ -380,6 +390,102 @@ async function reboot_bootloader() {
   sendCustomMessage(payload);
   // Note: Device will reboot immediately, so we don't wait for ACK
   console.log("Reboot command sent. Device should now enter bootloader mode.");
+}
+
+// --- Firmware update over SysEx ---
+
+// Packs 8-bit data into SysEx-safe 8-byte groups: 7 data bytes (low 7 bits)
+// followed by one byte carrying the MSBs. Mirrors codec::decode_8_to_7 in the
+// firmware. The final group is zero-padded; the device ignores the padding.
+function encode8to7(data) {
+  const out = [];
+  for (let i = 0; i < data.length; i += 7) {
+    let msbs = 0;
+    for (let j = 0; j < 7; j++) {
+      const byte = i + j < data.length ? data[i + j] : 0;
+      out.push(byte & 0x7F);
+      msbs |= ((byte >> 7) & 0x01) << j;
+    }
+    out.push(msbs);
+  }
+  return out;
+}
+
+// Encodes raw bytes as 16-bit values, 3 SysEx bytes per value (matches
+// codec::decode_3_to_16bit in the firmware). Used for the Begin payload.
+function encode3to16(bytes) {
+  const out = [];
+  for (let i = 0; i < bytes.length; i += 2) {
+    const value = bytes[i] | ((i + 1 < bytes.length ? bytes[i + 1] : 0) << 8);
+    out.push((value >> 14) & 0x7F, (value >> 7) & 0x7F, value & 0x7F);
+  }
+  return out;
+}
+
+const UF2_MAGIC_START_0 = 0x0A324655;
+const UF2_BLOCK_SIZE = 512;
+
+async function flash_firmware(filePath) {
+  const crypto = require('crypto');
+  const uf2 = fs.readFileSync(filePath);
+
+  if (uf2.length === 0 || uf2.length % UF2_BLOCK_SIZE !== 0) {
+    throw new Error(`${filePath} is not a UF2 file (size not a multiple of 512).`);
+  }
+  if (uf2.readUInt32LE(0) !== UF2_MAGIC_START_0) {
+    throw new Error(`${filePath} is not a UF2 file (bad magic).`);
+  }
+
+  const sha256 = crypto.createHash('sha256').update(uf2).digest();
+  console.log(`Firmware: ${filePath} (${uf2.length} bytes, ${uf2.length / UF2_BLOCK_SIZE} UF2 blocks)`);
+  console.log(`SHA-256:  ${sha256.toString('hex')}`);
+
+  try {
+    await get_firmware_version();
+  } catch (e) {
+    console.log('Could not read current firmware version, continuing anyway.');
+  }
+
+  // Begin: total size (32-bit LE) + SHA-256 + version placeholder (the device
+  // treats the version as informational).
+  const beginPayload = [
+    uf2.length & 0xFF, (uf2.length >> 8) & 0xFF,
+    (uf2.length >> 16) & 0xFF, (uf2.length >> 24) & 0xFF,
+    ...sha256, 0, 0, 0,
+  ];
+  sendCustomMessage([BEGIN_FIRMWARE_UPDATE, ...encode3to16(beginPayload)]);
+  await waitForCustomAck(FIRMWARE_ACK_TIMEOUT);
+  console.log('Device accepted firmware update, streaming...');
+
+  const startTime = Date.now();
+  try {
+    for (let offset = 0; offset < uf2.length; offset += FIRMWARE_CHUNK_SIZE) {
+      const chunk = uf2.subarray(offset, Math.min(offset + FIRMWARE_CHUNK_SIZE, uf2.length));
+      sendCustomMessage([FIRMWARE_BYTES, ...encode8to7(chunk)]);
+      await waitForCustomAck(FIRMWARE_ACK_TIMEOUT);
+
+      const done = Math.min(offset + FIRMWARE_CHUNK_SIZE, uf2.length);
+      const percent = Math.floor((done / uf2.length) * 100);
+      const barLength = 30;
+      const filled = Math.floor((done / uf2.length) * barLength);
+      const bar = '█'.repeat(filled) + '░'.repeat(barLength - filled);
+      process.stdout.write(`\r[${bar}] ${percent}% (${done}/${uf2.length} bytes)`);
+    }
+  } catch (e) {
+    process.stdout.write('\n');
+    sendCustomMessage([ABORT_FIRMWARE_UPDATE]);
+    throw new Error(`Transfer failed: ${e.message}`);
+  }
+  process.stdout.write('\n');
+
+  sendCustomMessage([END_FIRMWARE_UPDATE]);
+  await waitForCustomAck(FIRMWARE_ACK_TIMEOUT);
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`Firmware verified by device in ${elapsed}s.`);
+  console.log('Device is rebooting into the new firmware for a trial boot.');
+  console.log('It commits the update automatically after a few seconds of healthy operation.');
+  console.log("Run 'drumtool.js version' after the device reconnects to confirm.");
 }
 
 // Test universal SysEx identity request
@@ -941,6 +1047,7 @@ if (!command) {
   console.log("  drumtool.js format");
   console.log("  drumtool.js reboot-bootloader");
   console.log("  drumtool.js identity");
+  console.log("  drumtool.js flash <firmware.uf2>");
   console.log("");
   console.log("Commands:");
   console.log("  send           - Transfer audio samples (WAV or raw PCM) using SDS protocol");
@@ -949,6 +1056,7 @@ if (!command) {
   console.log("  format         - Format device filesystem");
   console.log("  reboot-bootloader - Reboot device into bootloader mode");
   console.log("  identity       - Test universal SysEx identity request");
+  console.log("  flash          - Update firmware over MIDI (A/B partition, auto-revert on failure)");
   console.log("");
   console.log("Send Arguments:");
   console.log("  file:slot      - Audio file path and target slot (0-127)");
@@ -1035,9 +1143,19 @@ async function main() {
         console.error(`Error: ${error.message}`);
         process.exit(1);
       }
+    } else if (command === 'flash') {
+      const file = process.argv[3];
+      if (!file) {
+        console.error("Error: 'flash' command requires a firmware .uf2 file argument.");
+        process.exit(1);
+      }
+      if (!fs.existsSync(file)) {
+        console.error(`Error: File not found: ${file}`);
+        process.exit(1);
+      }
     } else if (command !== 'version' && command !== 'storage' && command !== 'format' &&
                command !== 'reboot-bootloader' && command !== 'identity') {
-      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', or 'identity'.`);
+      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', or 'flash'.`);
       process.exit(1);
     }
 
@@ -1073,6 +1191,8 @@ async function main() {
       await reboot_bootloader();
     } else if (command === 'identity') {
       await test_universal_identity();
+    } else if (command === 'flash') {
+      await flash_firmware(process.argv[3]);
     }
   } catch (error) {
     console.error(`\nError: ${error.message}`);


### PR DESCRIPTION
## What

Adds over-MIDI firmware updates so the DRUM can be updated from a browser (WebMIDI) without entering the bootloader. The host streams the standard `.uf2` build artifact over new SysEx commands into the **inactive** A/B partition; the device verifies it with the RP2350 hardware SHA-256 and reboots into the new image using the bootrom's flash-update **try-before-you-buy** mechanism.

## Why

We want a firmware update flow on the Dato website. The hard requirement is that the device cannot be bricked: the running partition is never written, and an image that crashes or hangs before committing itself (`rom_explicit_buy` after 5 s of healthy main-loop operation) is ignored on the next boot, falling back to the previous firmware. If both partitions are ever invalid, the bootrom drops to the USB UF2 bootloader.

## How it works

1. `BeginFirmwareUpdate` (0x20): total size + SHA-256 + version → device resolves the inactive partition via `rom_get_boot_info`, Ack/Nack
2. `FirmwareBytes` (0x21): 7-bit-packed UF2 stream → parsed incrementally, rebased to the target partition, programmed one 4 KiB sector at a time (IRQs disabled, watchdog fed); Ack is sent **after** flashing so the host self-throttles
3. `EndFirmwareUpdate` (0x22): completeness + SHA-256 check → `rom_reboot(FLASH_UPDATE)` trial boot
4. New firmware buys itself after 5 s healthy operation (`drum/firmware_update_buyer`); `Begin` is Nacked while a trial boot is unbought

All images are now built with `PICO_CRT0_IMAGE_TYPE_TBYB=1` and a binary version (`pico_set_binary_version`), so picotool/BOOTSEL loads also self-commit on first boot. Sequencer LEDs fill as a progress bar during transfer; the existing FileTransfer state is reused.

## Notes for review

- `musin/flash/uf2_parser.h` is host-testable and handles a real-world subtlety: the RP2350-A2 erratum "absolute" block carries its **own** block numbering, so sequence/completion tracking only applies to rp2350-arm-s blocks
- Only RAM builds (`PICO_COPY_TO_RAM`, the default) are partition-relocatable; `build.sh` now warns for XIP builds
- `tools/drumtool/drumtool.js flash <firmware.uf2>` is the reference client the browser flow should mirror
- Protocol documented in `drum/README.md`

## Testing

- 26 new host test cases (UF2 parser + protocol state machine), full suite green (48 musin + 28 drum)
- **Verified on hardware:** two consecutive 450 KB updates (A→B then B→A) at ~33 KB/s, SHA verification, trial boot and self-commit confirmed; the second update being accepted proves the first bought itself
- Still outstanding: deliberate failure injection (power-pull mid-transfer, corrupted SHA, intentionally crashing image to observe the revert)