### PR TITLE
feat: quantize drum trace visualization into early/late step zones

### DIFF
--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -474,12 +474,12 @@ void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
     // trace is quantized forward; a hit clearly between two steps belongs to
     // neither and leaves no trace. Only the visualization is affected; the
     // sounded note keeps its live timing.
-    switch (musical_timing::hit_zone_from_phase(last_phase_12_)) {
-    case musical_timing::HitZone::Early:
+    switch (swing_effect_.classify_hit_phase(last_phase_12_)) {
+    case SequencerEffectSwing::HitZone::Early:
       break;
-    case musical_timing::HitZone::Middle:
+    case SequencerEffectSwing::HitZone::Middle:
       return;
-    case musical_timing::HitZone::Late:
+    case SequencerEffectSwing::HitZone::Late:
       trace_step = (trace_step + 1) % NumSteps;
       break;
     }

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -135,6 +135,7 @@ void SequencerController<NumTracks, NumSteps>::reset() {
   deactivate_repeat();
   disable_random_offset_mode();
   disable_random_probability_mode();
+  clear_traces();
   for (size_t i = 0; i < NumTracks; ++i) {
     deactivate_play_on_every_step(static_cast<uint8_t>(i));
   }
@@ -193,6 +194,7 @@ void SequencerController<NumTracks, NumSteps>::stop() {
 
   random_effect_.reset_to_inactive();
   random_intends_flip_ = false;
+  clear_traces();
 }
 
 template <size_t NumTracks, size_t NumSteps>
@@ -483,18 +485,35 @@ void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
       trace_step = (trace_step + 1) % NumSteps;
       break;
     }
-    track_state.last_pad_hit = PadHitTrace{trace_step, get_absolute_time()};
+    trace_velocities_[track_index][trace_step] = TRACE_INITIAL_VELOCITY;
   }
 }
 
 template <size_t NumTracks, size_t NumSteps>
