### PR TITLE
refactor: store outgoing SysEx payloads in dedicated queue (saves ~124KB RAM)

### DIFF
--- a/musin/midi/midi_output_queue.cpp
+++ b/musin/midi/midi_output_queue.cpp
@@ -1,8 +1,10 @@
 #include "musin/midi/midi_output_queue.h"
 #include "etl/deque.h"
+#include "etl/queue.h"
 #include "musin/midi/midi_wrapper.h" // For MIDI::internal actual send functions
 #include "pico/sync.h"
 #include "pico/time.h" // For RP2040 specific timing (get_absolute_time, absolute_time_diff_us, is_nil_time)
+#include <algorithm>   // For std::min, std::copy
 #include <cstdio>      // For printf
 #include <optional>
 
@@ -10,6 +12,9 @@ namespace musin::midi {
 
 // Define the global queue instance and its spinlock
 etl::deque<OutgoingMidiMessage, MIDI_QUEUE_SIZE> midi_output_queue;
+// SysEx payloads live here; a SYSTEM_EXCLUSIVE marker in midi_output_queue
+// holds their place in the send order. Both queues share the spinlock.
+static etl::queue<SystemExclusiveData, SYSEX_QUEUE_SIZE> sysex_payload_queue;
 static spin_lock_t *midi_queue_lock =
     spin_lock_init(spin_lock_claim_unused(true));
 
@@ -48,12 +53,42 @@ bool enqueue_midi_message(const OutgoingMidiMessage &message,
   return success;
 }
 
+bool enqueue_sysex_message(const uint8_t *payload, unsigned length,
+                           musin::Logger &logger) {
+  uint32_t irq_status = spin_lock_blocking(midi_queue_lock);
+
+  bool success = false;
+  if (midi_output_queue.full() || sysex_payload_queue.full()) {
+    logger.debug("MIDI queue full - sysex message dropped");
+  } else {
+    sysex_payload_queue.emplace();
+    SystemExclusiveData &slot = sysex_payload_queue.back();
+    if (payload != nullptr) {
+      slot.length = std::min(length, static_cast<unsigned>(MIDI::SysExMaxSize));
+      std::copy(payload, payload + slot.length, slot.data_buffer.begin());
+    } else {
+      slot.length = 0;
+    }
+
+    OutgoingMidiMessage marker;
+    marker.type = MidiMessageType::SYSTEM_EXCLUSIVE;
+    midi_output_queue.push_back(marker);
+    success = true;
+  }
+
+  spin_unlock(midi_queue_lock, irq_status);
+  return success;
+}
+
 // Rate limiting for non-real-time messages
 constexpr uint32_t MIN_INTERVAL_US_NON_REALTIME =
     960; // 3125 bytes per second at 3 bytes each
 static absolute_time_t last_non_realtime_send_time = nil_time;
 
 void process_midi_output_queue(musin::Logger &logger) {
+  // Scratch buffer for the dequeued SysEx payload; processing happens on a
+  // single context, and keeping it static avoids a 2KB stack copy.
+  static SystemExclusiveData sysex_scratch;
   std::optional<OutgoingMidiMessage> message_to_send;
   bool rate_limited = false;
 
@@ -68,6 +103,10 @@ void process_midi_output_queue(musin::Logger &logger) {
               MIN_INTERVAL_US_NON_REALTIME) {
         message_to_send = message_in_queue;
         midi_output_queue.pop_front();
+        if (message_to_send->type == MidiMessageType::SYSTEM_EXCLUSIVE) {
+          sysex_scratch = sysex_payload_queue.front();
+          sysex_payload_queue.pop();
+        }
       } else {
         rate_limited = true;
       }
@@ -113,9 +152,8 @@ void process_midi_output_queue(musin::Logger &logger) {
       // Real-time messages do not update last_non_realtime_send_time
       break;
     case MidiMessageType::SYSTEM_EXCLUSIVE:
-      MIDI::internal::_sendSysEx_actual(
-          message.data.system_exclusive_message.length,
-          message.data.system_exclusive_message.data_buffer.data());
+      MIDI::internal::_sendSysEx_actual(sysex_scratch.length,
+                                        sysex_scratch.data_buffer.data());
       last_non_realtime_send_time = get_absolute_time();
       break;
     }

--- a/musin/midi/midi_output_queue.h
+++ b/musin/midi/midi_output_queue.h
@@ -6,7 +6,6 @@
 #include "midi_common.h"
 #include "midi_wrapper.h" // For MIDI::SysExMaxSize (from musin/midi/midi_wrapper.h)
 #include "musin/hal/logger.h" // Include logger header
-#include <algorithm>          // For std::min, std::copy
 #include <cstdint>
 
 namespace musin::midi {
@@ -14,6 +13,8 @@ namespace musin::midi {
 // Configuration for the MIDI queue
 constexpr size_t MIDI_QUEUE_SIZE =
     64; // Max number of MIDI messages in the queue
+constexpr size_t SYSEX_QUEUE_SIZE =
+    2; // Max number of pending outgoing SysEx payloads
 
 enum class MidiMessageType : uint8_t {
   NOTE_ON,
@@ -24,8 +25,11 @@ enum class MidiMessageType : uint8_t {
   SYSTEM_EXCLUSIVE
 };
 
+// SysEx payloads are large (MIDI::SysExMaxSize bytes), so they are stored in
+// a small dedicated queue instead of the per-message union. A
+// SYSTEM_EXCLUSIVE entry in the main queue marks the payload's position in
+// the send order.
 struct SystemExclusiveData {
-  // Uses MIDI::SysExMaxSize from musin/midi/midi_wrapper.h (which is 128)
   etl::array<uint8_t, MIDI::SysExMaxSize> data_buffer;
   unsigned length;
 };
@@ -37,7 +41,6 @@ struct OutgoingMidiMessage {
     ControlChangeData control_change_message;
     PitchBendData pitch_bend_message;
     SystemRealtimeData system_realtime_message;
-    SystemExclusiveData system_exclusive_message;
 
     // Default constructor for the union.
     // Members will be initialized by the OutgoingMidiMessage constructors.
@@ -76,28 +79,18 @@ struct OutgoingMidiMessage {
     data.pitch_bend_message.channel = ch;
     data.pitch_bend_message.bend_value = pb_val;
   }
-
-  OutgoingMidiMessage(const uint8_t *sysex_payload, unsigned len)
-      : type(MidiMessageType::SYSTEM_EXCLUSIVE) {
-    // Ensure length does not exceed the buffer size defined by
-    // MIDI::SysExMaxSize from midi_wrapper.h
-    data.system_exclusive_message.length =
-        std::min(len, static_cast<unsigned>(MIDI::SysExMaxSize));
-    if (sysex_payload != nullptr) { // Check for null payload
-      std::copy(sysex_payload,
-                sysex_payload + data.system_exclusive_message.length,
-                data.system_exclusive_message.data_buffer.begin());
-    } else {
-      // If payload is null, ensure length is 0 to avoid copying garbage
-      data.system_exclusive_message.length = 0;
-    }
-  }
 };
 
 extern etl::deque<OutgoingMidiMessage, MIDI_QUEUE_SIZE> midi_output_queue;
 
 bool enqueue_midi_message(const OutgoingMidiMessage &message,
                           musin::Logger &logger);
+
+// Copies the payload into the dedicated SysEx queue and enqueues a
+// SYSTEM_EXCLUSIVE marker to preserve send ordering. Payloads longer than
+// MIDI::SysExMaxSize are truncated; a null payload is sent as length 0.
+bool enqueue_sysex_message(const uint8_t *payload, unsigned length,
+                           musin::Logger &logger);
 
 void process_midi_output_queue(musin::Logger &logger);
 

--- a/musin/ports/pico/port/midi_wrapper.cpp
+++ b/musin/ports/pico/port/midi_wrapper.cpp
@@ -148,13 +148,7 @@ void MIDI::sendPitchBend(const int bend, const byte channel) {
 }
 
 void MIDI::sendSysEx(const unsigned length, const byte *bytes) {
-  // printf("Enqueuing SysEx message (%u bytes): ", length);
-  // for (unsigned i = 0; i < length; ++i) {
-  //   printf("%02X ", bytes[i]);
-  // }
-  // printf("\n");
-  musin::midi::OutgoingMidiMessage msg(bytes, length);
-  musin::midi::enqueue_midi_message(msg, midi_send_logger);
+  musin::midi::enqueue_sysex_message(bytes, length, midi_send_logger);
 }
 
 // --- Internal Actual Send Functions (Called by Queue Processor) ---

--- a/test/musin/midi/midi_message_queue_test.cpp
+++ b/test/musin/midi/midi_message_queue_test.cpp
@@ -212,7 +212,6 @@ TEST_CASE("MidiMessageQueue Tests", "[midi_queue]") {
     OutgoingMidiMessage msg_cc(ch, ctrl, val);
     OutgoingMidiMessage msg_pitch_bend(ch, bend);
     OutgoingMidiMessage msg_rt(rt_type);
-    OutgoingMidiMessage msg_sysex(sysex_payload, sysex_len);
 
     REQUIRE(enqueue_midi_message(msg_note_on, test_logger));
     process_midi_output_queue(test_logger);
@@ -234,7 +233,7 @@ TEST_CASE("MidiMessageQueue Tests", "[midi_queue]") {
     process_midi_output_queue(test_logger);
     // No time advance needed after RT for next non-RT, as RT doesn't affect its timer
 
-    REQUIRE(enqueue_midi_message(msg_sysex, test_logger));
+    REQUIRE(enqueue_sysex_message(sysex_payload, sysex_len, test_logger));
     // SysEx is non-RT. If the previous non-RT was recent, this might be deferred.
     // The previous non-RT was pitch_bend, then RT, so the timer for non-RT is from pitch_bend.
     // We advanced time after pitch_bend, so this should send.
@@ -261,8 +260,7 @@ TEST_CASE("MidiMessageQueue Tests", "[midi_queue]") {
       reset_test_state();
       uint8_t payload[] = {0xF0, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7F, 0x00, 0x41, 0xF7};
       unsigned len = sizeof(payload);
-      OutgoingMidiMessage msg(payload, len);
-      REQUIRE(enqueue_midi_message(msg, test_logger));
+      REQUIRE(enqueue_sysex_message(payload, len, test_logger));
       process_midi_output_queue(test_logger);
       REQUIRE(mock_midi_calls.size() == 1);
       REQUIRE(mock_midi_calls[0] ==
@@ -275,8 +273,7 @@ TEST_CASE("MidiMessageQueue Tests", "[midi_queue]") {
 
     SECTION("Empty SysEx (nullptr payload, zero length in constructor)") {
       reset_test_state();
-      OutgoingMidiMessage msg(nullptr, 0);
-      REQUIRE(enqueue_midi_message(msg, test_logger));
+      REQUIRE(enqueue_sysex_message(nullptr, 0, test_logger));
       process_midi_output_queue(test_logger);
       REQUIRE(mock_midi_calls.size() == 1);
       // Constructor sets length to 0 if payload is nullptr
@@ -293,13 +290,13 @@ TEST_CASE("MidiMessageQueue Tests", "[midi_queue]") {
         long_payload_vec[i] = static_cast<uint8_t>(i);
       }
 
-      OutgoingMidiMessage msg(long_payload_vec.data(),
-                              static_cast<unsigned>(long_payload_vec.size()));
-      REQUIRE(enqueue_midi_message(msg, test_logger));
+      REQUIRE(enqueue_sysex_message(
+          long_payload_vec.data(),
+          static_cast<unsigned>(long_payload_vec.size()), test_logger));
       process_midi_output_queue(test_logger);
 
       REQUIRE(mock_midi_calls.size() == 1);
-      // The constructor of OutgoingMidiMessage truncates.
+      // enqueue_sysex_message truncates to MIDI::SysExMaxSize.
       REQUIRE(mock_midi_calls[0].function_name == "_sendSysEx_actual");
       REQUIRE(mock_midi_calls[0].sysex_length == MIDI::SysExMaxSize);
       REQUIRE(mock_midi_calls[0].sysex_data.size() == MIDI::SysExMaxSize);
@@ -309,11 +306,10 @@ TEST_CASE("MidiMessageQueue Tests", "[midi_queue]") {
                          long_payload_vec.begin(), long_payload_vec.begin() + MIDI::SysExMaxSize));
     }
 
-    SECTION("SysEx with zero length but non-null pointer in constructor") {
+    SECTION("SysEx with zero length but non-null pointer") {
       reset_test_state();
       uint8_t dummy_payload[] = {1, 2, 3}; // Content doesn't matter as length is 0
-      OutgoingMidiMessage msg(dummy_payload, 0);
-      REQUIRE(enqueue_midi_message(msg, test_logger));
+      REQUIRE(enqueue_sysex_message(dummy_payload, 0, test_logger));
       process_midi_output_queue(test_logger);
       REQUIRE(mock_midi_calls.size() == 1);
       REQUIRE(mock_midi_calls[0] ==


### PR DESCRIPTION
## What

The 64-entry MIDI output queue embedded a 2KB SysEx buffer (`SystemExclusiveData`) in every message union slot, costing ~128KB of bss for a queue that mostly holds 3-byte messages. This moves outgoing SysEx payloads into a small dedicated queue (depth 2), mirroring the pattern already used for incoming SysEx in `midi_input_queue`.

- `SystemExclusiveData` removed from the `OutgoingMidiMessage` union; each queue slot shrinks from ~2KB to ~8 bytes
- New `enqueue_sysex_message(payload, length, logger)` copies the payload into the side queue and pushes a `SYSTEM_EXCLUSIVE` marker into the main queue, so FIFO send ordering relative to other messages is preserved exactly
- Both queues share the existing spinlock; enqueue fails if either is full, keeping them in lockstep
- Rate limiting for non-realtime messages is unchanged — SysEx still flows through the same front-of-queue gate
- Truncation to `MIDI::SysExMaxSize` and null-payload→length-0 semantics carried over from the old constructor

## Why

Frees ~124KB of RAM: firmware bss drops from **160300 to 33616 bytes** (text +320 bytes).

## Reviewer notes

- At most 2 SysEx messages can be pending at once; a third is dropped and logged (same depth as the incoming queue). Fine for firmware-update/dump flows, worth knowing if anything bursts SysEx.
- Dequeued payloads are copied into a static scratch buffer in `process_midi_output_queue` to avoid a 2KB stack copy; processing runs on a single context.

## Testing

- `cd test && ./run_all_tests.sh` — all 50 tests pass, SysEx tests updated to the new API (behavior assertions unchanged)
- `drum/build.sh -n` builds clean; bss compared before/after