### PR TITLE
fix: XIP builds are safe for SysEx firmware updates

### DIFF
--- a/drum/README.md
+++ b/drum/README.md
@@ -225,7 +225,14 @@ firmware.uf2` is the reference client.
 Notes:
 - Firmware images are built with the TBYB flag, so picotool/BOOTSEL loads also
   self-commit on first boot via the same mechanism.
-- Only RAM builds (`PICO_COPY_TO_RAM`, the default) are relocatable between
-  partitions and safe to distribute for SysEx updates.
+- Both RAM (`PICO_COPY_TO_RAM`, the default) and flash (XIP) builds are
+  relocatable between partitions and safe to distribute for SysEx updates.
+  Images are linked to the XIP window base (0x10000000), and the RP2350
+  bootrom programs QMI address translation on every partition boot so the
+  booted partition appears at that address; partition A is not at flash
+  offset 0, so even A-boots rely on this. Flash reads that must bypass the
+  translation (e.g. the data partition) use storage offsets or the
+  untranslated XIP alias. Verified on hardware in both directions (A->B and
+  B->A) with an XIP build.
 - If both partitions ever hold invalid images, the bootrom falls back to the
   USB (UF2) bootloader; LED indication is not possible in that mode.

--- a/drum/build.sh
+++ b/drum/build.sh
@@ -167,10 +167,10 @@ if [ "$COPY_TO_RAM" = true ]; then
   CMAKE_ARGS="$CMAKE_ARGS -DPICO_COPY_TO_RAM=ON"
   echo "Building for RAM execution..."
 else
+  # Explicitly OFF: a cached PICO_COPY_TO_RAM=ON from a previous RAM build
+  # would otherwise silently persist and produce a RAM build.
+  CMAKE_ARGS="$CMAKE_ARGS -DPICO_COPY_TO_RAM=OFF"
   echo "Building for Flash execution..."
-  echo "WARNING: Flash (XIP) builds are linked to partition A's address and are"
-  echo "         NOT safe to distribute for SysEx firmware updates, which may"
-  echo "         place the image in partition B. Only RAM builds are relocatable."
 fi
 
 if [ "$VERBOSE" = true ]; then


### PR DESCRIPTION
## Summary
- Remove the incorrect `build.sh` warning claiming flash (XIP) builds are "linked to partition A's address" and unsafe to distribute for SysEx A/B updates
- Correct the corresponding note in `drum/README.md`
- Fix `build.sh -f` not passing `-DPICO_COPY_TO_RAM=OFF`: a cached `ON` from a previous RAM build silently produced a RAM build

## Why the warning was wrong
XIP builds are linked to the XIP window base (`0x10000000`), not to partition A's storage address. Partition A itself starts at flash offset `0x2000`, so **every** partition boot — A included — already depends on the RP2350 bootrom programming QMI address translation to map the booted partition to the XIP base. Partition B is no different. The rest of the update path was already translation-safe: pico-vfs reads the data partition through the untranslated XIP alias, and all flash writes use storage offsets from the partition table.

## Hardware verification
XIP build of current `main` (454 KB UF2) streamed over MIDI SysEx with `drumtool.js flash`, both directions:
- **A→B**: SHA-256 verified, trial boot from B, self-committed — partition B dump is byte-identical to the build except the TBYB flag byte (0x90→0x10), which only `rom_explicit_buy` running inside the trial image can flip
- **B→A**: `picotool info --debug` showed `last booted partition: 0` right after the trial reboot; A's TBYB flag committed as well
- MIDI version/identity/storage queries (exercising data-partition filesystem reads) worked from both slots

One operational caveat found during testing: opening/polling the USB-CDC serial port during the ~5 s TBYB trial window can prevent the self-commit; updaters should leave the device alone right after the trial reboot.