### PR TITLE
fix: buy TBYB firmware on any boot type via BUY_PENDING flag

### DIFF
--- a/drum/firmware_update_buyer.cpp
+++ b/drum/firmware_update_buyer.cpp
@@ -16,9 +16,10 @@ FirmwareUpdateBuyer::FirmwareUpdateBuyer(musin::Logger &logger)
     : logger_(logger) {
   boot_info_t boot_info{};
   if (rom_get_boot_info(&boot_info) != 0 &&
-      boot_info.boot_type == BOOT_TYPE_FLASH_UPDATE) {
+      (boot_info.tbyb_and_update_info &
+       BOOT_TBYB_AND_UPDATE_FLAG_BUY_PENDING)) {
     trial_boot_pending_ = true;
-    logger_.info("FirmwareUpdateBuyer: Trial boot detected, partition",
+    logger_.info("FirmwareUpdateBuyer: Buy pending, partition",
                  static_cast<int32_t>(boot_info.partition));
   }
 }


### PR DESCRIPTION
## Problem

`FirmwareUpdateBuyer` only armed `trial_boot_pending_` when the boot type was exactly `BOOT_TYPE_FLASH_UPDATE`:

```cpp
if (rom_get_boot_info(&boot_info) != 0 &&
    boot_info.boot_type == BOOT_TYPE_FLASH_UPDATE) {
```

Since #556, **every** image is built with `PICO_CRT0_IMAGE_TYPE_TBYB=1`, so any image — however it was flashed — boots in try-before-you-buy mode and must be committed with `rom_explicit_buy()` or the bootrom reverts to the previous image on the next reboot.

Images flashed via **BOOTSEL UF2 drag-drop** or **picotool** do not report `BOOT_TYPE_FLASH_UPDATE`, so the buyer never armed, never bought, and the device silently reverted to the old firmware. This contradicted the buyer's own header comment ("…SysEx updates, picotool loads and UF2 drag-drop alike").

## Fix

Detect the running image's pending state directly from the bootrom's `tbyb_and_update_info` `BOOT_TBYB_AND_UPDATE_FLAG_BUY_PENDING` flag, which the bootrom sets whenever the current image still carries an uncommitted explicit-buy flag — independent of how it booted. This:

- arms the buyer for SysEx, picotool, and UF2 drag-drop loads alike, and
- is a no-op for already-bought images (the flag is clear), avoiding a needless flash-sector rewrite on every normal boot.

`update()` and the buy logic are unchanged.

## Testing

Verified on hardware: a UF2 drag-drop load of the patched firmware now self-commits after the health period and persists across reboots (`tbyb: bought`), where the previous build reverted to the prior partition.