### PR TITLE
Drum trace visualizations

### DIFF
--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -459,7 +459,29 @@ void SequencerController<NumTracks, NumSteps>::record_velocity_hit(
     uint8_t track_index) {
   if (track_index < NumTracks) {
     track_states_[track_index].has_velocity_hit = true;
+    record_pad_hit_trace(track_index);
   }
+}
+
+template <size_t NumTracks, size_t NumSteps>
+void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
+    uint8_t track_index) {
+  if (_running && track_index < NumTracks) {
+    TrackState &track_state = track_states_[track_index];
+    const size_t cursor_step =
+        track_state.just_played_step.value_or(get_current_step());
+    track_state.last_pad_hit = PadHitTrace{cursor_step, get_absolute_time()};
+  }
+}
+
+template <size_t NumTracks, size_t NumSteps>
+std::optional<PadHitTrace>
+SequencerController<NumTracks, NumSteps>::get_last_pad_hit_for_track(
+    uint8_t track_index) const {
+  if (track_index < NumTracks) {
+    return track_states_[track_index].last_pad_hit;
+  }
+  return std::nullopt;
 }
 
 template <size_t NumTracks, size_t NumSteps>
@@ -511,6 +533,7 @@ void SequencerController<NumTracks, NumSteps>::update() {
           get_active_note_for_track(static_cast<uint8_t>(track_idx));
       trigger_note_on(static_cast<uint8_t>(track_idx), note_to_play,
                       drum::config::drumpad::RETRIGGER_VELOCITY);
+      record_pad_hit_trace(static_cast<uint8_t>(track_idx));
     }
   }
 
@@ -546,6 +569,7 @@ void SequencerController<NumTracks, NumSteps>::update() {
           get_active_note_for_track(static_cast<uint8_t>(track_idx));
       trigger_note_on(static_cast<uint8_t>(track_idx), note_to_play,
                       drum::config::drumpad::RETRIGGER_VELOCITY);
+      record_pad_hit_trace(static_cast<uint8_t>(track_idx));
     }
   }
 

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -17,6 +17,7 @@
 #include <optional>
 
 #include "musin/hal/logger.h"
+#include "pico/time.h"
 #include "sequencer_effect_random.h"
 #include "sequencer_effect_repeat.h"
 #include "sequencer_effect_retrigger.h"
