### PR TITLE
fix: keep audio_i2s.c out of flash so the audio ISR survives flash erase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,25 @@ DRUM is a MIDI drum machine/sequencer running on RP2350 microcontroller. Feature
 - **Hardware failure handling** essential
 - **Power state awareness** needed
 
+### Audio ISR RAM Residency (XIP builds)
+Audio renders inside the I2S DMA interrupt (priority 0), which stays enabled
+during flash erase/program (`musin/filesystem/audio_safe_flash.cpp`). Every
+function reachable from that interrupt — **including through function
+pointers** (`BufferSource` vtables, `audio_connection_t` take/give members) —
+must be RAM-resident, or the device hard-faults and watchdog-reboots when the
+interrupt fires mid-erase on an XIP cache miss. Symptom: random watchdog
+reboots, typically ~10 s after interaction (the debounced sequencer state save).
+
+When touching the audio path or `drum/memmap_xip_rodata_in_ram.ld`:
+- Annotate new audio-path code `__time_critical_func`/`__not_in_flash_func`,
+  or exclude its translation unit from flash in the linker script (see the
+  `pico_audio/audio.cpp.o` and `pico_audio_i2s/audio_i2s.c.o` exclusions).
+- Verify by disassembling the ELF and walking the call graph from the ISR
+  roots (`fill_buffers_from_irq`, `audio_i2s_dma_irq_handler`, buffer-pool and
+  connection functions, all `fill_buffer`/`read_samples` implementations): no
+  reachable function may have a flash address (`0x10xxxxxx`). A flash-side
+  `*_veneer` symbol for an ISR-tree function means a flash caller exists.
+
 ## Development Workflow
 
 ### Building & Testing

--- a/drum/memmap_xip_rodata_in_ram.ld
+++ b/drum/memmap_xip_rodata_in_ram.ld
@@ -64,7 +64,7 @@ SECTIONS
            and must stay callable during flash erase, so (unlike the SDK
            default script this file is based on) the whole translation unit
            is kept out of flash and falls through to RAM via .data below. */
-        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *pico_audio/audio.cpp.o) .text*)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *pico_audio/audio.cpp.o *pico_audio_i2s/audio_i2s.c.o) .text*)
         *(.fini)
         /* Pull all c'tors into .text */
         *crtbegin.o(.ctors)


### PR DESCRIPTION
## Problem

Since #555, the DRUM randomly crashes with a watchdog reboot, most often while interacting with the device (reported on `main`; not reproducible at or before c2b89b75).

## Root cause

#555 moved audio rendering into the I2S DMA interrupt (priority 0) and deliberately keeps that interrupt enabled during flash erase/program (`audio_safe_flash.cpp` BASEPRI masking). That requires the entire ISR call tree to be RAM-resident.

One function was missed: `wrap_consumer_take` (pico-extras `audio_i2s.c`) was linked into flash at `0x10013550`. It runs on **every** DMA interrupt via a function-pointer chain that direct call-graph inspection doesn't see:

`audio_i2s_dma_irq_handler` → `take_audio_buffer` → `connection->consumer_pool_take` → `wrap_consumer_take`

The linker script's flash exclusion covered `pico_audio/audio.cpp.o` but not `pico_audio_i2s/audio_i2s.c.o`, and only the IRQ handler itself is `__time_critical_func` in that file. When the interrupt fires mid-erase and the XIP cache misses that line, the instruction fetch returns garbage → hard fault → 4 s watchdog reboot.

This explains both symptoms:
- **Interaction correlation**: any edit marks sequencer state dirty, scheduling a flash save 10 s later (`SAVE_DEBOUNCE_MS`); each save is a crash window.
- **Randomness**: `wrap_consumer_take` runs every ~2.9 ms so it's usually XIP-cached; the crash needs its cache line evicted during the erase window.

## Fix

Add `*pico_audio_i2s/audio_i2s.c.o` to the `EXCLUDE_FILE` list in `memmap_xip_rodata_in_ram.ld`, keeping the whole translation unit in RAM — same approach as the existing `audio.cpp.o` exclusion. Costs ~1.5 kB of RAM.

Also documents the RAM-residency constraint and verification procedure in AGENTS.md.

## Verification

Static: disassembled the ELF and BFS-walked the call graph from all audio-ISR roots (render tree, buffer-pool functions, connection functions, all vtable implementations). Before: `wrap_consumer_take` reachable in flash (the flash-side `__mono_to_stereo_consumer_take_veneer` was the tell). After: **zero** flash-resident functions reachable from the audio interrupt.

⚠️ Needs hardware confirmation: flash this build, edit a pattern while playing, and let it run — crashes previously reproduced within a few edit-plus-10-second cycles.