-std::optional<PadHitTrace>
-SequencerController<NumTracks, NumSteps>::get_last_pad_hit_for_track(
-    uint8_t track_index) const {
-  if (track_index < NumTracks) {
-    return track_states_[track_index].last_pad_hit;
+void SequencerController<NumTracks, NumSteps>::fade_traces() {
+  constexpr uint8_t DECREMENT =
+      (TRACE_INITIAL_VELOCITY + TRACE_FADE_STEPS - 1) / TRACE_FADE_STEPS;
+  for (auto &track_traces : trace_velocities_) {
+    for (auto &velocity : track_traces) {
+      velocity = (velocity > DECREMENT) ? (velocity - DECREMENT) : 0;
+    }
   }
-  return std::nullopt;
+}
+
+template <size_t NumTracks, size_t NumSteps>
+void SequencerController<NumTracks, NumSteps>::clear_traces() {
+  for (auto &track_traces : trace_velocities_) {
+    track_traces.fill(0);
+  }
+}
+
+template <size_t NumTracks, size_t NumSteps>
+uint8_t SequencerController<NumTracks, NumSteps>::get_trace_velocity(
+    size_t track_idx, size_t step_idx) const {
+  if (track_idx < NumTracks && step_idx < NumSteps) {
+    return trace_velocities_[track_idx][step_idx];
+  }
+  return 0;
 }
 
 template <size_t NumTracks, size_t NumSteps>
@@ -554,6 +573,10 @@ void SequencerController<NumTracks, NumSteps>::update() {
     return;
   }
   _step_is_due = false;
+
+  // Fade before this step's hits are recorded, so a fresh trace stays at
+  // full brightness for the whole step window it landed on.
+  fade_traces();
 
   size_t base_step_index = calculate_base_step_index();
 

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -468,9 +468,22 @@ void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
     uint8_t track_index) {
   if (_running && track_index < NumTracks) {
     TrackState &track_state = track_states_[track_index];
-    const size_t cursor_step =
+    size_t trace_step =
         track_state.just_played_step.value_or(get_current_step());
-    track_state.last_pad_hit = PadHitTrace{cursor_step, get_absolute_time()};
+    // A hit late in the step feels like it anticipates the next step, so the
+    // trace is quantized forward; a hit clearly between two steps belongs to
+    // neither and leaves no trace. Only the visualization is affected; the
+    // sounded note keeps its live timing.
+    switch (musical_timing::hit_zone_from_phase(last_phase_12_)) {
+    case musical_timing::HitZone::Early:
+      break;
+    case musical_timing::HitZone::Middle:
+      return;
+    case musical_timing::HitZone::Late:
+      trace_step = (trace_step + 1) % NumSteps;
+      break;
+    }
+    track_state.last_pad_hit = PadHitTrace{trace_step, get_absolute_time()};
   }
 }
 

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -233,6 +233,12 @@ void SequencerController<NumTracks, NumSteps>::notification(
     return;
   }
 
+  // Accumulate elapsed ticks for trace fading; drained in update().
+  const uint32_t elapsed_ticks =
+      (event.phase_12 + musin::timing::DEFAULT_PPQN - last_phase_12_) %
+      musin::timing::DEFAULT_PPQN;
+  pending_trace_fade_ticks_.fetch_add(elapsed_ticks, std::memory_order_relaxed);
+
   // Calculate swing timing using the dedicated effect
   const size_t next_index = calculate_base_step_index();
   const auto timing = swing_effect_.calculate_step_timing(
@@ -469,6 +475,14 @@ template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
     uint8_t track_index) {
   if (_running && track_index < NumTracks) {
+    // Apply fade for ticks that elapsed before this hit, so the elapsed time
+    // doesn't age the fresh trace.
+    const uint32_t fade_ticks =
+        pending_trace_fade_ticks_.exchange(0, std::memory_order_relaxed);
+    if (fade_ticks > 0) {
+      fade_traces(fade_ticks);
+    }
+
     TrackState &track_state = track_states_[track_index];
     size_t trace_step =
         track_state.just_played_step.value_or(get_current_step());
@@ -490,12 +504,16 @@ void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
 }
 
 template <size_t NumTracks, size_t NumSteps>
-void SequencerController<NumTracks, NumSteps>::fade_traces() {
-  constexpr uint8_t DECREMENT =
-      (TRACE_INITIAL_VELOCITY + TRACE_FADE_STEPS - 1) / TRACE_FADE_STEPS;
+void SequencerController<NumTracks, NumSteps>::fade_traces(
+    uint32_t elapsed_ticks) {
+  constexpr uint32_t DECREMENT_PER_TICK =
+      (TRACE_INITIAL_VELOCITY + TRACE_FADE_TICKS - 1) / TRACE_FADE_TICKS;
+  const uint32_t decrement = DECREMENT_PER_TICK * elapsed_ticks;
   for (auto &track_traces : trace_velocities_) {
     for (auto &velocity : track_traces) {
-      velocity = (velocity > DECREMENT) ? (velocity - DECREMENT) : 0;
+      velocity = (velocity > decrement)
+                     ? static_cast<uint8_t>(velocity - decrement)
+                     : 0;
     }
   }
 }
@@ -569,14 +587,16 @@ void SequencerController<NumTracks, NumSteps>::update() {
     }
   }
 
+  const uint32_t fade_ticks =
+      pending_trace_fade_ticks_.exchange(0, std::memory_order_relaxed);
+  if (fade_ticks > 0) {
+    fade_traces(fade_ticks);
+  }
+
   if (!_step_is_due) {
     return;
   }
   _step_is_due = false;
-
-  // Fade before this step's hits are recorded, so a fresh trace stays at
-  // full brightness for the whole step window it landed on.
-  fade_traces();
 
   size_t base_step_index = calculate_base_step_index();
 

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -29,16 +29,6 @@
 
 namespace drum {
 
-/**
- * @brief Records where and when a drumpad was hit while the sequencer ran.
- * Consumed by the display to draw a fading trace note on the sequencer ring;
- * never affects playback or stored patterns.
- */
-struct PadHitTrace {
-  size_t step_index;
-  absolute_time_t timestamp;
-};
-
 namespace musical_timing {
 constexpr uint8_t PPQN = 12;
 constexpr uint8_t DOWNBEAT = 0;
@@ -56,7 +46,6 @@ struct TrackState {
   bool has_velocity_hit{false};
   std::optional<uint8_t> last_played_note{};
   std::optional<size_t> just_played_step{};
-  std::optional<PadHitTrace> last_pad_hit{};
 };
 
 // Forward declare the specific Sequencer instantiation from its new namespace
@@ -245,12 +234,14 @@ public:
   [[nodiscard]] bool has_recent_velocity_hit(uint8_t track_index) const;
 
   /**
-   * @brief Gets the most recent drumpad hit recorded while the sequencer was
-   * running, for display purposes. Returns std::nullopt if no hit has been
-   * recorded for the track.
+   * @brief Gets the current trace velocity for a step, for display purposes.
+   * Live hits land in a trace layer overlaid on the pattern; each step
+   * advance fades all traces linearly so they reach zero within
+   * TRACE_FADE_STEPS steps. Never affects playback or stored patterns.
+   * @return 0 when no trace is active on the step.
    */
-  [[nodiscard]] std::optional<PadHitTrace>
-  get_last_pad_hit_for_track(uint8_t track_index) const;
+  [[nodiscard]] uint8_t get_trace_velocity(size_t track_idx,
+                                           size_t step_idx) const;
 
   /**
    * @brief Get the current retrigger mode for a track.
@@ -305,6 +296,19 @@ private:
    */
   void record_pad_hit_trace(uint8_t track_index);
 
+  /**
+   * @brief Fades all trace velocities by one step's worth of brightness.
+   * Called once per step advance so traces age in lockstep with the cursor,
+   * regardless of swing timing.
+   */
+  void fade_traces();
+  void clear_traces();
+
+  // Trace velocities match the MIDI velocity range so the display maps them
+  // to brightness exactly like pattern steps.
+  static constexpr uint8_t TRACE_INITIAL_VELOCITY = 127;
+  static constexpr uint8_t TRACE_FADE_STEPS = 8;
+
   void initialize_active_notes();
   void initialize_all_sequencers();
   void initialize_timing_and_random();
@@ -315,6 +319,7 @@ private:
       sequencer_;
   uint32_t scheduled_step_counter_;
   etl::array<TrackState, NumTracks> track_states_{};
+  etl::array<etl::array<uint8_t, NumSteps>, NumTracks> trace_velocities_{};
   musin::timing::TempoHandler &tempo_source;
   bool _running = false;
   std::atomic<bool> _step_is_due = false;

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -42,9 +42,9 @@ struct PadHitTrace {
 namespace musical_timing {
 constexpr uint8_t PPQN = 12;
 constexpr uint8_t DOWNBEAT = 0;
-constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2;      // 6
-constexpr uint8_t TRIPLET_SUBDIVISION = PPQN / 3;   // 4
-constexpr uint8_t SIXTEENTH_SUBDIVISION = PPQN / 4; // 3
+constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2;       // 6
+constexpr uint8_t TRIPLET_SUBDIVISION = PPQN / 3;    // 4
+constexpr uint8_t SIXTEENTH_SUBDIVISION = PPQN / 4;  // 3
 constexpr uint8_t TICKS_PER_STEP = STRAIGHT_OFFBEAT; // 6
 
 /**

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -46,34 +46,6 @@ constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2;       // 6
 constexpr uint8_t TRIPLET_SUBDIVISION = PPQN / 3;    // 4
 constexpr uint8_t SIXTEENTH_SUBDIVISION = PPQN / 4;  // 3
 constexpr uint8_t TICKS_PER_STEP = STRAIGHT_OFFBEAT; // 6
-
-/**
- * @brief Where within a step's timing window a live hit landed.
- * A step spans 6 clock ticks. Early hits trace on the step that just played,
- * Late hits feel like they anticipate the upcoming step so they trace forward,
- * and Middle hits sit clearly between two steps and leave no trace. The zone
- * widths are one tick each; widen them here if that feels too narrow. Zones
- * use the straight grid and ignore swing.
- */
-enum class HitZone : uint8_t {
-  Early,
-  Middle,
-  Late,
-};
-
-constexpr uint8_t EARLY_ZONE_TICKS = 1;
-constexpr uint8_t LATE_ZONE_TICKS = 1;
-
-constexpr HitZone hit_zone_from_phase(uint8_t phase_12) {
-  const uint8_t tick_in_step = phase_12 % TICKS_PER_STEP;
-  if (tick_in_step < EARLY_ZONE_TICKS) {
-    return HitZone::Early;
-  }
-  if (tick_in_step >= TICKS_PER_STEP - LATE_ZONE_TICKS) {
-    return HitZone::Late;
-  }
-  return HitZone::Middle;
-}
 } // namespace musical_timing
 
 /**

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -297,17 +297,20 @@ private:
   void record_pad_hit_trace(uint8_t track_index);
 
   /**
-   * @brief Fades all trace velocities by one step's worth of brightness.
-   * Called once per step advance so traces age in lockstep with the cursor,
-   * regardless of swing timing.
+   * @brief Fades all trace velocities by the given number of clock ticks.
+   * Ticks are accumulated in notification() and drained in update(), so all
+   * traces age together on the uniform 12 PPQN grid — smooth in wall time
+   * and immune to swing's uneven step lengths.
    */
-  void fade_traces();
+  void fade_traces(uint32_t elapsed_ticks);
   void clear_traces();
 
   // Trace velocities match the MIDI velocity range so the display maps them
   // to brightness exactly like pattern steps.
   static constexpr uint8_t TRACE_INITIAL_VELOCITY = 127;
   static constexpr uint8_t TRACE_FADE_STEPS = 8;
+  static constexpr uint32_t TRACE_FADE_TICKS =
+      TRACE_FADE_STEPS * musical_timing::TICKS_PER_STEP;
 
   void initialize_active_notes();
   void initialize_all_sequencers();
@@ -320,6 +323,7 @@ private:
   uint32_t scheduled_step_counter_;
   etl::array<TrackState, NumTracks> track_states_{};
   etl::array<etl::array<uint8_t, NumSteps>, NumTracks> trace_velocities_{};
+  std::atomic<uint32_t> pending_trace_fade_ticks_{0};
   musin::timing::TempoHandler &tempo_source;
   bool _running = false;
   std::atomic<bool> _step_is_due = false;

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -45,6 +45,35 @@ constexpr uint8_t DOWNBEAT = 0;
 constexpr uint8_t STRAIGHT_OFFBEAT = PPQN / 2;      // 6
 constexpr uint8_t TRIPLET_SUBDIVISION = PPQN / 3;   // 4
 constexpr uint8_t SIXTEENTH_SUBDIVISION = PPQN / 4; // 3
+constexpr uint8_t TICKS_PER_STEP = STRAIGHT_OFFBEAT; // 6
+
+/**
+ * @brief Where within a step's timing window a live hit landed.
+ * A step spans 6 clock ticks. Early hits trace on the step that just played,
+ * Late hits feel like they anticipate the upcoming step so they trace forward,
+ * and Middle hits sit clearly between two steps and leave no trace. The zone
+ * widths are one tick each; widen them here if that feels too narrow. Zones
+ * use the straight grid and ignore swing.
+ */
+enum class HitZone : uint8_t {
+  Early,
+  Middle,
+  Late,
+};
+
+constexpr uint8_t EARLY_ZONE_TICKS = 1;
+constexpr uint8_t LATE_ZONE_TICKS = 1;
+
+constexpr HitZone hit_zone_from_phase(uint8_t phase_12) {
+  const uint8_t tick_in_step = phase_12 % TICKS_PER_STEP;
+  if (tick_in_step < EARLY_ZONE_TICKS) {
+    return HitZone::Early;
+  }
+  if (tick_in_step >= TICKS_PER_STEP - LATE_ZONE_TICKS) {
+    return HitZone::Late;
+  }
+  return HitZone::Middle;
+}
 } // namespace musical_timing
 
 /**

--- a/drum/sequencer_effect_swing.cpp
+++ b/drum/sequencer_effect_swing.cpp
@@ -14,7 +14,22 @@ constexpr uint32_t SIXTEENTH_MASK =
     (1u << 0) | (1u << 3) | (1u << 6) | (1u << 9);
 constexpr uint32_t TRIPLET_MASK = (1u << 0) | (1u << 4) | (1u << 8);
 constexpr uint32_t MASK12 = (1u << 12) - 1u;
+
+constexpr uint32_t rotl12(uint32_t mask, uint8_t rotation) {
+  return ((mask << rotation) | (mask >> (12 - rotation))) & MASK12;
+}
 } // namespace
+
+uint8_t SequencerEffectSwing::onset_phase_for_parity(bool is_even) const {
+  const uint8_t straight_phase = is_even ? DOWNBEAT : STRAIGHT_OFFBEAT;
+  const bool is_delayed =
+      swing_enabled_ && (swing_delays_odd_steps_ ? !is_even : is_even);
+  if (is_delayed) {
+    return static_cast<uint8_t>(
+        (straight_phase + drum::config::timing::SWING_OFFSET_PHASES) % PPQN);
+  }
+  return straight_phase;
+}
 
 SequencerEffectSwing::StepTiming SequencerEffectSwing::calculate_step_timing(
     size_t next_index, bool repeat_active, uint64_t transport_step) const {
@@ -24,31 +39,44 @@ SequencerEffectSwing::StepTiming SequencerEffectSwing::calculate_step_timing(
   const bool next_is_even =
       repeat_active ? ((transport_step & 1u) == 0) : ((next_index & 1u) == 0);
 
-  // Calculate base expected phase (straight timing)
-  uint8_t expected_phase = next_is_even ? DOWNBEAT : STRAIGHT_OFFBEAT;
-
-  // Apply swing delay if enabled and this step should be delayed
-  bool is_delay_applied = false;
-  if (swing_enabled_) {
-    const bool should_delay = (swing_delays_odd_steps_ && !next_is_even) ||
-                              (!swing_delays_odd_steps_ && next_is_even);
-    if (should_delay) {
-      expected_phase = static_cast<uint8_t>(
-          (expected_phase + drum::config::timing::SWING_OFFSET_PHASES) % PPQN);
-      is_delay_applied = true;
-    }
-  }
+  const uint8_t expected_phase = onset_phase_for_parity(next_is_even);
+  const uint8_t straight_phase = next_is_even ? DOWNBEAT : STRAIGHT_OFFBEAT;
+  const bool is_delay_applied = expected_phase != straight_phase;
 
   // Select appropriate retrigger mask based on swing state
   const uint32_t base_mask = swing_enabled_ ? TRIPLET_MASK : SIXTEENTH_MASK;
 
   // Rotate the mask by the expected phase to align retriggers with the main
   // step
-  const uint8_t rotation = expected_phase;
-  const uint32_t substep_mask =
-      ((base_mask << rotation) | (base_mask >> (12 - rotation))) & MASK12;
+  const uint32_t substep_mask = rotl12(base_mask, expected_phase);
 
   return {expected_phase, substep_mask, is_delay_applied};
+}
+
+SequencerEffectSwing::HitZone
+SequencerEffectSwing::classify_hit_phase(uint8_t phase_12) const {
+  // Zone masks anchored at phase 0: Early covers the ticks at and just after
+  // an onset, Late covers the ticks just before it.
+  constexpr uint32_t EARLY_BASE = (1u << EARLY_ZONE_TICKS) - 1u;
+  constexpr uint32_t LATE_BASE = ((1u << LATE_ZONE_TICKS) - 1u)
+                                 << (PPQN - LATE_ZONE_TICKS);
+
+  const uint8_t even_onset = onset_phase_for_parity(true);
+  const uint8_t odd_onset = onset_phase_for_parity(false);
+
+  const uint32_t early_mask =
+      rotl12(EARLY_BASE, even_onset) | rotl12(EARLY_BASE, odd_onset);
+  const uint32_t late_mask =
+      rotl12(LATE_BASE, even_onset) | rotl12(LATE_BASE, odd_onset);
+
+  const uint32_t phase_bit = 1u << (phase_12 % PPQN);
+  if ((early_mask & phase_bit) != 0u) {
+    return HitZone::Early;
+  }
+  if ((late_mask & phase_bit) != 0u) {
+    return HitZone::Late;
+  }
+  return HitZone::Middle;
 }
 
 void SequencerEffectSwing::set_swing_enabled(bool enabled) {

--- a/drum/sequencer_effect_swing.h
+++ b/drum/sequencer_effect_swing.h
@@ -25,6 +25,32 @@ public:
   };
 
   /**
+   * @brief Where within a step's timing window a live hit landed.
+   * Early hits trace on the step that just played, Late hits feel like they
+   * anticipate the upcoming step so they trace forward, and Middle hits sit
+   * clearly between two steps and leave no trace. Zones are anchored on the
+   * actual (swung) step onsets, so they follow the cursor in every swing
+   * direction. The zone widths are one tick each; widen them here if that
+   * feels too narrow.
+   */
+  enum class HitZone : uint8_t {
+    Early,
+    Middle,
+    Late,
+  };
+
+  static constexpr uint8_t EARLY_ZONE_TICKS = 1;
+  static constexpr uint8_t LATE_ZONE_TICKS = 1;
+
+  /**
+   * @brief Classify a live hit's clock phase relative to the swung step grid.
+   * @param phase_12 Clock phase in [0, 11] at the moment of the hit
+   * @return Early if just after a step onset, Late if just before the next
+   * onset, Middle otherwise
+   */
+  [[nodiscard]] HitZone classify_hit_phase(uint8_t phase_12) const;
+
+  /**
    * @brief Calculate complete timing information for a step.
    * @param next_index The step index that will be played next
    * @param repeat_active Whether repeat mode is currently active
@@ -55,6 +81,8 @@ public:
   void set_swing_target(bool delay_odd);
 
 private:
+  [[nodiscard]] uint8_t onset_phase_for_parity(bool is_even) const;
+
   bool swing_enabled_{false};
   bool swing_delays_odd_steps_{true};
 };

--- a/drum/ui/display_mode.cpp
+++ b/drum/ui/display_mode.cpp
@@ -72,8 +72,6 @@ SequencerDisplayMode::SequencerDisplayMode(
 
 void SequencerDisplayMode::draw(PizzaDisplay &display, absolute_time_t now) {
   sync_highlight_phase_with_step();
-  measure_step_period(now);
-  update_pad_traces();
   draw_base_elements(display, now);
   draw_animations(display, now);
 }
@@ -130,7 +128,7 @@ void SequencerDisplayMode::draw_sequencer_state(PizzaDisplay &display,
       // a visible note already give feedback on their own.
       if (is_running && base_step_color == 0u) {
         std::optional<Color> trace_color =
-            calculate_trace_color(display, track_idx, step_idx, now);
+            calculate_trace_color(display, track_idx, step_idx);
         if (trace_color.has_value()) {
           final_color = trace_color.value();
         }
@@ -331,77 +329,11 @@ bool SequencerDisplayMode::is_highlight_bright(
   return display._highlight_is_bright.load(std::memory_order_relaxed);
 }
 
-void SequencerDisplayMode::measure_step_period(absolute_time_t now) {
-  if (!_sequencer_controller_ref.is_running()) {
-    _last_timed_step = std::nullopt;
-    _last_step_change_time = nil_time;
-    return;
-  }
-
-  uint32_t current_step = _sequencer_controller_ref.get_current_step();
-  if (_last_timed_step.has_value() &&
-      _last_timed_step.value() == current_step) {
-    return;
-  }
-
-  if (!is_nil_time(_last_step_change_time)) {
-    _measured_step_period_us = static_cast<uint64_t>(
-        absolute_time_diff_us(_last_step_change_time, now));
-  }
-  _last_timed_step = current_step;
-  _last_step_change_time = now;
-}
-
-void SequencerDisplayMode::update_pad_traces() {
-  if (!_sequencer_controller_ref.is_running()) {
-    clear_pad_traces();
-    return;
-  }
-
-  for (uint8_t track_idx = 0; track_idx < config::NUM_TRACKS; ++track_idx) {
-    auto hit = _sequencer_controller_ref.get_last_pad_hit_for_track(track_idx);
-    if (!hit.has_value() ||
-        to_us_since_boot(hit->timestamp) ==
-            to_us_since_boot(_last_trace_timestamps[track_idx])) {
-      continue;
-    }
-    _last_trace_timestamps[track_idx] = hit->timestamp;
-    if (hit->step_index < config::NUM_STEPS_PER_TRACK) {
-      _trace_start_times[track_idx][hit->step_index] = hit->timestamp;
-    }
-  }
-}
-
-void SequencerDisplayMode::clear_pad_traces() {
-  for (auto &track_traces : _trace_start_times) {
-    track_traces.fill(nil_time);
-  }
-}
-
-uint64_t SequencerDisplayMode::trace_fade_duration_us() const {
-  uint64_t step_period_us = (_measured_step_period_us != 0)
-                                ? _measured_step_period_us
-                                : DEFAULT_STEP_PERIOD_US;
-  return static_cast<uint64_t>(static_cast<float>(step_period_us) *
-                               TRACE_FADE_STEPS);
-}
-
-std::optional<Color>
-SequencerDisplayMode::calculate_trace_color(const PizzaDisplay &display,
-                                            size_t track_idx, size_t step_idx,
-                                            absolute_time_t now) {
-  absolute_time_t start = _trace_start_times[track_idx][step_idx];
-  if (is_nil_time(start)) {
-    return std::nullopt;
-  }
-
-  // A hit recorded later in the same main-loop iteration carries a timestamp
-  // slightly ahead of the `now` this frame draws with; treat it as just
-  // started rather than expired.
-  int64_t elapsed_us = std::max<int64_t>(absolute_time_diff_us(start, now), 0);
-  uint64_t duration_us = trace_fade_duration_us();
-  if (static_cast<uint64_t>(elapsed_us) >= duration_us) {
-    _trace_start_times[track_idx][step_idx] = nil_time;
+std::optional<Color> SequencerDisplayMode::calculate_trace_color(
+    const PizzaDisplay &display, size_t track_idx, size_t step_idx) const {
+  uint8_t velocity =
+      _sequencer_controller_ref.get_trace_velocity(track_idx, step_idx);
+  if (velocity == 0) {
     return std::nullopt;
   }
 
@@ -413,10 +345,12 @@ SequencerDisplayMode::calculate_trace_color(const PizzaDisplay &display,
     return std::nullopt;
   }
 
-  float fade_factor =
-      1.0f - (static_cast<float>(elapsed_us) / static_cast<float>(duration_us));
-  uint8_t brightness =
-      static_cast<uint8_t>(PizzaDisplay::MAX_BRIGHTNESS * fade_factor);
+  // Same velocity-to-brightness mapping as pattern steps.
+  uint16_t calculated_brightness = static_cast<uint16_t>(velocity) *
+                                   PizzaDisplay::VELOCITY_TO_BRIGHTNESS_SCALE;
+  uint8_t brightness = static_cast<uint8_t>(
+      std::min(calculated_brightness,
+               static_cast<uint16_t>(PizzaDisplay::MAX_BRIGHTNESS)));
   return Color(display._leds.adjust_color_brightness(
       static_cast<uint32_t>(base_color.value()), brightness));
 }

--- a/drum/ui/display_mode.h
+++ b/drum/ui/display_mode.h
@@ -35,11 +35,6 @@ public:
   void draw(PizzaDisplay &display, absolute_time_t now) override;
 
 private:
-  // A pad-hit trace fades out over this many step durations.
-  static constexpr float TRACE_FADE_STEPS = 8.0f;
-  // Step period assumed until one has been measured (eighth note at 120 BPM).
-  static constexpr uint64_t DEFAULT_STEP_PERIOD_US = 250'000;
-
   void draw_base_elements(PizzaDisplay &display, absolute_time_t now);
   void draw_animations(PizzaDisplay &display, absolute_time_t now) const;
   void draw_sequencer_state(PizzaDisplay &display, absolute_time_t now);
@@ -49,25 +44,14 @@ private:
   static Color apply_pulsing_highlight(Color base_color, bool bright_phase);
   void sync_highlight_phase_with_step();
   bool is_highlight_bright(const PizzaDisplay &display) const;
-  void measure_step_period(absolute_time_t now);
-  void update_pad_traces();
-  void clear_pad_traces();
-  [[nodiscard]] uint64_t trace_fade_duration_us() const;
   std::optional<Color> calculate_trace_color(const PizzaDisplay &display,
-                                             size_t track_idx, size_t step_idx,
-                                             absolute_time_t now);
+                                             size_t track_idx,
+                                             size_t step_idx) const;
   drum::SequencerController<config::NUM_TRACKS, config::NUM_STEPS_PER_TRACK>
       &_sequencer_controller_ref;
   musin::timing::TempoHandler &_tempo_handler_ref;
   std::optional<uint32_t> _last_synced_step_index{};
   bool _bright_phase_for_current_step = true;
-  etl::array<etl::array<absolute_time_t, config::NUM_STEPS_PER_TRACK>,
-             config::NUM_TRACKS>
-      _trace_start_times{};
-  etl::array<absolute_time_t, config::NUM_TRACKS> _last_trace_timestamps{};
-  std::optional<uint32_t> _last_timed_step{};
-  absolute_time_t _last_step_change_time = nil_time;
-  uint64_t _measured_step_period_us = 0;
 };
 
 // --- Concrete Strategy for File Transfer Mode ---

--- a/test/drum/sequencer_effect_swing_test.cpp
+++ b/test/drum/sequencer_effect_swing_test.cpp
@@ -526,4 +526,42 @@ TEST_CASE("SequencerEffectSwing retrigger mask tests",
   }
 }
 
+TEST_CASE("SequencerEffectSwing hit zone classification",
+          "[sequencer_effect_swing]") {
+  SequencerEffectSwing swing_effect;
+  using HitZone = SequencerEffectSwing::HitZone;
+
+  auto zones_for_onsets = [&](uint8_t even_onset, uint8_t odd_onset) {
+    for (uint8_t phase = 0; phase < PHASES_PER_BEAT; ++phase) {
+      HitZone expected = HitZone::Middle;
+      if (phase == even_onset || phase == odd_onset) {
+        expected = HitZone::Early;
+      } else if (phase ==
+                     (even_onset + PHASES_PER_BEAT - 1) % PHASES_PER_BEAT ||
+                 phase == (odd_onset + PHASES_PER_BEAT - 1) % PHASES_PER_BEAT) {
+        expected = HitZone::Late;
+      }
+      INFO("phase " << static_cast<int>(phase));
+      REQUIRE(swing_effect.classify_hit_phase(phase) == expected);
+    }
+  };
+
+  SECTION("Straight timing anchors zones at phases 0 and 6") {
+    swing_effect.set_swing_enabled(false);
+    zones_for_onsets(DOWNBEAT, OFFBEAT);
+  }
+
+  SECTION("Swing delaying odd steps moves the offbeat zones") {
+    swing_effect.set_swing_enabled(true);
+    swing_effect.set_swing_target(true);
+    zones_for_onsets(DOWNBEAT, OFFBEAT + config::timing::SWING_OFFSET_PHASES);
+  }
+
+  SECTION("Swing delaying even steps moves the downbeat zones") {
+    swing_effect.set_swing_enabled(true);
+    swing_effect.set_swing_target(false);
+    zones_for_onsets(config::timing::SWING_OFFSET_PHASES, OFFBEAT);
+  }
+}
+
 } // namespace drum


### PR DESCRIPTION
## Summary
When live drumming along with the running sequencer, a hit that lands just before the sequencer advances leaves its trace on the step *before* where the drummer feels it was played. This PR quantizes the trace visualization (and only the visualization — the sounded note keeps its live timing) using the DUO's Early/Middle/Late zone concept:

- **Early** (first tick of the step's 6-tick window): trace on the step that just played, as before.
- **Late** (last tick): trace quantized forward onto the next step, matching the intuition that a hit just ahead of the beat belongs to the upcoming step.
- **Middle** (ticks 1–4): dead zone — a hit clearly between two steps belongs to neither and leaves no trace.

Zone widths are `EARLY_ZONE_TICKS` / `LATE_ZONE_TICKS` constants (currently 1 tick ≈ 17% each) so they're easy to widen to 2 ticks if playtesting says they're too narrow.

**Swing-aware zones:** zone classification lives in `SequencerEffectSwing`, which rotates the early/late zone masks onto the actual (swung) step onsets using the same rotation as the retrigger substep mask. Traces follow the cursor in both swing directions; straight timing is unchanged.

**Step-synced fading:** traces are stored as a velocity grid overlaid on the pattern in the sequencer controller, replacing the old wall-clock fade in the display code. Hits land at full velocity (placed by the swing-aware zones) and fade by a fixed decrement per 12 PPQN clock tick, reaching zero within `TRACE_FADE_STEPS` (8) steps. Because all traces age together on the uniform tick grid, swing can no longer make adjacent fading traces alternate in brightness (the old measured-step-period timebase oscillated 2:1 under swing). This also removes the `PadHitTrace` timestamps and the stale-`now` clamp they required; the display maps trace velocities to brightness exactly like pattern steps. Traces clear on stop and reset.

Behavior note: retrigger hits share this path. Step-boundary retriggers (tick 0) still trace; sixteenth-substep retriggers (tick 3) fall in the dead zone and no longer trace.

Follow-up to #431 / the trace feature from 55adbbe4 experiments.

## Test plan
- Zone boundary logic verified with static asserts and swing-rotation unit tests (`sequencer_effect_swing_test.cpp`)
- All host tests pass
- Firmware builds cleanly via `drum/build.sh`
- Needs a hardware play test to confirm the forward-quantized trace, dead zone, and tick-fade feel right