@@ -26,6 +27,16 @@
 #include <cstddef>
 
 namespace drum {
+
+/**
+ * @brief Records where and when a drumpad was hit while the sequencer ran.
+ * Consumed by the display to draw a fading trace note on the sequencer ring;
+ * never affects playback or stored patterns.
+ */
+struct PadHitTrace {
+  size_t step_index;
+  absolute_time_t timestamp;
+};
 
 namespace musical_timing {
 constexpr uint8_t PPQN = 12;
@@ -43,6 +54,7 @@ struct TrackState {
   bool has_velocity_hit{false};
   std::optional<uint8_t> last_played_note{};
   std::optional<size_t> just_played_step{};
+  std::optional<PadHitTrace> last_pad_hit{};
 };
 
 // Forward declare the specific Sequencer instantiation from its new namespace
@@ -230,6 +242,14 @@ public:
   [[nodiscard]] bool has_recent_velocity_hit(uint8_t track_index) const;
 
   /**
+   * @brief Gets the most recent drumpad hit recorded while the sequencer was
+   * running, for display purposes. Returns std::nullopt if no hit has been
+   * recorded for the track.
+   */
+  [[nodiscard]] std::optional<PadHitTrace>
+  get_last_pad_hit_for_track(uint8_t track_index) const;
+
+  /**
    * @brief Get the current retrigger mode for a track.
    * @param track_index The track index to check.
    * @return 0 for off, 1 for single retrigger, 2 for double retrigger.
@@ -275,6 +295,12 @@ private:
 
   [[nodiscard]] size_t calculate_base_step_index() const;
   void process_track_step(size_t track_idx, size_t step_index_to_play);
+
+  /**
+   * @brief Stores a display trace for a live hit (drumpad or retrigger) on the
+   * track's current cursor step. No-op when the sequencer is stopped.
+   */
+  void record_pad_hit_trace(uint8_t track_index);
 
   void initialize_active_notes();
   void initialize_all_sequencers();

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -184,13 +184,9 @@ void SequencerDisplayMode::draw_sequencer_state(PizzaDisplay &display,
 
 void SequencerDisplayMode::update_track_override_colors(
     PizzaDisplay &display) const {
-  // While running, pad hits are shown as fading traces on the cursor step
-  // instead of flashing the whole ring.
-  bool ring_flash_enabled = !_sequencer_controller_ref.is_running();
   for (uint8_t track_idx = 0;
        track_idx < PizzaDisplay::SEQUENCER_TRACKS_DISPLAYED; ++track_idx) {
-    if (ring_flash_enabled &&
-        _sequencer_controller_ref.has_recent_velocity_hit(track_idx)) {
+    if (_sequencer_controller_ref.has_recent_velocity_hit(track_idx)) {
       uint8_t active_note =
           _sequencer_controller_ref.get_active_note_for_track(track_idx);
       std::optional<Color> color_opt =

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -72,6 +72,8 @@ SequencerDisplayMode::SequencerDisplayMode(
 
 void SequencerDisplayMode::draw(PizzaDisplay &display, absolute_time_t now) {
   sync_highlight_phase_with_step();
+  measure_step_period(now);
+  update_pad_traces();
   draw_base_elements(display, now);
   draw_animations(display, now);
 }
@@ -124,6 +126,16 @@ void SequencerDisplayMode::draw_sequencer_state(PizzaDisplay &display,
       Color base_step_color = calculate_step_color(display, step);
       Color final_color = base_step_color;
 
+      // Pad-hit traces only show on steps that display as empty; steps with
+      // a visible note already give feedback on their own.
+      if (is_running && base_step_color == 0u) {
+        std::optional<Color> trace_color =
+            calculate_trace_color(display, track_idx, step_idx, now);
+        if (trace_color.has_value()) {
+          final_color = trace_color.value();
+        }
+      }
+
       // Apply track override color if active
       if (track_idx < display._track_override_colors.size() &&
           display._track_override_colors[track_idx].has_value()) {
@@ -172,9 +184,13 @@ void SequencerDisplayMode::draw_sequencer_state(PizzaDisplay &display,
 
 void SequencerDisplayMode::update_track_override_colors(
     PizzaDisplay &display) const {
+  // While running, pad hits are shown as fading traces on the cursor step
+  // instead of flashing the whole ring.
+  bool ring_flash_enabled = !_sequencer_controller_ref.is_running();
   for (uint8_t track_idx = 0;
        track_idx < PizzaDisplay::SEQUENCER_TRACKS_DISPLAYED; ++track_idx) {
-    if (_sequencer_controller_ref.has_recent_velocity_hit(track_idx)) {
+    if (ring_flash_enabled &&
+        _sequencer_controller_ref.has_recent_velocity_hit(track_idx)) {
       uint8_t active_note =
           _sequencer_controller_ref.get_active_note_for_track(track_idx);
       std::optional<Color> color_opt =
@@ -317,6 +333,96 @@ bool SequencerDisplayMode::is_highlight_bright(
   // When stopped: use phase-based blinking managed by PizzaDisplay
   // This provides consistent blinking on phases 0 and 12
   return display._highlight_is_bright.load(std::memory_order_relaxed);
+}
+
+void SequencerDisplayMode::measure_step_period(absolute_time_t now) {
+  if (!_sequencer_controller_ref.is_running()) {
+    _last_timed_step = std::nullopt;
+    _last_step_change_time = nil_time;
+    return;
+  }
+
+  uint32_t current_step = _sequencer_controller_ref.get_current_step();
+  if (_last_timed_step.has_value() &&
+      _last_timed_step.value() == current_step) {
+    return;
+  }
+
+  if (!is_nil_time(_last_step_change_time)) {
+    _measured_step_period_us = static_cast<uint64_t>(
+        absolute_time_diff_us(_last_step_change_time, now));
+  }
+  _last_timed_step = current_step;
+  _last_step_change_time = now;
+}
+
+void SequencerDisplayMode::update_pad_traces() {
+  if (!_sequencer_controller_ref.is_running()) {
+    clear_pad_traces();
+    return;
+  }
+
+  for (uint8_t track_idx = 0; track_idx < config::NUM_TRACKS; ++track_idx) {
+    auto hit = _sequencer_controller_ref.get_last_pad_hit_for_track(track_idx);
+    if (!hit.has_value() ||
+        to_us_since_boot(hit->timestamp) ==
+            to_us_since_boot(_last_trace_timestamps[track_idx])) {
+      continue;
+    }
+    _last_trace_timestamps[track_idx] = hit->timestamp;
+    if (hit->step_index < config::NUM_STEPS_PER_TRACK) {
+      _trace_start_times[track_idx][hit->step_index] = hit->timestamp;
+    }
+  }
+}
+
+void SequencerDisplayMode::clear_pad_traces() {
+  for (auto &track_traces : _trace_start_times) {
+    track_traces.fill(nil_time);
+  }
+}
+
+uint64_t SequencerDisplayMode::trace_fade_duration_us() const {
+  uint64_t step_period_us = (_measured_step_period_us != 0)
+                                ? _measured_step_period_us
+                                : DEFAULT_STEP_PERIOD_US;
+  return static_cast<uint64_t>(static_cast<float>(step_period_us) *
+                               TRACE_FADE_STEPS);
+}
+
+std::optional<Color>
+SequencerDisplayMode::calculate_trace_color(const PizzaDisplay &display,
+                                            size_t track_idx, size_t step_idx,
+                                            absolute_time_t now) {
+  absolute_time_t start = _trace_start_times[track_idx][step_idx];
+  if (is_nil_time(start)) {
+    return std::nullopt;
+  }
+
+  // A hit recorded later in the same main-loop iteration carries a timestamp
+  // slightly ahead of the `now` this frame draws with; treat it as just
+  // started rather than expired.
+  int64_t elapsed_us = std::max<int64_t>(absolute_time_diff_us(start, now), 0);
+  uint64_t duration_us = trace_fade_duration_us();
+  if (static_cast<uint64_t>(elapsed_us) >= duration_us) {
+    _trace_start_times[track_idx][step_idx] = nil_time;
+    return std::nullopt;
+  }
+
+  uint8_t active_note = _sequencer_controller_ref.get_active_note_for_track(
+      static_cast<uint8_t>(track_idx));
+  std::optional<Color> base_color =
+      display.get_color_for_midi_note(active_note);
+  if (!base_color.has_value()) {
+    return std::nullopt;
+  }
+
+  float fade_factor =
+      1.0f - (static_cast<float>(elapsed_us) / static_cast<float>(duration_us));
+  uint8_t brightness =
+      static_cast<uint8_t>(PizzaDisplay::MAX_BRIGHTNESS * fade_factor);
+  return Color(display._leds.adjust_color_brightness(
+      static_cast<uint32_t>(base_color.value()), brightness));
 }
 
 // --- FileTransferDisplayMode Implementation ---

--- a/drum/ui/display_mode.h
+++ b/drum/ui/display_mode.h
@@ -4,6 +4,7 @@
 #include "drum/config.h"
 #include "drum/sequencer_controller.h"
 #include "drum/ui/color.h"
+#include "etl/array.h"
 #include "musin/timing/step_sequencer.h"
 #include "musin/timing/tempo_handler.h"
 #include "pico/time.h"
@@ -34,6 +35,12 @@ public:
   void draw(PizzaDisplay &display, absolute_time_t now) override;
 
 private:
+  // A pad-hit trace fades out over this many step durations, so it is gone
+  // well before the cursor wraps around the 8-step ring.
+  static constexpr float TRACE_FADE_STEPS = 6.0f;
+  // Step period assumed until one has been measured (eighth note at 120 BPM).
+  static constexpr uint64_t DEFAULT_STEP_PERIOD_US = 250'000;
+
   void draw_base_elements(PizzaDisplay &display, absolute_time_t now);
   void draw_animations(PizzaDisplay &display, absolute_time_t now) const;
   void draw_sequencer_state(PizzaDisplay &display, absolute_time_t now);
@@ -43,11 +50,25 @@ private:
   static Color apply_pulsing_highlight(Color base_color, bool bright_phase);
   void sync_highlight_phase_with_step();
   bool is_highlight_bright(const PizzaDisplay &display) const;
+  void measure_step_period(absolute_time_t now);
+  void update_pad_traces();
+  void clear_pad_traces();
+  [[nodiscard]] uint64_t trace_fade_duration_us() const;
+  std::optional<Color> calculate_trace_color(const PizzaDisplay &display,
+                                             size_t track_idx, size_t step_idx,
+                                             absolute_time_t now);
   drum::SequencerController<config::NUM_TRACKS, config::NUM_STEPS_PER_TRACK>
       &_sequencer_controller_ref;
   musin::timing::TempoHandler &_tempo_handler_ref;
   std::optional<uint32_t> _last_synced_step_index{};
   bool _bright_phase_for_current_step = true;
+  etl::array<etl::array<absolute_time_t, config::NUM_STEPS_PER_TRACK>,
+             config::NUM_TRACKS>
+      _trace_start_times{};
+  etl::array<absolute_time_t, config::NUM_TRACKS> _last_trace_timestamps{};
+  std::optional<uint32_t> _last_timed_step{};
+  absolute_time_t _last_step_change_time = nil_time;
+  uint64_t _measured_step_period_us = 0;
 };
 
 // --- Concrete Strategy for File Transfer Mode ---

--- a/drum/ui/display_mode.h
+++ b/drum/ui/display_mode.h
@@ -35,9 +35,8 @@ public:
   void draw(PizzaDisplay &display, absolute_time_t now) override;
 
 private:
-  // A pad-hit trace fades out over this many step durations, so it is gone
-  // well before the cursor wraps around the 8-step ring.
-  static constexpr float TRACE_FADE_STEPS = 6.0f;
+  // A pad-hit trace fades out over this many step durations.
+  static constexpr float TRACE_FADE_STEPS = 8.0f;
   // Step period assumed until one has been measured (eighth note at 120 BPM).
   static constexpr uint64_t DEFAULT_STEP_PERIOD_US = 250'000;
 


### PR DESCRIPTION
Fixes #431

Adds a drum trace visualization that shows manually hit drums as fading steps.