### PR TITLE
Architecture cleanup: musin/drum layering, SysEx chunk lifetime, SequencerController decomposition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,19 @@ drum/build.sh [options]  # See README.md for full options
 cd test && ./run_all_tests.sh
 ```
 
+### Git Worktrees & Submodules
+Fresh worktrees do **not** have submodules populated; builds and tests fail with missing CMakeLists.txt or headers until they are initialized. Run this first in any new worktree:
+```bash
+# For host tests:
+git submodule update --init --depth 1 lib/etl lib/test/Catch2 \
+  musin/ports/pico/libraries/arduino_midi_library \
+  musin/ports/pico/libraries/Arduino-USBMIDI
+# Additionally, for firmware builds (large download):
+git submodule update --init --recursive --depth 1 \
+  musin/ports/pico/pico-sdk musin/ports/pico/pico-extras \
+  musin/ports/pico/libraries/pico-vfs
+```
+
 ### Code Quality
 - **Pre-commit hooks:** Run `pre-commit` before commits
 - **Conventional commits:** `fix:` `feat:` `refactor:` etc.

--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -55,6 +55,7 @@ set(KIT_BINARY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${KIT_NAME}.bin")
 # The pico toolchain setup will automatically apply the correct compiler flags.
 add_library(${KIT_NAME}_obj OBJECT ${KIT_SRC_CPP})
 target_link_libraries(${KIT_NAME}_obj PRIVATE etl::etl)
+target_include_directories(${KIT_NAME}_obj PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 # 2. Find objcopy
 find_program(OBJCOPY_PATH NAMES arm-none-eabi-objcopy HINTS ENV PICO_TOOLCHAIN_PATH)

--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -32,6 +32,8 @@ add_executable(${EXECUTABLE_NAME}
   sequencer_storage.cpp
   sequencer_effect_swing.cpp
   sequencer_effect_random.cpp
+  sequencer_effect_repeat.cpp
+  sequencer_effect_retrigger.cpp
   save_timing_manager.cpp
   configuration_manager.cpp
   message_router.cpp

--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -133,6 +133,7 @@ target_link_libraries(${EXECUTABLE_NAME} PRIVATE
   musin::usb_midi
   musin::audio
   musin::filesystem
+  pico_rand
 )
 
 # Enable filesystem for the pico (must be done after linking)

--- a/drum/config.h
+++ b/drum/config.h
@@ -3,6 +3,7 @@
 
 #include "etl/array.h"
 #include "etl/span.h"
+#include "musin/ui/drumpad_config.h"
 #include <cstddef>
 #include <cstdint>
 
@@ -68,17 +69,8 @@ namespace drumpad {
 constexpr uint8_t DEFAULT_FALLBACK_NOTE = 36;
 constexpr uint8_t RETRIGGER_VELOCITY = 100;
 
-// Per-pad settings structure
-struct DrumpadConfig {
-  uint16_t noise_threshold;
-  uint16_t trigger_threshold;
-  uint16_t high_pressure_threshold;
-  bool active_low;
-  uint32_t debounce_time_us;
-  uint32_t hold_time_us;
-  uint64_t max_velocity_time_us;
-  uint64_t min_velocity_time_us;
-};
+// Per-pad settings structure (defined by the musin drumpad driver)
+using DrumpadConfig = musin::ui::DrumpadConfig;
 
 // Since all pads are physically identical, we can define a single configuration
 constexpr DrumpadConfig default_drumpad_config = {.noise_threshold = 150,

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -119,6 +119,10 @@ int main() {
     sequencer_controller.init_persistence();
   }
 
+  tempo_handler.set_tempo_control_range(
+      drum::config::analog_controls::MIN_BPM_ADJUST,
+      drum::config::analog_controls::MAX_BPM_ADJUST);
+
   midi_manager.init();
 
   audio_engine.init();

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -47,8 +47,6 @@ static musin::NullLogger logger;
 
 static musin::NullLogger null_logger;
 
-// System State Machine (will be initialized after pizza_display)
-
 // Model
 static drum::ConfigurationManager config_manager(logger);
 static drum::SampleRepository sample_repository(logger);
@@ -59,7 +57,6 @@ static musin::timing::InternalClock internal_clock(120.0f);
 static musin::timing::MidiClockProcessor midi_clock_processor;
 static musin::timing::SyncIn sync_in(DATO_SUBMARINE_SYNC_IN_PIN,
                                      DATO_SUBMARINE_SYNC_DETECT_PIN);
-// SyncIn now handles 2 PPQN to 24 PPQN conversion internally
 static musin::timing::ClockRouter
     clock_router(internal_clock, midi_clock_processor, sync_in,
                  musin::timing::ClockSource::INTERNAL);
@@ -91,7 +88,6 @@ static drum::MidiManager midi_manager(message_router, midi_clock_processor,
 static drum::PizzaDisplay pizza_display(sequencer_controller, tempo_handler,
                                         logger);
 
-// System State Machine (simplified without wrapper)
 static drum::SystemStateMachine system_state_machine(logger);
 
 // Controller
@@ -138,12 +134,7 @@ int main() {
   pizza_display.init();
   pizza_controls.init();
 
-  // Boot animation is now handled by BootState
-  // No circular references needed with simplified approach
-
   // --- Initialize Clocking System ---
-  // TempoHandler's constructor calls set_clock_source, which handles initial
-  // observation. SyncIn is now connected directly via ClockRouter.
   tempo_handler.add_observer(sequencer_controller);
   tempo_handler.add_observer(
       pizza_display); // PizzaDisplay needs tempo events for pulsing
@@ -173,8 +164,7 @@ int main() {
   clock_router.add_observer(midi_clock_out);
   clock_router.add_observer(speed_adapter);
 
-  // SystemStateMachine automatically starts in Boot state
-  // No initialization_complete() call needed
+  // SystemStateMachine starts in Boot state.
 
   // Track state transitions for display management
   drum::SystemStateId previous_state = drum::SystemStateId::Boot;
@@ -244,7 +234,9 @@ int main() {
       internal_clock.update(now);
       clock_router.update_auto_source_switching();
 
-      // ClockRouter handles raw clock routing; SyncOut remains attached
+      // Second drain: process_midi_output_queue sends at most one message
+      // per call, so draining twice per loop halves MIDI output latency
+      // (see #527).
       musin::midi::process_midi_output_queue(null_logger);
       sleep_us(10);
       break;

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -25,6 +25,9 @@ extern "C" {
 }
 
 #include "hardware/watchdog.h"
+#include "pico/rand.h"
+
+#include <cstdlib>
 
 #include "audio_engine.h"
 #include "drum/drum_pizza_hardware.h"
@@ -98,6 +101,10 @@ static drum::PizzaControls pizza_controls(pizza_display, tempo_handler,
 
 int main() {
   stdio_usb_init();
+
+  // Seed rand() from the hardware RNG; seeding from the boot clock in static
+  // constructors produced the same sequence every power-up.
+  srand(get_rand_32());
 
 #ifdef VERBOSE
   musin::usb::init(true); // Wait for serial connection in debug builds

--- a/drum/message_router.cpp
+++ b/drum/message_router.cpp
@@ -16,22 +16,6 @@ namespace drum {
 
 namespace { // Anonymous namespace for internal linkage
 
-void send_midi_cc([[maybe_unused]] const uint8_t channel,
-                  [[maybe_unused]] const uint8_t cc_number,
-                  [[maybe_unused]] const uint8_t value) {
-  // This function is no longer used directly for sending MIDI CCs from
-  // MessageRouter as MidiSender will handle it.
-  // MIDI::sendControlChange(cc_number, value, channel);
-}
-
-void send_midi_note([[maybe_unused]] const uint8_t channel,
-                    [[maybe_unused]] const uint8_t note_number,
-                    [[maybe_unused]] const uint8_t velocity) {
-  // This function is no longer used directly for sending MIDI notes from
-  // MessageRouter as MidiSender will handle it. MIDI::sendNoteOn(note_number,
-  // velocity, channel);
-}
-
 struct ParameterMapping {
   Parameter param_id;
   std::optional<uint8_t> track_index;

--- a/drum/midi_manager.cpp
+++ b/drum/midi_manager.cpp
@@ -45,11 +45,15 @@ void MidiManager::init() {
 void MidiManager::process_input() {
   MIDI::read();
 
+  while (const sysex::Chunk *chunk = musin::midi::peek_incoming_sysex_chunk()) {
+    handle_sysex(*chunk);
+    musin::midi::pop_incoming_sysex_chunk();
+  }
+
   musin::midi::IncomingMidiMessage message;
   while (musin::midi::dequeue_incoming_midi_message(message)) {
-    // Gate all non-SysEx messages during a file transfer to prevent conflicts.
-    if (sysex_handler_.is_busy() &&
-        !etl::holds_alternative<sysex::Chunk>(message)) {
+    // Gate all other messages during a file transfer to prevent conflicts.
+    if (sysex_handler_.is_busy()) {
       continue;
     }
 
@@ -75,8 +79,6 @@ void MidiManager::process_input() {
           } else if constexpr (std::is_same_v<
                                    T, musin::midi::SystemRealtimeData>) {
             handle_realtime(arg.type);
-          } else if constexpr (std::is_same_v<T, sysex::Chunk>) {
-            handle_sysex(arg);
           }
         },
         message);
@@ -109,8 +111,7 @@ void MidiManager::sysex_callback(uint8_t *data, unsigned length) {
   if (length < 2) {
     return;
   }
-  musin::midi::enqueue_incoming_midi_message(
-      sysex::Chunk(data + 1, length - 2));
+  musin::midi::enqueue_incoming_sysex_chunk(data + 1, length - 2);
 }
 
 void MidiManager::clock_callback() {

--- a/drum/midi_manager.h
+++ b/drum/midi_manager.h
@@ -1,7 +1,7 @@
 #ifndef DRUM_MIDI_MANAGER_H
 #define DRUM_MIDI_MANAGER_H
 
-#include "drum/sysex/chunk.h"
+#include "musin/midi/sysex_chunk.h"
 #include <cstdint>
 
 // Forward declarations to minimize header includes

--- a/drum/pizza_controls.cpp
+++ b/drum/pizza_controls.cpp
@@ -516,7 +516,6 @@ void PizzaControls::AnalogControlComponent::handle_control_change(
         drum::Parameter::FILTER_RESONANCE, (1.0f - value));
     break;
   case RANDOM:
-    // This is now handled by the pressure-sensitive button logic
     parent_controls->_message_router_ref.set_parameter(
         drum::Parameter::RANDOM_EFFECT, value, 0);
     break;

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -3,7 +3,6 @@
 #include "events.h"
 #include "pico/time.h"
 #include "sequencer_persistence.h"
-#include "sequencer_storage.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -11,22 +10,12 @@
 
 namespace drum {
 
-namespace {
-constexpr std::uint32_t SIXTEENTH_MASK =
-    (1u << 0) | (1u << 3) | (1u << 6) | (1u << 9);
-constexpr std::uint32_t TRIPLET_MASK = (1u << 0) | (1u << 4) | (1u << 8);
-constexpr std::uint32_t TRIPLET_OFFSET_MASK =
-    (1u << 2) | (1u << 6) | (1u << 10);
-constexpr std::uint32_t MASK12 = (1u << 12) - 1u;
-} // namespace
-
 template <size_t NumTracks, size_t NumSteps>
 SequencerController<NumTracks, NumSteps>::SequencerController(
     musin::timing::TempoHandler &tempo_handler_ref, musin::Logger &logger)
     : sequencer_(main_sequencer_), scheduled_step_counter_{0},
-      last_played_note_per_track{}, _just_played_step_per_track{},
       tempo_source(tempo_handler_ref), _running(false), _step_is_due{false},
-      _active_note_per_track{}, _retrigger_mode_per_track{}, logger_(logger) {
+      persistence_(logger), logger_(logger) {
 
   initialize_active_notes();
   initialize_all_sequencers();
@@ -46,18 +35,8 @@ SequencerController<NumTracks, NumSteps>::~SequencerController() {
 template <size_t NumTracks, size_t NumSteps>
 size_t
 SequencerController<NumTracks, NumSteps>::calculate_base_step_index() const {
-  const size_t num_steps = sequencer_.get().get_num_steps();
-  if (num_steps == 0)
-    return 0;
-
-  if (repeat_active_ && repeat_length_ > 0) {
-    uint64_t steps_since_activation =
-        scheduled_step_counter_ - repeat_activation_step_counter_;
-    uint64_t loop_position = steps_since_activation % repeat_length_;
-    return (repeat_activation_step_index_ + loop_position) % num_steps;
-  } else {
-    return scheduled_step_counter_ % num_steps;
-  }
+  return repeat_effect_.calculate_step_index(scheduled_step_counter_,
+                                             sequencer_.get().get_num_steps());
 }
 
 template <size_t NumTracks, size_t NumSteps>
@@ -65,15 +44,16 @@ void SequencerController<NumTracks, NumSteps>::process_track_step(
     size_t track_idx, size_t step_index_to_play) {
   const size_t num_steps = sequencer_.get().get_num_steps();
   uint8_t track_index_u8 = static_cast<uint8_t>(track_idx);
+  TrackState &track_state = track_states_[track_idx];
 
   // Emit Note Off event if a note was previously playing on this track
-  if (last_played_note_per_track[track_idx].has_value()) {
+  if (track_state.last_played_note.has_value()) {
     drum::Events::NoteEvent note_off_event{
         .track_index = track_index_u8,
-        .note = last_played_note_per_track[track_idx].value(),
+        .note = track_state.last_played_note.value(),
         .velocity = 0};
     this->notify_observers(note_off_event);
-    last_played_note_per_track[track_idx] = std::nullopt;
+    track_state.last_played_note = std::nullopt;
   }
 
   const int effective_step_with_fixed_offset =
@@ -107,7 +87,7 @@ void SequencerController<NumTracks, NumSteps>::process_track_step(
                                           .note = step.note.value(),
                                           .velocity = effective_velocity};
     this->notify_observers(note_on_event);
-    last_played_note_per_track[track_idx] = step.note.value();
+    track_state.last_played_note = step.note.value();
   }
 }
 
@@ -131,28 +111,25 @@ bool SequencerController<NumTracks, NumSteps>::is_swing_enabled() const {
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::reset() {
-  for (size_t track_idx = 0; track_idx < last_played_note_per_track.size();
-       ++track_idx) {
-    if (last_played_note_per_track[track_idx].has_value()) {
+  for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
+    TrackState &track_state = track_states_[track_idx];
+    if (track_state.last_played_note.has_value()) {
       drum::Events::NoteEvent note_off_event{
           .track_index = static_cast<uint8_t>(track_idx),
-          .note = last_played_note_per_track[track_idx].value(),
+          .note = track_state.last_played_note.value(),
           .velocity = 0};
       this->notify_observers(note_off_event);
-      last_played_note_per_track[track_idx] = std::nullopt;
+      track_state.last_played_note = std::nullopt;
     }
   }
   scheduled_step_counter_ = 0;
   last_phase_12_ = 0;
 
-  _just_played_step_per_track.fill(std::nullopt);
-
   // Pre-populate last-played step indices so the UI has a cursor immediately
   // after starting, even before the first incoming tick.
   size_t base_step_index = calculate_base_step_index();
-  size_t num_tracks = sequencer_.get().get_num_tracks();
-  for (size_t track_idx = 0; track_idx < num_tracks; ++track_idx) {
-    _just_played_step_per_track[track_idx] = base_step_index;
+  for (auto &track_state : track_states_) {
+    track_state.just_played_step = base_step_index;
   }
 
   deactivate_repeat();
@@ -174,7 +151,9 @@ void SequencerController<NumTracks, NumSteps>::start() {
     return;
   }
 
-  _just_played_step_per_track.fill(std::nullopt);
+  for (auto &track_state : track_states_) {
+    track_state.just_played_step = std::nullopt;
+  }
 
   tempo_source.add_observer(*this);
   tempo_source.set_playback_state(musin::timing::PlaybackState::PLAYING);
@@ -199,12 +178,11 @@ void SequencerController<NumTracks, NumSteps>::stop() {
   tempo_source.remove_observer(*this);
   _running = false;
 
-  for (size_t track_idx = 0; track_idx < last_played_note_per_track.size();
-       ++track_idx) {
-    if (last_played_note_per_track[track_idx].has_value()) {
+  for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
+    if (track_states_[track_idx].last_played_note.has_value()) {
       drum::Events::NoteEvent note_off_event{
           .track_index = static_cast<uint8_t>(track_idx),
-          .note = last_played_note_per_track[track_idx].value(),
+          .note = track_states_[track_idx].last_played_note.value(),
           .velocity = 0};
       this->notify_observers(note_off_event);
     }
@@ -256,7 +234,7 @@ void SequencerController<NumTracks, NumSteps>::notification(
   // Calculate swing timing using the dedicated effect
   const size_t next_index = calculate_base_step_index();
   const auto timing = swing_effect_.calculate_step_timing(
-      next_index, repeat_active_, scheduled_step_counter_);
+      next_index, repeat_effect_.is_active(), scheduled_step_counter_);
   const uint8_t expected_phase = timing.expected_phase;
 
   // --- Look-behind scheduling check for the main step ---
@@ -295,25 +273,7 @@ void SequencerController<NumTracks, NumSteps>::notification(
 
   const bool substep_is_due = (substep_grid_mask & range_mask) != 0;
 
-  uint8_t local_retrigger_mask = 0;
-  for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
-    RetriggerMode mode = _retrigger_mode_per_track[track_idx];
-    if (mode == RetriggerMode::Off) {
-      continue;
-    }
-
-    bool due = (mode == RetriggerMode::Step)       ? is_step_due
-               : (mode == RetriggerMode::Substeps) ? substep_is_due
-                                                   : false;
-
-    if (due) {
-      local_retrigger_mask |= (1u << track_idx);
-    }
-  }
-  if (local_retrigger_mask != 0) {
-    _retrigger_due_mask.fetch_or(local_retrigger_mask,
-                                 std::memory_order_relaxed);
-  }
+  retrigger_effect_.mark_due_tracks(is_step_due, substep_is_due);
 
   last_phase_12_ = event.phase_12;
 }
@@ -332,7 +292,7 @@ template <size_t NumTracks, size_t NumSteps>
 SequencerController<NumTracks, NumSteps>::get_last_played_step_for_track(
     size_t track_idx) const {
   if ((track_idx < NumTracks)) {
-    return _just_played_step_per_track[track_idx];
+    return track_states_[track_idx].just_played_step;
   }
   return std::nullopt;
 }
@@ -346,45 +306,33 @@ SequencerController<NumTracks, NumSteps>::is_running() const {
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::activate_repeat(
     uint32_t length) {
-  if (_running && !repeat_active_) {
-    repeat_active_ = true;
-    repeat_length_ = std::max(uint32_t{1}, length);
-    const size_t num_steps = sequencer_.get().get_num_steps();
-    repeat_activation_step_index_ =
-        (num_steps > 0) ? (scheduled_step_counter_ % num_steps) : 0;
-    repeat_activation_step_counter_ = scheduled_step_counter_;
+  if (_running) {
+    repeat_effect_.activate(length, scheduled_step_counter_,
+                            sequencer_.get().get_num_steps());
   }
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::deactivate_repeat() {
-  if (repeat_active_) {
-    repeat_active_ = false;
-    repeat_length_ = 0;
-  }
+  repeat_effect_.deactivate();
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::set_repeat_length(
     uint32_t length) {
-  if (repeat_active_) {
-    uint32_t new_length = std::max(uint32_t{1}, length);
-    if (new_length != repeat_length_) {
-      repeat_length_ = new_length;
-    }
-  }
+  repeat_effect_.set_length(length);
 }
 
 template <size_t NumTracks, size_t NumSteps>
 [[nodiscard]] bool
 SequencerController<NumTracks, NumSteps>::is_repeat_active() const {
-  return repeat_active_;
+  return repeat_effect_.is_active();
 }
 
 template <size_t NumTracks, size_t NumSteps>
 [[nodiscard]] uint32_t
 SequencerController<NumTracks, NumSteps>::get_repeat_length() const {
-  return repeat_active_ ? repeat_length_ : 0;
+  return repeat_effect_.get_length();
 }
 
 template <size_t NumTracks, size_t NumSteps>
@@ -446,12 +394,13 @@ void SequencerController<NumTracks, NumSteps>::trigger_note_on(
   static_cast<void>(0); // Placeholder for debug log - will add proper logging
 
   // Ensure any previously playing note on this track is turned off first
-  if (last_played_note_per_track[track_index].has_value()) {
-    if (last_played_note_per_track[track_index].value() !=
+  TrackState &track_state = track_states_[track_index];
+  if (track_state.last_played_note.has_value()) {
+    if (track_state.last_played_note.value() !=
         note) { // Only send note off if it's a different note
       drum::Events::NoteEvent note_off_event{
           .track_index = track_index,
-          .note = last_played_note_per_track[track_index].value(),
+          .note = track_state.last_played_note.value(),
           .velocity = 0};
       this->notify_observers(note_off_event);
     }
@@ -460,19 +409,20 @@ void SequencerController<NumTracks, NumSteps>::trigger_note_on(
   drum::Events::NoteEvent note_on_event{
       .track_index = track_index, .note = note, .velocity = velocity};
   this->notify_observers(note_on_event);
-  last_played_note_per_track[track_index] = note;
+  track_state.last_played_note = note;
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::trigger_note_off(
     uint8_t track_index, uint8_t note) {
   // Only send note off if this note was the one playing
-  if (last_played_note_per_track[track_index].has_value() &&
-      last_played_note_per_track[track_index].value() == note) {
+  TrackState &track_state = track_states_[track_index];
+  if (track_state.last_played_note.has_value() &&
+      track_state.last_played_note.value() == note) {
     drum::Events::NoteEvent note_off_event{
         .track_index = track_index, .note = note, .velocity = 0};
     this->notify_observers(note_off_event);
-    last_played_note_per_track[track_index] = std::nullopt;
+    track_state.last_played_note = std::nullopt;
   }
 }
 
@@ -480,10 +430,8 @@ template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::set_active_note_for_track(
     uint8_t track_index, uint8_t note) {
   if (track_index < NumTracks) {
-    _active_note_per_track[track_index] = note;
-    if (storage_.has_value()) {
-      storage_->mark_state_dirty();
-    }
+    track_states_[track_index].active_note = note;
+    persistence_.mark_dirty();
   }
   // else: track_index is out of bounds, do nothing or log an error.
   // For now, we silently ignore out-of-bounds access to prevent crashes.
@@ -493,7 +441,7 @@ template <size_t NumTracks, size_t NumSteps>
 uint8_t SequencerController<NumTracks, NumSteps>::get_active_note_for_track(
     uint8_t track_index) const {
   if (track_index < NumTracks) {
-    return _active_note_per_track[track_index];
+    return track_states_[track_index].active_note;
   }
   // track_index is out of bounds. Return a default/safe value.
   // 0 is a common default for MIDI notes, though often unassigned.
@@ -503,17 +451,14 @@ uint8_t SequencerController<NumTracks, NumSteps>::get_active_note_for_track(
 template <size_t NumTracks, size_t NumSteps>
 uint8_t SequencerController<NumTracks, NumSteps>::get_retrigger_mode_for_track(
     uint8_t track_index) const {
-  if (track_index < NumTracks) {
-    return static_cast<uint8_t>(_retrigger_mode_per_track[track_index]);
-  }
-  return 0;
+  return static_cast<uint8_t>(retrigger_effect_.get_mode(track_index));
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::record_velocity_hit(
     uint8_t track_index) {
   if (track_index < NumTracks) {
-    _has_active_velocity_hit[track_index] = true;
+    track_states_[track_index].has_velocity_hit = true;
   }
 }
 
@@ -521,7 +466,7 @@ template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::clear_velocity_hit(
     uint8_t track_index) {
   if (track_index < NumTracks) {
-    _has_active_velocity_hit[track_index] = false;
+    track_states_[track_index].has_velocity_hit = false;
   }
 }
 
@@ -529,7 +474,7 @@ template <size_t NumTracks, size_t NumSteps>
 bool SequencerController<NumTracks, NumSteps>::has_recent_velocity_hit(
     uint8_t track_index) const {
   if (track_index < NumTracks) {
-    return _has_active_velocity_hit[track_index];
+    return track_states_[track_index].has_velocity_hit;
   }
   return false;
 }
@@ -537,45 +482,36 @@ bool SequencerController<NumTracks, NumSteps>::has_recent_velocity_hit(
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::activate_play_on_every_step(
     uint8_t track_index, RetriggerMode mode) {
-  if (track_index < NumTracks) {
-    _retrigger_mode_per_track[track_index] = mode;
-  }
+  retrigger_effect_.set_mode(track_index, mode);
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::deactivate_play_on_every_step(
     uint8_t track_index) {
-  if (track_index < NumTracks) {
-    _retrigger_mode_per_track[track_index] = RetriggerMode::Off;
-  }
+  retrigger_effect_.set_mode(track_index, RetriggerMode::Off);
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::update() {
   // Periodic save logic with debouncing (runs regardless of step timing)
-  if (storage_.has_value() && storage_->should_save_now()) {
+  if (persistence_.should_save_now()) {
     SequencerPersistentState state;
     create_persistent_state(state);
-    if (storage_->save_state_to_flash(state)) {
+    if (persistence_.save(state)) {
       logger_.debug("Periodic save completed successfully");
     } else {
       logger_.warn("Periodic save failed");
     }
   }
 
-  uint8_t current_retrigger_mask = _retrigger_due_mask.load();
-  if (current_retrigger_mask > 0) {
-    uint8_t processed_mask = 0;
-    for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
-      if ((current_retrigger_mask >> track_idx) & 1) {
-        uint8_t note_to_play =
-            get_active_note_for_track(static_cast<uint8_t>(track_idx));
-        trigger_note_on(static_cast<uint8_t>(track_idx), note_to_play,
-                        drum::config::drumpad::RETRIGGER_VELOCITY);
-        processed_mask |= (1 << track_idx);
-      }
+  uint8_t retrigger_mask = retrigger_effect_.take_due_mask();
+  for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
+    if ((retrigger_mask >> track_idx) & 1) {
+      uint8_t note_to_play =
+          get_active_note_for_track(static_cast<uint8_t>(track_idx));
+      trigger_note_on(static_cast<uint8_t>(track_idx), note_to_play,
+                      drum::config::drumpad::RETRIGGER_VELOCITY);
     }
-    _retrigger_due_mask.fetch_and(~processed_mask);
   }
 
   if (!_step_is_due) {
@@ -585,7 +521,9 @@ void SequencerController<NumTracks, NumSteps>::update() {
 
   size_t base_step_index = calculate_base_step_index();
 
-  _just_played_step_per_track.fill(std::nullopt);
+  for (auto &track_state : track_states_) {
+    track_state.just_played_step = std::nullopt;
+  }
 
   size_t num_tracks = sequencer_.get().get_num_tracks();
 
@@ -593,16 +531,17 @@ void SequencerController<NumTracks, NumSteps>::update() {
     // Calculate randomized step using the effect
     const size_t num_steps = sequencer_.get().get_num_steps();
     auto randomized_step = random_effect_.calculate_randomized_step(
-        base_step_index, track_idx, num_steps, repeat_active_);
+        base_step_index, track_idx, num_steps, repeat_effect_.is_active());
 
     size_t step_index_to_play_for_track = randomized_step.effective_step_index;
 
-    _just_played_step_per_track[track_idx] = step_index_to_play_for_track;
+    track_states_[track_idx].just_played_step = step_index_to_play_for_track;
     process_track_step(track_idx, step_index_to_play_for_track);
 
     // Handle the first retrigger note for the main step event
     // Simple guard: only add explicit boundary retrigger for Step mode
-    if (_retrigger_mode_per_track[track_idx] == RetriggerMode::Step) {
+    if (retrigger_effect_.get_mode(static_cast<uint8_t>(track_idx)) ==
+        RetriggerMode::Step) {
       uint8_t note_to_play =
           get_active_note_for_track(static_cast<uint8_t>(track_idx));
       trigger_note_on(static_cast<uint8_t>(track_idx), note_to_play,
@@ -613,8 +552,9 @@ void SequencerController<NumTracks, NumSteps>::update() {
   // Advance random offset indices when REPEAT + RANDOM are both active
   // Only cycle through offsets for light press (mode 1), freeze on hard press
   // (mode 2)
-  if (repeat_active_) {
-    random_effect_.advance_offset_indices(num_tracks, repeat_length_);
+  if (repeat_effect_.is_active()) {
+    random_effect_.advance_offset_indices(num_tracks,
+                                          repeat_effect_.get_length());
   }
 
   // Increment scheduled_step_counter_ AFTER processing the step
@@ -625,7 +565,7 @@ template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::initialize_active_notes() {
   for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
     if (track_idx < config::track_ranges.size()) {
-      _active_note_per_track[track_idx] =
+      track_states_[track_idx].active_note =
           config::track_ranges[track_idx].low_note;
     }
   }
@@ -634,7 +574,7 @@ void SequencerController<NumTracks, NumSteps>::initialize_active_notes() {
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::initialize_all_sequencers() {
   for (size_t track_idx = 0; track_idx < NumTracks; ++track_idx) {
-    uint8_t initial_note = _active_note_per_track[track_idx];
+    uint8_t initial_note = track_states_[track_idx].active_note;
     auto &main_track = main_sequencer_.get_track(track_idx);
     auto &random_track = random_sequencer_.get_track(track_idx);
     for (size_t step_idx = 0; step_idx < NumSteps; ++step_idx) {
@@ -650,8 +590,10 @@ void SequencerController<NumTracks, NumSteps>::initialize_all_sequencers() {
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::initialize_timing_and_random() {
-  _just_played_step_per_track.fill(std::nullopt);
-  _has_active_velocity_hit.fill(false);
+  for (auto &track_state : track_states_) {
+    track_state.just_played_step = std::nullopt;
+    track_state.has_velocity_hit = false;
+  }
 }
 
 template <size_t NumTracks, size_t NumSteps>
@@ -681,7 +623,7 @@ void SequencerController<NumTracks, NumSteps>::create_persistent_state(
   // Copy active notes per track
   for (size_t track_idx = 0;
        track_idx < NumTracks && track_idx < config::NUM_TRACKS; ++track_idx) {
-    state.active_notes[track_idx] = _active_note_per_track[track_idx];
+    state.active_notes[track_idx] = track_states_[track_idx].active_note;
   }
 }
 
@@ -691,7 +633,7 @@ void SequencerController<NumTracks, NumSteps>::apply_persistent_state(
   // Apply active notes first
   for (size_t track_idx = 0;
        track_idx < NumTracks && track_idx < config::NUM_TRACKS; ++track_idx) {
-    _active_note_per_track[track_idx] = state.active_notes[track_idx];
+    track_states_[track_idx].active_note = state.active_notes[track_idx];
   }
 
   // Apply per-step velocities to main sequencer; note is derived from active
@@ -699,7 +641,7 @@ void SequencerController<NumTracks, NumSteps>::apply_persistent_state(
   for (size_t track_idx = 0;
        track_idx < NumTracks && track_idx < config::NUM_TRACKS; ++track_idx) {
     auto &track = main_sequencer_.get_track(track_idx);
-    uint8_t track_note = _active_note_per_track[track_idx];
+    uint8_t track_note = track_states_[track_idx].active_note;
     // Ensure track default note matches active note
     track.set_note(track_note);
     for (size_t step_idx = 0;
@@ -722,14 +664,9 @@ void SequencerController<NumTracks, NumSteps>::apply_persistent_state(
 
 template <size_t NumTracks, size_t NumSteps>
 bool SequencerController<NumTracks, NumSteps>::save_state_to_flash() {
-  if (!storage_.has_value()) {
-    logger_.error("Manual save to flash failed - persistence not initialized");
-    return false;
-  }
-
   SequencerPersistentState state;
   create_persistent_state(state);
-  bool success = storage_->save_state_to_flash(state);
+  bool success = persistence_.save(state);
   if (success) {
     logger_.info("Manual save to flash completed successfully");
   } else {
@@ -740,14 +677,8 @@ bool SequencerController<NumTracks, NumSteps>::save_state_to_flash() {
 
 template <size_t NumTracks, size_t NumSteps>
 bool SequencerController<NumTracks, NumSteps>::load_state_from_flash() {
-  if (!storage_.has_value()) {
-    logger_.error(
-        "Manual load from flash failed - persistence not initialized");
-    return false;
-  }
-
   SequencerPersistentState state;
-  if (storage_->load_state_from_flash(state)) {
+  if (persistence_.load(state)) {
     apply_persistent_state(state);
     logger_.info("Manual load from flash completed successfully");
     return true;
@@ -758,17 +689,13 @@ bool SequencerController<NumTracks, NumSteps>::load_state_from_flash() {
 
 template <size_t NumTracks, size_t NumSteps>
 bool SequencerController<NumTracks, NumSteps>::init_persistence() {
-  if (storage_.has_value()) {
-    logger_.warn("Persistence already initialized");
-    return true;
+  if (!persistence_.init()) {
+    return true; // Already initialized
   }
-
-  // Initialize storage now that filesystem is ready
-  storage_.emplace();
 
   // Attempt to load existing state
   SequencerPersistentState loaded_state;
-  if (storage_->load_state_from_flash(loaded_state)) {
+  if (persistence_.load(loaded_state)) {
     apply_persistent_state(loaded_state);
     logger_.info("Sequencer state loaded from flash during init_persistence");
     return true;
@@ -782,14 +709,12 @@ bool SequencerController<NumTracks, NumSteps>::init_persistence() {
 template <size_t NumTracks, size_t NumSteps>
 bool SequencerController<NumTracks, NumSteps>::is_persistence_initialized()
     const {
-  return storage_.has_value();
+  return persistence_.is_initialized();
 }
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::mark_state_dirty_public() {
-  if (storage_.has_value()) {
-    storage_->mark_state_dirty();
-  }
+  persistence_.mark_dirty();
 }
 
 template <size_t NumTracks, size_t NumSteps>

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -2,7 +2,6 @@
 #include "config.h"
 #include "events.h"
 #include "pico/time.h"
-#include "pizza_controls.h" // For config constants
 #include "sequencer_persistence.h"
 #include "sequencer_storage.h"
 #include <algorithm>
@@ -186,7 +185,9 @@ void SequencerController<NumTracks, NumSteps>::start() {
   const auto [anchor_phase, primed_phase] =
       align_to_last_anchor(last_phase_12_);
   last_phase_12_ = primed_phase;
-  tempo_source.trigger_manual_sync(anchor_phase);
+  if (drum::config::RETRIGGER_SYNC_ON_PLAYBUTTON) {
+    tempo_source.trigger_manual_sync(anchor_phase);
+  }
 }
 
 template <size_t NumTracks, size_t NumSteps>

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -650,7 +650,6 @@ void SequencerController<NumTracks, NumSteps>::initialize_all_sequencers() {
 
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::initialize_timing_and_random() {
-  srand(time_us_32());
   _just_played_step_per_track.fill(std::nullopt);
   _has_active_velocity_hit.fill(false);
 }

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -18,9 +18,11 @@
 
 #include "musin/hal/logger.h"
 #include "sequencer_effect_random.h"
+#include "sequencer_effect_repeat.h"
+#include "sequencer_effect_retrigger.h"
 #include "sequencer_effect_swing.h"
 #include "sequencer_persistence.h"
-#include "sequencer_storage.h"
+#include "sequencer_persistence_manager.h"
 #include <cstddef>
 
 namespace drum {
@@ -33,10 +35,14 @@ constexpr uint8_t TRIPLET_SUBDIVISION = PPQN / 3;   // 4
 constexpr uint8_t SIXTEENTH_SUBDIVISION = PPQN / 4; // 3
 } // namespace musical_timing
 
-enum class RetriggerMode : uint8_t {
-  Off = 0,
-  Step = 1,
-  Substeps = 2
+/**
+ * @brief Per-track runtime state for the sequencer.
+ */
+struct TrackState {
+  uint8_t active_note{0};
+  bool has_velocity_hit{false};
+  std::optional<uint8_t> last_played_note{};
+  std::optional<size_t> just_played_step{};
 };
 
 // Forward declare the specific Sequencer instantiation from its new namespace
@@ -279,30 +285,20 @@ private:
   std::reference_wrapper<musin::timing::Sequencer<NumTracks, NumSteps>>
       sequencer_;
   uint32_t scheduled_step_counter_;
-  etl::array<std::optional<uint8_t>, NumTracks> last_played_note_per_track;
-  etl::array<std::optional<size_t>, NumTracks> _just_played_step_per_track;
+  etl::array<TrackState, NumTracks> track_states_{};
   musin::timing::TempoHandler &tempo_source;
   bool _running = false;
   std::atomic<bool> _step_is_due = false;
-  std::atomic<uint8_t> _retrigger_due_mask{0};
   uint8_t last_phase_12_{0};
 
-  bool repeat_active_ = false;
-  uint32_t repeat_length_ = 0;
-  uint32_t repeat_activation_step_index_ = 0;
-  uint64_t repeat_activation_step_counter_ = 0;
-
+  SequencerEffectRepeat repeat_effect_;
+  SequencerEffectRetrigger retrigger_effect_;
   SequencerEffectSwing swing_effect_;
   SequencerEffectRandom random_effect_;
   // User intent: true when RANDOM is held hard-press while running.
   bool random_intends_flip_{false};
 
-  etl::array<uint8_t, NumTracks> _active_note_per_track{};
-  etl::array<RetriggerMode, NumTracks> _retrigger_mode_per_track{};
-  etl::array<bool, NumTracks> _has_active_velocity_hit{};
-
-  // Persistence management (optional until filesystem is ready)
-  std::optional<SequencerStorage<NumTracks, NumSteps>> storage_;
+  SequencerPersistenceManager<NumTracks, NumSteps> persistence_;
 
   // Logger reference
   musin::Logger &logger_;

--- a/drum/sequencer_effect_random.cpp
+++ b/drum/sequencer_effect_random.cpp
@@ -7,8 +7,6 @@
 namespace drum {
 
 SequencerEffectRandom::SequencerEffectRandom() {
-  srand(time_us_32());
-
   for (size_t track_idx = 0; track_idx < MAX_TRACKS; ++track_idx) {
     current_offset_index_per_track_[track_idx] = 0;
     highlighted_random_steps_[track_idx] = 0;

--- a/drum/sequencer_effect_random.h
+++ b/drum/sequencer_effect_random.h
@@ -16,6 +16,16 @@ enum class RandomEffectState {
   StepPreview     // Stopped + any press: step highlighting for preview
 };
 
+/**
+ * @brief Randomization effect driven by the two-stage pressure-sensitive
+ * RANDOM button.
+ *
+ * The two mechanisms are layered, not alternatives: a soft press swaps
+ * playback to randomized step offsets (OffsetActive); a hard press keeps the
+ * offsets and additionally flips each step's enabled state with 50%
+ * probability at play time (OffsetWithFlip). While stopped, pressing
+ * previews randomly chosen steps instead (StepPreview).
+ */
 class SequencerEffectRandom {
 public:
   struct RandomizedStep {

--- a/drum/sequencer_effect_repeat.cpp
+++ b/drum/sequencer_effect_repeat.cpp
@@ -1,0 +1,52 @@
+#include "sequencer_effect_repeat.h"
+
+#include <algorithm>
+
+namespace drum {
+
+void SequencerEffectRepeat::activate(uint32_t length,
+                                     uint32_t current_step_counter,
+                                     size_t num_steps) {
+  if (active_) {
+    return;
+  }
+  active_ = true;
+  length_ = std::max(uint32_t{1}, length);
+  activation_step_index_ =
+      (num_steps > 0) ? (current_step_counter % num_steps) : 0;
+  activation_step_counter_ = current_step_counter;
+}
+
+void SequencerEffectRepeat::deactivate() {
+  active_ = false;
+  length_ = 0;
+}
+
+void SequencerEffectRepeat::set_length(uint32_t length) {
+  if (active_) {
+    length_ = std::max(uint32_t{1}, length);
+  }
+}
+
+bool SequencerEffectRepeat::is_active() const {
+  return active_;
+}
+
+uint32_t SequencerEffectRepeat::get_length() const {
+  return active_ ? length_ : 0;
+}
+
+size_t SequencerEffectRepeat::calculate_step_index(uint32_t step_counter,
+                                                   size_t num_steps) const {
+  if (num_steps == 0) {
+    return 0;
+  }
+  if (active_ && length_ > 0) {
+    uint32_t steps_since_activation = step_counter - activation_step_counter_;
+    uint32_t loop_position = steps_since_activation % length_;
+    return (activation_step_index_ + loop_position) % num_steps;
+  }
+  return step_counter % num_steps;
+}
+
+} // namespace drum

--- a/drum/sequencer_effect_repeat.h
+++ b/drum/sequencer_effect_repeat.h
@@ -1,0 +1,58 @@
+#ifndef DRUM_SEQUENCER_EFFECT_REPEAT_H
+#define DRUM_SEQUENCER_EFFECT_REPEAT_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace drum {
+
+/**
+ * @brief Encapsulates the repeat (loop) effect for the sequencer.
+ *
+ * While active, playback loops over a window of steps starting at the step
+ * that was playing when the effect was activated.
+ */
+class SequencerEffectRepeat {
+public:
+  /**
+   * @brief Activate the repeat loop.
+   * @param length Loop length in steps (clamped to at least 1).
+   * @param current_step_counter The transport step counter at activation.
+   * @param num_steps Number of steps in the pattern.
+   */
+  void activate(uint32_t length, uint32_t current_step_counter,
+                size_t num_steps);
+
+  void deactivate();
+
+  /**
+   * @brief Change the loop length while active. Ignored when inactive.
+   */
+  void set_length(uint32_t length);
+
+  [[nodiscard]] bool is_active() const;
+
+  /**
+   * @brief The current loop length, or 0 when inactive.
+   */
+  [[nodiscard]] uint32_t get_length() const;
+
+  /**
+   * @brief Map the transport step counter to the pattern step to play,
+   * looping within the repeat window while active.
+   * @param step_counter The transport step counter.
+   * @param num_steps Number of steps in the pattern (0 yields step 0).
+   */
+  [[nodiscard]] size_t calculate_step_index(uint32_t step_counter,
+                                            size_t num_steps) const;
+
+private:
+  bool active_{false};
+  uint32_t length_{0};
+  uint32_t activation_step_index_{0};
+  uint32_t activation_step_counter_{0};
+};
+
+} // namespace drum
+
+#endif // DRUM_SEQUENCER_EFFECT_REPEAT_H

--- a/drum/sequencer_effect_retrigger.cpp
+++ b/drum/sequencer_effect_retrigger.cpp
@@ -1,0 +1,45 @@
+#include "sequencer_effect_retrigger.h"
+
+namespace drum {
+
+void SequencerEffectRetrigger::set_mode(uint8_t track_index,
+                                        RetriggerMode mode) {
+  if (track_index < MAX_TRACKS) {
+    mode_per_track_[track_index] = mode;
+  }
+}
+
+RetriggerMode SequencerEffectRetrigger::get_mode(uint8_t track_index) const {
+  if (track_index < MAX_TRACKS) {
+    return mode_per_track_[track_index];
+  }
+  return RetriggerMode::Off;
+}
+
+void SequencerEffectRetrigger::mark_due_tracks(bool step_is_due,
+                                               bool substep_is_due) {
+  uint8_t mask = 0;
+  for (size_t track_idx = 0; track_idx < MAX_TRACKS; ++track_idx) {
+    RetriggerMode mode = mode_per_track_[track_idx];
+    bool due = (mode == RetriggerMode::Step)       ? step_is_due
+               : (mode == RetriggerMode::Substeps) ? substep_is_due
+                                                   : false;
+    if (due) {
+      mask |= static_cast<uint8_t>(1u << track_idx);
+    }
+  }
+  if (mask != 0) {
+    due_mask_.fetch_or(mask, std::memory_order_relaxed);
+  }
+}
+
+uint8_t SequencerEffectRetrigger::take_due_mask() {
+  uint8_t mask = due_mask_.load(std::memory_order_relaxed);
+  if (mask != 0) {
+    due_mask_.fetch_and(static_cast<uint8_t>(~mask),
+                        std::memory_order_relaxed);
+  }
+  return mask;
+}
+
+} // namespace drum

--- a/drum/sequencer_effect_retrigger.cpp
+++ b/drum/sequencer_effect_retrigger.cpp
@@ -36,8 +36,7 @@ void SequencerEffectRetrigger::mark_due_tracks(bool step_is_due,
 uint8_t SequencerEffectRetrigger::take_due_mask() {
   uint8_t mask = due_mask_.load(std::memory_order_relaxed);
   if (mask != 0) {
-    due_mask_.fetch_and(static_cast<uint8_t>(~mask),
-                        std::memory_order_relaxed);
+    due_mask_.fetch_and(static_cast<uint8_t>(~mask), std::memory_order_relaxed);
   }
   return mask;
 }

--- a/drum/sequencer_effect_retrigger.h
+++ b/drum/sequencer_effect_retrigger.h
@@ -1,0 +1,54 @@
+#ifndef DRUM_SEQUENCER_EFFECT_RETRIGGER_H
+#define DRUM_SEQUENCER_EFFECT_RETRIGGER_H
+
+#include "etl/array.h"
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace drum {
+
+enum class RetriggerMode : uint8_t {
+  Off = 0,
+  Step = 1,
+  Substeps = 2
+};
+
+/**
+ * @brief Encapsulates per-track retriggering ("play on every step").
+ *
+ * Tracks set to Step mode retrigger on every step boundary; Substeps mode
+ * retriggers on the substep grid as well. Due tracks are accumulated into an
+ * atomic mask from the tempo callback (mark_due_tracks) and drained from the
+ * main loop (take_due_mask).
+ */
+class SequencerEffectRetrigger {
+public:
+  static constexpr size_t MAX_TRACKS = 4;
+
+  void set_mode(uint8_t track_index, RetriggerMode mode);
+
+  [[nodiscard]] RetriggerMode get_mode(uint8_t track_index) const;
+
+  /**
+   * @brief Accumulate due tracks for the elapsed tick window.
+   * Safe to call from the tempo notification context.
+   * @param step_is_due Whether a step boundary fell in the window.
+   * @param substep_is_due Whether a substep grid point fell in the window.
+   */
+  void mark_due_tracks(bool step_is_due, bool substep_is_due);
+
+  /**
+   * @brief Drain and return the mask of tracks due for a retrigger.
+   * Call from the main loop; bit N set means track N is due.
+   */
+  uint8_t take_due_mask();
+
+private:
+  etl::array<RetriggerMode, MAX_TRACKS> mode_per_track_{};
+  std::atomic<uint8_t> due_mask_{0};
+};
+
+} // namespace drum
+
+#endif // DRUM_SEQUENCER_EFFECT_RETRIGGER_H

--- a/drum/sequencer_persistence_manager.h
+++ b/drum/sequencer_persistence_manager.h
@@ -1,0 +1,78 @@
+#ifndef DRUM_SEQUENCER_PERSISTENCE_MANAGER_H
+#define DRUM_SEQUENCER_PERSISTENCE_MANAGER_H
+
+#include "musin/hal/logger.h"
+#include "sequencer_persistence.h"
+#include "sequencer_storage.h"
+#include <cstddef>
+#include <optional>
+
+namespace drum {
+
+/**
+ * @brief Owns the optional flash storage lifecycle for sequencer state.
+ *
+ * Storage cannot exist until the filesystem is ready, so it starts empty and
+ * is created by init(). All methods are safe no-ops (returning false) before
+ * initialization, which keeps callers free of has_value() checks.
+ */
+template <size_t NumTracks, size_t NumSteps> class SequencerPersistenceManager {
+public:
+  explicit SequencerPersistenceManager(musin::Logger &logger)
+      : logger_(logger) {
+  }
+
+  /**
+   * @brief Create the storage backend. Call after the filesystem is ready.
+   * @return false if already initialized.
+   */
+  bool init() {
+    if (storage_.has_value()) {
+      logger_.warn("Persistence already initialized");
+      return false;
+    }
+    storage_.emplace();
+    return true;
+  }
+
+  [[nodiscard]] bool is_initialized() const {
+    return storage_.has_value();
+  }
+
+  void mark_dirty() {
+    if (storage_.has_value()) {
+      storage_->mark_state_dirty();
+    }
+  }
+
+  /**
+   * @brief Whether the debounced periodic save is due.
+   */
+  [[nodiscard]] bool should_save_now() const {
+    return storage_.has_value() && storage_->should_save_now();
+  }
+
+  bool save(const SequencerPersistentState &state) {
+    if (!storage_.has_value()) {
+      logger_.error("Save to flash failed - persistence not initialized");
+      return false;
+    }
+    return storage_->save_state_to_flash(state);
+  }
+
+  bool load(SequencerPersistentState &state) {
+    if (!storage_.has_value()) {
+      logger_.error("Load from flash failed - persistence not initialized");
+      return false;
+    }
+    return storage_->load_state_from_flash(state);
+  }
+
+private:
+  std::optional<SequencerStorage<NumTracks, NumSteps>> storage_;
+  musin::Logger &logger_;
+};
+
+} // namespace drum
+
+#endif // DRUM_SEQUENCER_PERSISTENCE_MANAGER_H

--- a/drum/sysex/protocol.h
+++ b/drum/sysex/protocol.h
@@ -15,7 +15,7 @@ extern "C" {
 
 #include "musin/midi/midi_wrapper.h"
 
-#include "./chunk.h"
+#include "musin/midi/sysex_chunk.h"
 #include "./codec.h"
 
 namespace sysex {

--- a/drum/sysex/protocol.h
+++ b/drum/sysex/protocol.h
@@ -15,8 +15,8 @@ extern "C" {
 
 #include "musin/midi/midi_wrapper.h"
 
-#include "musin/midi/sysex_chunk.h"
 #include "./codec.h"
+#include "musin/midi/sysex_chunk.h"
 
 namespace sysex {
 

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -6,7 +6,6 @@ namespace drum::ui {
 
 namespace {
 
-// This helper function was previously in pizza_display.cpp
 Color apply_visual_effects(Color color, float filter_val, float crush_val,
                            absolute_time_t now) {
   if (filter_val < 0.04f && crush_val < 0.04f) {

--- a/musin/audio/waveshaper.cpp
+++ b/musin/audio/waveshaper.cpp
@@ -28,8 +28,6 @@
 #include <cstddef>       // For size_t
 #include <cstdint>       // For int16_t, uint16_t, int32_t
 
-// Destructor is no longer needed as etl::vector handles memory.
-
 void Waveshaper::shape(const float *new_shape, size_t length) {
   // Validate input shape and length
   if (!new_shape || length < 2 || length > MAX_WAVESHAPE_SIZE) {

--- a/musin/drivers/ws2812.h
+++ b/musin/drivers/ws2812.h
@@ -202,10 +202,6 @@ private:
   // --- Constants ---
   static constexpr uint32_t LATCH_DELAY_US = 80;
 
-  // --- PIO Program Info ---
-  // PIO program loading and SM claiming are now handled dynamically in init()
-  // using SDK helpers. Static tracking is no longer needed here.
-
 }; // class WS2812
 
 // =============================================================================

--- a/musin/hal/pico_dma_copier.h
+++ b/musin/hal/pico_dma_copier.h
@@ -35,7 +35,6 @@ struct PicoDmaCopier {
       return;
     }
 
-    // The DMA logic now uses the static channel.
     dma_channel_config cfg = dma_channel_get_default_config(dma_channel_);
     channel_config_set_transfer_data_size(&cfg, DMA_SIZE_16);
     channel_config_set_read_increment(&cfg, true);

--- a/musin/midi/midi_input_queue.cpp
+++ b/musin/midi/midi_input_queue.cpp
@@ -22,7 +22,26 @@ template bool
 enqueue_incoming_midi_message<ControlChangeData>(const ControlChangeData &);
 template bool
 enqueue_incoming_midi_message<SystemRealtimeData>(const SystemRealtimeData &);
-template bool enqueue_incoming_midi_message<sysex::Chunk>(const sysex::Chunk &);
+
+namespace {
+etl::queue_spsc_atomic<sysex::Chunk, SYSEX_INPUT_QUEUE_SIZE,
+                       etl::memory_model::MEMORY_MODEL_SMALL>
+    sysex_input_queue;
+} // namespace
+
+bool enqueue_incoming_sysex_chunk(const uint8_t *data, size_t length) {
+  // emplace constructs the chunk in the queue slot, avoiding a 2 KB stack
+  // copy.
+  return sysex_input_queue.emplace(data, length);
+}
+
+const sysex::Chunk *peek_incoming_sysex_chunk() {
+  return sysex_input_queue.empty() ? nullptr : &sysex_input_queue.front();
+}
+
+void pop_incoming_sysex_chunk() {
+  sysex_input_queue.pop();
+}
 
 bool dequeue_incoming_midi_message(IncomingMidiMessage &message) {
   if (midi_input_queue.empty()) {

--- a/musin/midi/midi_input_queue.h
+++ b/musin/midi/midi_input_queue.h
@@ -24,9 +24,13 @@ struct NoteOffData {
   uint8_t velocity;
 };
 
-using IncomingMidiMessage =
-    etl::variant<NoteOnData, NoteOffData, ControlChangeData, SystemRealtimeData,
-                 sysex::Chunk>;
+using IncomingMidiMessage = etl::variant<NoteOnData, NoteOffData,
+                                         ControlChangeData, SystemRealtimeData>;
+
+// SysEx chunks own a MAX_PAYLOAD_SIZE buffer each, so they get a dedicated
+// shallow queue instead of inflating every slot of the main message queue.
+// The transfer protocol is ACK-paced, so more than two in flight is abnormal.
+constexpr size_t SYSEX_INPUT_QUEUE_SIZE = 2;
 
 extern etl::queue_spsc_atomic<IncomingMidiMessage, MIDI_INPUT_QUEUE_SIZE,
                               etl::memory_model::MEMORY_MODEL_SMALL>
@@ -35,6 +39,19 @@ extern etl::queue_spsc_atomic<IncomingMidiMessage, MIDI_INPUT_QUEUE_SIZE,
 template <typename T> bool enqueue_incoming_midi_message(const T &message_data);
 
 bool dequeue_incoming_midi_message(IncomingMidiMessage &message);
+
+/**
+ * @brief Copies a SysEx payload into the sysex queue. Drops it if full.
+ */
+bool enqueue_incoming_sysex_chunk(const uint8_t *data, size_t length);
+
+/**
+ * @brief Returns the oldest queued chunk, or nullptr if the queue is empty.
+ * Call pop_incoming_sysex_chunk() after processing it.
+ */
+const sysex::Chunk *peek_incoming_sysex_chunk();
+
+void pop_incoming_sysex_chunk();
 
 } // namespace musin::midi
 

--- a/musin/midi/midi_input_queue.h
+++ b/musin/midi/midi_input_queue.h
@@ -1,7 +1,7 @@
 #ifndef MUSIN_MIDI_MIDI_INPUT_QUEUE_H
 #define MUSIN_MIDI_MIDI_INPUT_QUEUE_H
 
-#include "drum/sysex/chunk.h"
+#include "musin/midi/sysex_chunk.h"
 #include "etl/queue_spsc_atomic.h"
 #include "etl/span.h"
 #include "etl/variant.h"

--- a/musin/midi/midi_output_queue.h
+++ b/musin/midi/midi_output_queue.h
@@ -25,7 +25,9 @@ enum class MidiMessageType : uint8_t {
 };
 
 struct SystemExclusiveData {
-  // Uses MIDI::SysExMaxSize from musin/midi/midi_wrapper.h (which is 128)
+  // Sized by MIDI::SysExMaxSize from musin/midi/midi_wrapper.h (2048 bytes).
+  // Note: this buffer lives in a union inside every OutgoingMidiMessage, so
+  // each of the MIDI_QUEUE_SIZE queue slots carries it (~128 KB total).
   etl::array<uint8_t, MIDI::SysExMaxSize> data_buffer;
   unsigned length;
 };

--- a/musin/midi/sysex_chunk.h
+++ b/musin/midi/sysex_chunk.h
@@ -1,59 +1,71 @@
 #ifndef MUSIN_MIDI_SYSEX_CHUNK_H
 #define MUSIN_MIDI_SYSEX_CHUNK_H
 
+#include "etl/array.h"
 #include "etl/span.h"
+#include <cstddef>
+#include <cstdint>
 
 namespace sysex {
 
+// Largest SysEx payload (excluding 0xF0/0xF7 framing) that can be received.
+// Matches MIDI::SysExMaxSize (2048) minus the two framing bytes.
+inline constexpr size_t MAX_PAYLOAD_SIZE = 2046;
+
 /**
  * @class Chunk
- * @brief A non-owning view of a SysEx message chunk.
+ * @brief An owning, fixed-capacity copy of a SysEx message chunk.
  *
- * This class wraps an etl::span to provide a consistent, non-owning
- * interface to a segment of a SysEx message. It avoids copying data,
- * making it efficient for processing message fragments that are owned
- * by another buffer (e.g., the MIDI driver's receive buffer).
+ * Copies the payload at construction so the chunk remains valid after the
+ * MIDI driver's receive buffer is reused. Payloads longer than
+ * MAX_PAYLOAD_SIZE are truncated.
  */
 class Chunk {
 public:
-  using const_iterator = etl::span<const uint8_t>::const_iterator;
+  using const_iterator = const uint8_t *;
 
   /**
-   * @brief Constructs a Chunk from a raw pointer and size.
+   * @brief Constructs a Chunk by copying from a raw pointer and size.
    */
-  constexpr Chunk(const uint8_t *data, size_t size) : view_(data, size) {
+  constexpr Chunk(const uint8_t *data, size_t size)
+      : size_(size < MAX_PAYLOAD_SIZE ? size : MAX_PAYLOAD_SIZE) {
+    for (size_t i = 0; i < size_; ++i) {
+      data_[i] = data[i];
+    }
   }
 
   /**
-   * @brief Constructs a Chunk from an etl::span.
+   * @brief Constructs a Chunk by copying from an etl::span.
    */
-  explicit constexpr Chunk(etl::span<const uint8_t> view) : view_(view) {
+  explicit constexpr Chunk(etl::span<const uint8_t> view)
+      : Chunk(view.data(), view.size()) {
   }
 
   constexpr const uint8_t &operator[](size_t i) const {
-    return view_[i];
+    return data_[i];
   }
   constexpr size_t size() const {
-    return view_.size();
+    return size_;
   }
   constexpr bool empty() const {
-    return view_.empty();
+    return size_ == 0;
   }
   constexpr const_iterator begin() const {
-    return view_.begin();
+    return data_.data();
   }
   constexpr const_iterator end() const {
-    return view_.end();
+    return data_.data() + size_;
   }
   constexpr const_iterator cbegin() const {
-    return view_.cbegin();
+    return begin();
   }
   constexpr const_iterator cend() const {
-    return view_.cend();
+    return end();
   }
 
 private:
-  etl::span<const uint8_t> view_;
+  etl::array<uint8_t, MAX_PAYLOAD_SIZE> data_{};
+  size_t size_;
 };
 
 } // namespace sysex

--- a/musin/midi/sysex_chunk.h
+++ b/musin/midi/sysex_chunk.h
@@ -1,5 +1,5 @@
-#ifndef SYSEX_CHUNK_H_JY7GCIDU
-#define SYSEX_CHUNK_H_JY7GCIDU
+#ifndef MUSIN_MIDI_SYSEX_CHUNK_H
+#define MUSIN_MIDI_SYSEX_CHUNK_H
 
 #include "etl/span.h"
 
@@ -58,4 +58,4 @@ private:
 
 } // namespace sysex
 
-#endif /* end of include guard: SYSEX_CHUNK_H_JY7GCIDU */
+#endif // MUSIN_MIDI_SYSEX_CHUNK_H

--- a/musin/timing/step_sequencer.h
+++ b/musin/timing/step_sequencer.h
@@ -33,22 +33,23 @@ public:
 
   /**
    * @brief Get a reference to a specific step.
-   * @param index The index of the step (0 to NumSteps - 1).
+   * @param index The index of the step (0 to NumSteps - 1). Asserts on
+   * out-of-bounds access.
    * @return A reference to the Step object.
-   * @note Assumes index is valid.
    */
   [[nodiscard]] constexpr Step &get_step(size_t index) {
+    ETL_ASSERT(index < NumSteps,
+               etl::range_error("Track::get_step: index out of bounds"));
     return steps[index];
   }
 
   /**
    * @brief Get a const reference to a specific step.
-   * @param index The index of the step (0 to NumSteps - 1).
+   * @param index The index of the step (0 to NumSteps - 1). Asserts on
+   * out-of-bounds access.
    * @return A const reference to the Step object.
-   * @note Assumes index is valid.
    */
   [[nodiscard]] constexpr const Step &get_step(size_t index) const {
-    // Basic bounds check (can be enhanced with ETL assertions if desired)
     ETL_ASSERT(index < NumSteps,
                etl::range_error("Track::get_step: index out of bounds"));
     return steps[index];

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -1,5 +1,4 @@
 #include "musin/timing/tempo_handler.h"
-#include "drum/config.h"
 #include "musin/timing/tempo_event.h"
 #include "musin/timing/timing_constants.h"
 
@@ -105,13 +104,16 @@ PlaybackState TempoHandler::get_playback_state() const {
   return _playback_state;
 }
 
+void TempoHandler::set_tempo_control_range(float min_bpm, float max_bpm) {
+  min_bpm_ = min_bpm;
+  max_bpm_ = max_bpm;
+}
+
 void TempoHandler::set_tempo_control_value(float knob_value) {
   last_tempo_knob_value_ = knob_value;
 
   if (get_clock_source() == ClockSource::INTERNAL) {
-    float bpm = drum::config::analog_controls::MIN_BPM_ADJUST +
-                knob_value * (drum::config::analog_controls::MAX_BPM_ADJUST -
-                              drum::config::analog_controls::MIN_BPM_ADJUST);
+    float bpm = min_bpm_ + knob_value * (max_bpm_ - min_bpm_);
     set_bpm(bpm);
     // Ensure speed modifier is always normal when on internal clock
     set_speed_modifier(SpeedModifier::NORMAL_SPEED);
@@ -131,10 +133,6 @@ void TempoHandler::set_playback_state(PlaybackState new_state) {
 }
 
 void TempoHandler::trigger_manual_sync(uint8_t target_phase) {
-  if (!drum::config::RETRIGGER_SYNC_ON_PLAYBUTTON) {
-    return;
-  }
-
   switch (get_clock_source()) {
   case ClockSource::INTERNAL:
   case ClockSource::MIDI:

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -62,6 +62,12 @@ public:
 
   void set_bpm(float bpm);
   void set_speed_modifier(SpeedModifier modifier);
+
+  /**
+   * @brief Sets the BPM range the tempo control knob maps onto when the
+   * internal clock is active.
+   */
+  void set_tempo_control_range(float min_bpm, float max_bpm);
   void set_tempo_control_value(float knob_value);
 
   [[nodiscard]] SpeedModifier get_speed_modifier() const;
@@ -88,6 +94,8 @@ private:
   uint64_t tick_count_;
   const bool _send_midi_clock_when_stopped;
   bool initialized_ = false;
+  float min_bpm_ = 60.0f;
+  float max_bpm_ = 360.0f;
   float last_tempo_knob_value_ = 0.5f;
   SyncState sync_state_ = SyncState::RUNNING;
 };

--- a/musin/ui/drumpad.cpp
+++ b/musin/ui/drumpad.cpp
@@ -1,10 +1,8 @@
 #include "musin/ui/drumpad.h"
-#include "drum/config.h"
 
 namespace musin::ui {
 
-Drumpad::Drumpad(uint8_t pad_id,
-                 const drum::config::drumpad::DrumpadConfig &config)
+Drumpad::Drumpad(uint8_t pad_id, const DrumpadConfig &config)
     : _pad_id(pad_id), _noise_threshold(config.noise_threshold),
       _trigger_threshold(config.trigger_threshold),
       _high_pressure_threshold(

--- a/musin/ui/drumpad.h
+++ b/musin/ui/drumpad.h
@@ -4,9 +4,9 @@
 #include <cstdint>
 #include <optional>
 
-#include "drum/config.h"
 #include "etl/observer.h"
 #include "musin/hal/adc_defs.h" // For ADC_MAX_VALUE
+#include "musin/ui/drumpad_config.h"
 
 extern "C" {
 #include "pico/time.h"
@@ -43,8 +43,7 @@ enum class RetriggerMode : uint8_t {
 
 class Drumpad : public etl::observable<etl::observer<DrumpadEvent>, 4> {
 public:
-  explicit Drumpad(uint8_t pad_id,
-                   const drum::config::drumpad::DrumpadConfig &config);
+  explicit Drumpad(uint8_t pad_id, const DrumpadConfig &config);
 
   Drumpad(const Drumpad &) = delete;
   Drumpad &operator=(const Drumpad &) = delete;

--- a/musin/ui/drumpad_config.h
+++ b/musin/ui/drumpad_config.h
@@ -1,0 +1,24 @@
+#ifndef MUSIN_UI_DRUMPAD_CONFIG_H
+#define MUSIN_UI_DRUMPAD_CONFIG_H
+
+#include <cstdint>
+
+namespace musin::ui {
+
+/**
+ * @brief Per-pad tuning parameters for a pressure-sensitive drumpad.
+ */
+struct DrumpadConfig {
+  uint16_t noise_threshold;
+  uint16_t trigger_threshold;
+  uint16_t high_pressure_threshold;
+  bool active_low;
+  uint32_t debounce_time_us;
+  uint32_t hold_time_us;
+  uint64_t max_velocity_time_us;
+  uint64_t min_velocity_time_us;
+};
+
+} // namespace musin::ui
+
+#endif // MUSIN_UI_DRUMPAD_CONFIG_H


### PR DESCRIPTION
## What changed

Seven commits from an architecture review pass, each independently reviewable:

1. **docs**: AGENTS.md now documents submodule initialization for fresh git worktrees (host tests and firmware builds fail cryptically without it).
2. **refactor: musin no longer includes drum headers** — `DrumpadConfig` moved to `musin/ui/drumpad_config.h`; `TempoHandler` takes the tempo-knob BPM range via `set_tempo_control_range()` and the `RETRIGGER_SYNC_ON_PLAYBUTTON` policy check moved to its caller; generic `sysex::Chunk` moved to `musin/midi/sysex_chunk.h`. The library boundary is now real: nothing under `musin/` depends on `drum/`.
3. **fix: SysEx chunk lifetime** — queued chunks were non-owning views into the MIDI driver's receive buffer, which can be reused before the queue drains. `Chunk` now copies its payload into an owned 2046-byte buffer and lives in a dedicated depth-2 queue (transfers are ACK-paced), keeping the 2 KB buffer out of all 64 slots of the main message queue. Costs ~4 KB bss.
4. **fix: rand() seeding** — both `srand(time_us_32())` calls ran during static init where the boot clock is near-identical every power-up, making the RANDOM effect close to deterministic per boot. Now seeded once in `main()` from `get_rand_32()`.
5. **fix**: the non-const `Track::get_step` overload now bounds-asserts like the const one.
6. **chore**: removed change-narration comments and dead code (`send_midi_cc`/`send_midi_note` stubs); corrected the SysEx buffer size comment in `midi_output_queue.h` (2048, not 128); documented why `process_midi_output_queue` is intentionally called twice per loop (#527 latency).
7. **refactor: SequencerController decomposition** — extracted `SequencerEffectRepeat` and `SequencerEffectRetrigger` alongside the existing swing/random effects, wrapped the optional flash storage in `SequencerPersistenceManager`, and collapsed five parallel per-track arrays into one `TrackState` array. Controller cpp drops from 909 to ~770 lines; public API unchanged; the two-stage RANDOM button contract (soft press = offset swap, hard press = + probability flip) is now documented on the effect.

## Why

Review found the musin/drum split leaking in four places, a latent use-after-reuse in the SysEx input path, and a controller that had absorbed five concerns. Net diff is negative despite four new files.

## Verification

- Host test suite: 50/50 passing (`test/run_all_tests.sh`)
- Firmware builds clean for RP2350 (`drum/build.sh -n`); bss +6 KB from the owned chunk queue
- Behavior preserved throughout: repeat/retrigger/persistence semantics are exact moves, including `get_repeat_length()` returning 0 while inactive

## Reviewer notes

- The chunk-header rename lands in commit 2 as a pure rename; the owning-buffer rewrite is separate in commit 3, so both diffs stay readable.
- Only the final commit was build-verified; intermediates were grouped to compile but not individually built.
- Known follow-up (flagged, not included): the *outgoing* MIDI queue has the same 2 KB-per-slot union problem (~128 KB bss) and would benefit from the same dedicated-queue treatment.