### PR TITLE
feat: SysEx sequencer state read/write + persistent device settings

### DIFF
--- a/drum/CMakeLists.txt
+++ b/drum/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(${EXECUTABLE_NAME}
   main.cpp
   midi_manager.cpp
   sysex_handler.cpp
+  settings_manager.cpp
   firmware_update_buyer.cpp
   ../musin/flash/firmware_writer.cpp
   pizza_controls.cpp

--- a/drum/README.md
+++ b/drum/README.md
@@ -236,3 +236,52 @@ Notes:
   B->A) with an XIP build.
 - If both partitions ever hold invalid images, the bootrom falls back to the
   USB (UF2) bootloader; LED indication is not possible in that mode.
+
+### Sequencer State Commands
+These commands allow reading and writing the current sequencer pattern state, including step velocities and active note assignments for each track.
+
+#### RequestSequencerState (0x30)
+Requests the current sequencer state from the device. No payload.
+
+**Response:** The device replies with a `SequencerStateResponse` message containing the current pattern.
+
+#### SequencerStateResponse (0x31)
+The device's response to `RequestSequencerState`, containing the full sequencer state.
+
+**Response Format:**
+```
+F0 00 22 01 65 31 <Payload> F7
+```
+
+**Payload (37 bytes):**
+- Byte 0: Payload format version (currently `1`)
+- Bytes 1-32: Velocity data for all steps (4 tracks x 8 steps)
+  - Track 0 steps (0-7): bytes 1-8
+  - Track 1 steps (0-7): bytes 9-16
+  - Track 2 steps (0-7): bytes 17-24
+  - Track 3 steps (0-7): bytes 25-32
+  - Velocity 0 = step disabled, 1-127 = step enabled with velocity
+- Bytes 33-36: Active MIDI note per track
+  - Track 0 note: byte 33
+  - Track 1 note: byte 34
+  - Track 2 note: byte 35
+  - Track 3 note: byte 36
+
+All values are 7-bit MIDI-compliant (0-127).
+
+#### SetSequencerState (0x32)
+Sets the sequencer state on the device.
+
+**Command Format:**
+```
+F0 00 22 01 65 32 <Payload> F7
+```
+
+**Payload:** Same 37-byte versioned structure as `SequencerStateResponse` (see above), sent as raw 7-bit bytes directly after the command byte (no 3-to-16bit packing, unlike `BeginFileWrite`).
+
+**Response:** The device replies with `Ack` (0x13) on success, or `Nack` (0x14) if the payload is malformed, too short, or has an unsupported version byte.
+
+**Notes:**
+- The leading version byte lets the device reject payloads from a mismatched protocol version instead of misinterpreting the data. If the payload format ever changes, this version byte is bumped.
+- Setting sequencer state marks the internal storage as dirty, triggering an automatic save to flash after a debounce period.
+- Sample selection is done by sending MIDI note numbers matching the desired sample slots (as documented in the MIDI Note Numbers section above).

--- a/drum/README.md
+++ b/drum/README.md
@@ -253,19 +253,18 @@ The device's response to `RequestSequencerState`, containing the full sequencer 
 F0 00 22 01 65 31 <Payload> F7
 ```
 
-**Payload (37 bytes):**
-- Byte 0: Payload format version (currently `1`)
-- Bytes 1-32: Velocity data for all steps (4 tracks x 8 steps)
-  - Track 0 steps (0-7): bytes 1-8
-  - Track 1 steps (0-7): bytes 9-16
-  - Track 2 steps (0-7): bytes 17-24
-  - Track 3 steps (0-7): bytes 25-32
+**Payload (36 bytes):**
+- Bytes 0-31: Velocity data for all steps (4 tracks x 8 steps)
+  - Track 0 steps (0-7): bytes 0-7
+  - Track 1 steps (0-7): bytes 8-15
+  - Track 2 steps (0-7): bytes 16-23
+  - Track 3 steps (0-7): bytes 24-31
   - Velocity 0 = step disabled, 1-127 = step enabled with velocity
-- Bytes 33-36: Active MIDI note per track
-  - Track 0 note: byte 33
-  - Track 1 note: byte 34
-  - Track 2 note: byte 35
-  - Track 3 note: byte 36
+- Bytes 32-35: Active MIDI note per track
+  - Track 0 note: byte 32
+  - Track 1 note: byte 33
+  - Track 2 note: byte 34
+  - Track 3 note: byte 35
 
 All values are 7-bit MIDI-compliant (0-127).
 
@@ -277,11 +276,11 @@ Sets the sequencer state on the device.
 F0 00 22 01 65 32 <Payload> F7
 ```
 
-**Payload:** Same 37-byte versioned structure as `SequencerStateResponse` (see above), sent as raw 7-bit bytes directly after the command byte (no 3-to-16bit packing, unlike `BeginFileWrite`).
+**Payload:** Same 36-byte structure as `SequencerStateResponse` (see above), sent as raw 7-bit bytes directly after the command byte (no 3-to-16bit packing, unlike `BeginFileWrite`).
 
-**Response:** The device replies with `Ack` (0x13) on success, or `Nack` (0x14) if the payload is malformed, too short, or has an unsupported version byte.
+**Response:** The device replies with `Ack` (0x13) on success, or `Nack` (0x14) if the payload is malformed or too short.
 
 **Notes:**
-- The leading version byte lets the device reject payloads from a mismatched protocol version instead of misinterpreting the data. If the payload format ever changes, this version byte is bumped.
+- If the payload layout ever changes, a new SysEx tag should be introduced for the new format so existing tools keep working.
 - Setting sequencer state marks the internal storage as dirty, triggering an automatic save to flash after a debounce period.
 - Sample selection is done by sending MIDI note numbers matching the desired sample slots (as documented in the MIDI Note Numbers section above).

--- a/drum/README.md
+++ b/drum/README.md
@@ -1,7 +1,7 @@
 # DATO DRUM MIDI Implementation Chart
 
 ## General Settings
-- **Default MIDI Channel:** 10 (GM Percussion Standard)
+- **Default MIDI Channel:** 10 (GM Percussion Standard), configurable via the `SetSetting` SysEx command (see Settings Commands below)
 - **Note Off Messages:** Ignored
 - **Velocity Range:** 1-127
 - **Clock:** Master by default, slave when external clock detected
@@ -113,7 +113,7 @@
 - **Stops when sequencer stopped**
 
 ## Configuration Notes
-- All MIDI channels, CC numbers, and note mappings configurable via web interface
+- The MIDI channel is configurable via the `SetSetting` SysEx command (see Settings Commands below)
 - Sample-to-note mapping updates in real-time during sample selection
 - **MIDI Input:** Receiving a note plays that sound on the corresponding track AND sets that note as the active sample for that track
 - MIDI Clock input automatically detected and followed
@@ -284,3 +284,43 @@ F0 00 22 01 65 32 <Payload> F7
 - If the payload layout ever changes, a new SysEx tag should be introduced for the new format so existing tools keep working.
 - Setting sequencer state marks the internal storage as dirty, triggering an automatic save to flash after a debounce period.
 - Sample selection is done by sending MIDI note numbers matching the desired sample slots (as documented in the MIDI Note Numbers section above).
+
+### Settings Commands
+
+Generic key-value access to device settings. Each setting has a 7-bit id, a
+valid range, and a compile-time default (see `drum/settings.h`). Values are
+persisted on the device as one file per setting under `/settings/`; a missing
+or invalid file means the default applies.
+
+| Setting | ID | Range | Default | Description |
+|---------|-----|-------|---------|-------------|
+| `midi_channel` | 0x01 | 1-16 | 10 | MIDI channel for incoming and outgoing notes and CCs |
+
+#### GetSetting (0x40)
+Requests the current value of one setting.
+
+**Command Format:**
+```
+F0 00 22 01 65 40 <setting id> F7
+```
+
+**Response:** A `SettingValue` message, or `Nack` (0x14) for unknown setting ids.
+
+#### SettingValue (0x41)
+The device's response to `GetSetting`.
+
+**Response Format:**
+```
+F0 00 22 01 65 41 <setting id> <value> F7
+```
+
+#### SetSetting (0x42)
+Sets and persists one setting. The new value takes effect immediately.
+
+**Command Format:**
+```
+F0 00 22 01 65 42 <setting id> <value> F7
+```
+
+**Response:** `Ack` (0x13) on success, or `Nack` (0x14) for unknown setting
+ids, out-of-range values, or persistence failures.

--- a/drum/config.h
+++ b/drum/config.h
@@ -25,10 +25,8 @@ constexpr float DISPLAY_BRIGHTNESS_MAX_VALUE = 255.0f;
 constexpr size_t MAX_PATH_LENGTH = 64;
 
 // MIDI Configuration
-constexpr uint8_t MIDI_IN_CHANNEL =
-    10; // Input MIDI Channel (GM Percussion Standard)
-constexpr uint8_t MIDI_OUT_CHANNEL =
-    10; // Output MIDI Channel (GM Percussion Standard)
+// The MIDI channel (default 10, GM Percussion Standard) is a runtime
+// setting; see drum/settings.h.
 constexpr bool SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER = true;
 constexpr bool SEND_SYNC_CLOCK_WHEN_STOPPED_AS_MASTER = true;
 constexpr bool RETRIGGER_SYNC_ON_PLAYBUTTON = true;

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -161,6 +161,9 @@ int main() {
   // internally.
   sequencer_controller.add_observer(message_router);
 
+  // Connect SysExHandler to SequencerController for sequencer state transfer
+  sysex_handler.set_sequencer_state_access(&sequencer_controller);
+
   // Register observers for SysEx state changes
   sysex_handler.add_observer(message_router);
   sysex_handler.add_observer(sequencer_controller);

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -16,6 +16,7 @@
 #include "drum/configuration_manager.h"
 #include "drum/firmware_update_buyer.h"
 #include "drum/midi_manager.h"
+#include "drum/settings_manager.h"
 #include "drum/sysex_handler.h"
 #include "musin/filesystem/filesystem.h"
 #include "sample_repository.h"
@@ -51,9 +52,12 @@ static musin::NullLogger null_logger;
 
 // Model
 static drum::ConfigurationManager config_manager(logger);
+static drum::settings::Settings settings;
+static drum::SettingsManager settings_manager(settings, logger);
 static drum::SampleRepository sample_repository(logger);
 static musin::filesystem::Filesystem filesystem(logger);
-static drum::SysExHandler sysex_handler(config_manager, logger, filesystem);
+static drum::SysExHandler sysex_handler(config_manager, settings_manager,
+                                        logger, filesystem);
 static drum::SampleSlotManager sample_slot_manager(logger);
 static drum::AudioEngine audio_engine(sample_repository, sample_slot_manager,
                                       logger);
@@ -82,11 +86,11 @@ static musin::midi::MidiSender midi_sender(
     musin::midi::MidiSendStrategy::QUEUED,
     null_logger); // Change to DIRECT_BYPASS_QUEUE for testing bypass
 static drum::MessageRouter message_router(audio_engine, sequencer_controller,
-                                          midi_sender, logger);
+                                          midi_sender, settings, logger);
 
 // MIDI Manager
 static drum::MidiManager midi_manager(message_router, midi_clock_processor,
-                                      sysex_handler, logger);
+                                      sysex_handler, settings, logger);
 
 // View
 static drum::PizzaDisplay pizza_display(sequencer_controller, tempo_handler,
@@ -121,6 +125,7 @@ int main() {
     filesystem.list_files("/"); // List files in the root directory
 
     config_manager.load();
+    settings_manager.init();
 
     // Initialize persistence subsystem now that filesystem is ready
     sequencer_controller.init_persistence();

--- a/drum/message_router.cpp
+++ b/drum/message_router.cpp
@@ -101,9 +101,10 @@ MessageRouter::MessageRouter(
     SequencerController<drum::config::NUM_TRACKS,
                         drum::config::NUM_STEPS_PER_TRACK>
         &sequencer_controller,
-    musin::midi::MidiSender &midi_sender, musin::Logger &logger)
+    musin::midi::MidiSender &midi_sender, const settings::Settings &settings,
+    musin::Logger &logger)
     : _audio_engine(audio_engine), _sequencer_controller(sequencer_controller),
-      _midi_sender(midi_sender), logger_(logger),
+      _midi_sender(midi_sender), settings_(settings), logger_(logger),
       _output_mode(OutputMode::BOTH), _local_control_mode(LocalControlMode::ON),
       _previous_local_control_mode(
           std::nullopt) { // Default local control to ON
@@ -157,7 +158,7 @@ void MessageRouter::set_parameter(Parameter param_id, float value,
   if (_output_mode == OutputMode::MIDI || _output_mode == OutputMode::BOTH) {
     uint8_t cc_number = map_parameter_to_midi_cc(param_id, track_index);
     if (cc_number > 0) {
-      uint8_t midi_channel = drum::config::MIDI_OUT_CHANNEL;
+      uint8_t midi_channel = settings_.get(settings::Id::MidiChannel);
       uint8_t midi_value = static_cast<uint8_t>(std::round(value * 127.0f));
       midi_value = std::min(midi_value, static_cast<uint8_t>(127));
 
@@ -210,8 +211,8 @@ void MessageRouter::update() {
                   static_cast<uint32_t>(event.track_index));
 
     if (_output_mode == OutputMode::MIDI || _output_mode == OutputMode::BOTH) {
-      _midi_sender.sendNoteOn(drum::config::MIDI_OUT_CHANNEL, event.note,
-                              event.velocity);
+      _midi_sender.sendNoteOn(settings_.get(settings::Id::MidiChannel),
+                              event.note, event.velocity);
     }
 
     if ((_output_mode == OutputMode::AUDIO ||

--- a/drum/message_router.h
+++ b/drum/message_router.h
@@ -5,6 +5,7 @@
 #include "config.h" // For NUM_TRACKS, NUM_STEPS_PER_TRACK and potentially message_router::MAX_NOTE_EVENT_OBSERVERS
 #include "etl/observer.h"
 #include "etl/queue.h"
+#include "drum/settings.h"
 #include "events.h" // Include NoteEvent definition
 #include "musin/hal/logger.h"
 #include "musin/midi/midi_sender.h"
@@ -58,7 +59,8 @@ public:
       AudioEngine &audio_engine,
       SequencerController<config::NUM_TRACKS, config::NUM_STEPS_PER_TRACK>
           &sequencer_controller,
-      musin::midi::MidiSender &midi_sender, musin::Logger &logger);
+      musin::midi::MidiSender &midi_sender,
+      const settings::Settings &settings, musin::Logger &logger);
 
   // Delete copy and move operations
   MessageRouter(const MessageRouter &) = delete;
@@ -182,6 +184,7 @@ private:
   SequencerController<config::NUM_TRACKS, config::NUM_STEPS_PER_TRACK>
       &_sequencer_controller;
   musin::midi::MidiSender &_midi_sender;
+  const settings::Settings &settings_;
   musin::Logger &logger_;
   OutputMode _output_mode;
   LocalControlMode _local_control_mode;

--- a/drum/message_router.h
+++ b/drum/message_router.h
@@ -3,9 +3,9 @@
 
 #include "audio_engine.h"
 #include "config.h" // For NUM_TRACKS, NUM_STEPS_PER_TRACK and potentially message_router::MAX_NOTE_EVENT_OBSERVERS
+#include "drum/settings.h"
 #include "etl/observer.h"
 #include "etl/queue.h"
-#include "drum/settings.h"
 #include "events.h" // Include NoteEvent definition
 #include "musin/hal/logger.h"
 #include "musin/midi/midi_sender.h"
@@ -59,8 +59,8 @@ public:
       AudioEngine &audio_engine,
       SequencerController<config::NUM_TRACKS, config::NUM_STEPS_PER_TRACK>
           &sequencer_controller,
-      musin::midi::MidiSender &midi_sender,
-      const settings::Settings &settings, musin::Logger &logger);
+      musin::midi::MidiSender &midi_sender, const settings::Settings &settings,
+      musin::Logger &logger);
 
   // Delete copy and move operations
   MessageRouter(const MessageRouter &) = delete;

--- a/drum/midi_manager.cpp
+++ b/drum/midi_manager.cpp
@@ -19,10 +19,11 @@ MidiManager *MidiManager::instance_ = nullptr;
 MidiManager::MidiManager(
     MessageRouter &message_router,
     musin::timing::MidiClockProcessor &midi_clock_processor,
-    SysExHandler &sysex_handler, musin::Logger &logger)
+    SysExHandler &sysex_handler, const settings::Settings &settings,
+    musin::Logger &logger)
     : message_router_(message_router),
       midi_clock_processor_(midi_clock_processor),
-      sysex_handler_(sysex_handler), logger_(logger) {
+      sysex_handler_(sysex_handler), settings_(settings), logger_(logger) {
   assert(!instance_ && "Only one MidiManager instance is allowed.");
   instance_ = this;
 }
@@ -138,7 +139,7 @@ void MidiManager::stop_callback() {
 
 void MidiManager::handle_note_on(uint8_t channel, uint8_t note,
                                  uint8_t velocity) {
-  if (channel != drum::config::MIDI_IN_CHANNEL) {
+  if (channel != settings_.get(settings::Id::MidiChannel)) {
     return; // Ignore messages not on our input channel
   }
   message_router_.handle_incoming_note_on(note, velocity);
@@ -146,7 +147,7 @@ void MidiManager::handle_note_on(uint8_t channel, uint8_t note,
 
 void MidiManager::handle_note_off(uint8_t channel, uint8_t note,
                                   uint8_t velocity) {
-  if (channel != drum::config::MIDI_IN_CHANNEL) {
+  if (channel != settings_.get(settings::Id::MidiChannel)) {
     return; // Ignore messages not on our input channel
   }
   message_router_.handle_incoming_note_off(note, velocity);
@@ -154,7 +155,7 @@ void MidiManager::handle_note_off(uint8_t channel, uint8_t note,
 
 void MidiManager::handle_control_change(uint8_t channel, uint8_t controller,
                                         uint8_t value) {
-  if (channel != drum::config::MIDI_IN_CHANNEL) {
+  if (channel != settings_.get(settings::Id::MidiChannel)) {
     return; // Ignore messages not on our input channel
   }
   message_router_.handle_incoming_midi_cc(controller, value);

--- a/drum/midi_manager.h
+++ b/drum/midi_manager.h
@@ -1,6 +1,7 @@
 #ifndef DRUM_MIDI_MANAGER_H
 #define DRUM_MIDI_MANAGER_H
 
+#include "drum/settings.h"
 #include "musin/midi/sysex_chunk.h"
 #include <cstdint>
 
@@ -33,11 +34,13 @@ public:
    * @param message_router Reference to the router for Note/CC messages.
    * @param midi_clock_processor Reference to the processor for clock messages.
    * @param sysex_handler Reference to the handler for SysEx messages.
+   * @param settings Reference to the device settings (for the MIDI channel).
    * @param logger Reference to the system logger.
    */
   MidiManager(MessageRouter &message_router,
               musin::timing::MidiClockProcessor &midi_clock_processor,
-              SysExHandler &sysex_handler, musin::Logger &logger);
+              SysExHandler &sysex_handler, const settings::Settings &settings,
+              musin::Logger &logger);
 
   /**
    * @brief Initializes the MIDI hardware and sets up callbacks.
@@ -58,6 +61,7 @@ private:
   MessageRouter &message_router_;
   musin::timing::MidiClockProcessor &midi_clock_processor_;
   SysExHandler &sysex_handler_;
+  const settings::Settings &settings_;
   musin::Logger &logger_;
 
   // --- Singleton Instance for C Callbacks ---

--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -742,6 +742,29 @@ void SequencerController<NumTracks, NumSteps>::mark_state_dirty_public() {
 }
 
 template <size_t NumTracks, size_t NumSteps>
+SequencerPersistentState
+SequencerController<NumTracks, NumSteps>::get_current_state() const {
+  SequencerPersistentState state;
+  create_persistent_state(state);
+  return state;
+}
+
+template <size_t NumTracks, size_t NumSteps>
+bool SequencerController<NumTracks, NumSteps>::apply_state(
+    const SequencerPersistentState &state) {
+  if (!state.is_valid()) {
+    logger_.error("SequencerController: Cannot apply invalid state");
+    return false;
+  }
+
+  apply_persistent_state(state);
+  mark_state_dirty_public();
+
+  logger_.info("SequencerController: State applied successfully");
+  return true;
+}
+
+template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::enable_random_offset_mode() {
   random_effect_.request_state(RandomEffectState::OffsetActive,
                                is_repeat_active());

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -24,6 +24,7 @@
 #include "sequencer_effect_swing.h"
 #include "sequencer_persistence.h"
 #include "sequencer_persistence_manager.h"
+#include "sequencer_state_access.h"
 #include <cstddef>
 
 namespace drum {
@@ -74,7 +75,8 @@ class SequencerController
     : public etl::observer<musin::timing::TempoEvent>,
       public etl::observer<drum::Events::SysExTransferStateChangeEvent>,
       public etl::observable<etl::observer<drum::Events::NoteEvent>,
-                             drum::config::MAX_NOTE_EVENT_OBSERVERS> {
+                             drum::config::MAX_NOTE_EVENT_OBSERVERS>,
+      public SequencerStateAccess {
 public:
   /**
    * @brief Constructor.
@@ -390,6 +392,20 @@ public:
    * Call this after modifying sequencer patterns via get_sequencer().
    */
   void mark_state_dirty_public();
+
+  /**
+   * @brief Gets the current sequencer state for SysEx transfer.
+   * @return The current persistent state including all track velocities and
+   * active notes.
+   */
+  [[nodiscard]] SequencerPersistentState get_current_state() const override;
+
+  /**
+   * @brief Applies a sequencer state received via SysEx.
+   * @param state The state to apply to the sequencer.
+   * @return true if state was applied successfully, false on error.
+   */
+  bool apply_state(const SequencerPersistentState &state) override;
 };
 
 } // namespace drum

--- a/drum/sequencer_state_access.h
+++ b/drum/sequencer_state_access.h
@@ -1,0 +1,36 @@
+#ifndef DRUM_SEQUENCER_STATE_ACCESS_H
+#define DRUM_SEQUENCER_STATE_ACCESS_H
+
+#include "drum/sequencer_persistence.h"
+
+namespace drum {
+
+/**
+ * @brief Abstract accessor for reading/writing sequencer pattern state.
+ *
+ * Decouples consumers (e.g. SysExHandler) from the concrete
+ * SequencerController template instantiation, avoiding template coupling
+ * and void* casts across module boundaries.
+ */
+class SequencerStateAccess {
+public:
+  virtual ~SequencerStateAccess() = default;
+
+  /**
+   * @brief Gets the current sequencer state for external transfer.
+   * @return The current persistent state including all track velocities and
+   * active notes.
+   */
+  [[nodiscard]] virtual SequencerPersistentState get_current_state() const = 0;
+
+  /**
+   * @brief Applies an externally-provided sequencer state.
+   * @param state The state to apply to the sequencer.
+   * @return true if state was applied successfully, false on error.
+   */
+  virtual bool apply_state(const SequencerPersistentState &state) = 0;
+};
+
+} // namespace drum
+
+#endif // DRUM_SEQUENCER_STATE_ACCESS_H

--- a/drum/settings.h
+++ b/drum/settings.h
@@ -1,0 +1,98 @@
+#ifndef DRUM_SETTINGS_H
+#define DRUM_SETTINGS_H
+
+#include "etl/array.h"
+#include "etl/string_view.h"
+#include <cstddef>
+#include <cstdint>
+
+namespace drum::settings {
+
+/**
+ * @brief Identifiers for device settings, used as keys on the SysEx wire.
+ *
+ * Values must stay 7-bit safe (0x01-0x7F) and must never be reused for a
+ * different setting once released.
+ */
+enum class Id : uint8_t {
+  MidiChannel = 0x01,
+};
+
+/**
+ * @brief Describes one setting: wire id, short name, valid range and default.
+ *
+ * The name doubles as the filename under /settings/ on the device
+ * filesystem, so keep it short, lowercase and filesystem-safe.
+ */
+struct Descriptor {
+  Id id;
+  etl::string_view name;
+  uint8_t min;
+  uint8_t max;
+  uint8_t default_value;
+};
+
+inline constexpr etl::array<Descriptor, 1> DESCRIPTORS{{
+    {Id::MidiChannel, "midi_channel", 1, 16, 10},
+}};
+
+/**
+ * @brief Finds the descriptor for a setting id.
+ * @return Pointer into DESCRIPTORS, or nullptr for unknown ids.
+ */
+constexpr const Descriptor *find_descriptor(Id id) {
+  for (const auto &descriptor : DESCRIPTORS) {
+    if (descriptor.id == id) {
+      return &descriptor;
+    }
+  }
+  return nullptr;
+}
+
+/**
+ * @brief In-RAM store of all setting values.
+ *
+ * Values are always within their descriptor's range; set() rejects anything
+ * else. Persistence is handled separately by SettingsManager.
+ */
+class Settings {
+public:
+  constexpr Settings() {
+    for (size_t i = 0; i < DESCRIPTORS.size(); ++i) {
+      values_[i] = DESCRIPTORS[i].default_value;
+    }
+  }
+
+  [[nodiscard]] constexpr uint8_t get(Id id) const {
+    const auto *descriptor = find_descriptor(id);
+    if (descriptor == nullptr) {
+      return 0;
+    }
+    return values_[index_of(descriptor)];
+  }
+
+  /**
+   * @brief Sets a value after validating id and range.
+   * @return false for unknown ids or out-of-range values.
+   */
+  constexpr bool set(Id id, uint8_t value) {
+    const auto *descriptor = find_descriptor(id);
+    if (descriptor == nullptr || value < descriptor->min ||
+        value > descriptor->max) {
+      return false;
+    }
+    values_[index_of(descriptor)] = value;
+    return true;
+  }
+
+private:
+  static constexpr size_t index_of(const Descriptor *descriptor) {
+    return static_cast<size_t>(descriptor - DESCRIPTORS.data());
+  }
+
+  etl::array<uint8_t, DESCRIPTORS.size()> values_{};
+};
+
+} // namespace drum::settings
+
+#endif // DRUM_SETTINGS_H

--- a/drum/settings_manager.cpp
+++ b/drum/settings_manager.cpp
@@ -1,0 +1,96 @@
+#include "drum/settings_manager.h"
+
+#include <cstdio>
+#include <sys/stat.h>
+
+namespace drum {
+
+namespace {
+constexpr const char *SETTINGS_DIR = "/settings";
+constexpr size_t MAX_PATH_LENGTH = 64;
+
+bool build_path(const settings::Descriptor &descriptor,
+                char (&path)[MAX_PATH_LENGTH]) {
+  const int written = snprintf(path, MAX_PATH_LENGTH, "%s/%.*s", SETTINGS_DIR,
+                               static_cast<int>(descriptor.name.size()),
+                               descriptor.name.data());
+  return written > 0 && static_cast<size_t>(written) < MAX_PATH_LENGTH;
+}
+} // namespace
+
+SettingsManager::SettingsManager(settings::Settings &settings,
+                                 musin::Logger &logger)
+    : settings_(settings), logger_(logger) {
+}
+
+void SettingsManager::init() {
+  mkdir(SETTINGS_DIR, 0777); // Already existing is fine.
+
+  for (const auto &descriptor : settings::DESCRIPTORS) {
+    load_one(descriptor);
+  }
+}
+
+uint8_t SettingsManager::get(settings::Id id) const {
+  return settings_.get(id);
+}
+
+bool SettingsManager::set(settings::Id id, uint8_t value) {
+  const auto *descriptor = settings::find_descriptor(id);
+  if (descriptor == nullptr) {
+    logger_.warn("Settings: Unknown setting id",
+                 static_cast<uint32_t>(static_cast<uint8_t>(id)));
+    return false;
+  }
+  if (!settings_.set(id, value)) {
+    logger_.warn("Settings: Value out of range", static_cast<uint32_t>(value));
+    return false;
+  }
+  return persist_one(*descriptor, value);
+}
+
+void SettingsManager::load_one(const settings::Descriptor &descriptor) {
+  char path[MAX_PATH_LENGTH];
+  if (!build_path(descriptor, path)) {
+    return;
+  }
+
+  FILE *file = fopen(path, "rb");
+  if (file == nullptr) {
+    return; // Missing file means the default applies.
+  }
+
+  uint8_t value = 0;
+  const size_t bytes_read = fread(&value, 1, 1, file);
+  fclose(file);
+
+  if (bytes_read != 1 || !settings_.set(descriptor.id, value)) {
+    logger_.warn("Settings: Ignoring invalid stored value for");
+    logger_.warn(descriptor.name);
+  }
+}
+
+bool SettingsManager::persist_one(const settings::Descriptor &descriptor,
+                                  uint8_t value) {
+  char path[MAX_PATH_LENGTH];
+  if (!build_path(descriptor, path)) {
+    return false;
+  }
+
+  FILE *file = fopen(path, "wb");
+  if (file == nullptr) {
+    logger_.error("Settings: Failed to open file for writing");
+    return false;
+  }
+
+  const size_t bytes_written = fwrite(&value, 1, 1, file);
+  fclose(file);
+
+  if (bytes_written != 1) {
+    logger_.error("Settings: Failed to write value");
+    return false;
+  }
+  return true;
+}
+
+} // namespace drum

--- a/drum/settings_manager.h
+++ b/drum/settings_manager.h
@@ -1,0 +1,45 @@
+#ifndef DRUM_SETTINGS_MANAGER_H
+#define DRUM_SETTINGS_MANAGER_H
+
+#include "drum/settings.h"
+#include "musin/hal/logger.h"
+
+namespace drum {
+
+/**
+ * @brief Persists settings as one file per setting under /settings/.
+ *
+ * The filename is the setting's short name and the file content is the raw
+ * value byte. A missing or unreadable file means the compile-time default
+ * applies, so no migration or versioning of the store is needed: unknown
+ * files are ignored and absent files fall back to defaults.
+ */
+class SettingsManager {
+public:
+  SettingsManager(settings::Settings &settings, musin::Logger &logger);
+
+  /**
+   * @brief Loads all known settings from the filesystem.
+   * Call once after the filesystem is mounted.
+   */
+  void init();
+
+  [[nodiscard]] uint8_t get(settings::Id id) const;
+
+  /**
+   * @brief Validates, applies and persists a setting value.
+   * @return false for unknown ids, out-of-range values, or write failures.
+   */
+  bool set(settings::Id id, uint8_t value);
+
+private:
+  void load_one(const settings::Descriptor &descriptor);
+  bool persist_one(const settings::Descriptor &descriptor, uint8_t value);
+
+  settings::Settings &settings_;
+  musin::Logger &logger_;
+};
+
+} // namespace drum
+
+#endif // DRUM_SETTINGS_MANAGER_H

--- a/drum/sysex/protocol.h
+++ b/drum/sysex/protocol.h
@@ -93,6 +93,11 @@ template <typename FileOperations> struct Protocol {
     RequestSequencerState = 0x30,
     SequencerStateResponse = 0x31,
     SetSequencerState = 0x32,
+
+    // Settings Commands (generic key-value, see drum/settings.h)
+    GetSetting = 0x40,
+    SettingValue = 0x41,
+    SetSetting = 0x42,
   };
 
   enum class Result {
@@ -104,6 +109,8 @@ template <typename FileOperations> struct Protocol {
     PrintStorageInfo,
     PrintSequencerState,
     SetSequencerState,
+    GetSetting,
+    SetSetting,
     FileError,
     ShortMessage,
     NotSysex,
@@ -138,6 +145,15 @@ template <typename FileOperations> struct Protocol {
     // let the handler read the payload directly from the chunk.
     if (get_tag_from_chunk(chunk) == Tag::SetSequencerState) {
       return Result::SetSequencerState;
+    }
+
+    // Settings commands also carry raw 7-bit payloads (setting id and
+    // value bytes); the handler reads them directly from the chunk.
+    if (get_tag_from_chunk(chunk) == Tag::GetSetting) {
+      return Result::GetSetting;
+    }
+    if (get_tag_from_chunk(chunk) == Tag::SetSetting) {
+      return Result::SetSetting;
     }
 
     const uint16_t tag = (*iterator++);

--- a/drum/sysex/protocol.h
+++ b/drum/sysex/protocol.h
@@ -20,6 +20,21 @@ extern "C" {
 
 namespace sysex {
 
+// SysEx message frame sizes
+static constexpr size_t SYSEX_START_SIZE = 1;  // 0xF0
+static constexpr size_t SYSEX_MFR_ID_SIZE = 3; // 3 manufacturer ID bytes
+static constexpr size_t SYSEX_DEVICE_ID_SIZE = 1;
+static constexpr size_t SYSEX_TAG_SIZE = 1;
+static constexpr size_t SYSEX_END_SIZE = 1; // 0xF7
+static constexpr size_t SYSEX_HEADER_SIZE =
+    SYSEX_START_SIZE + SYSEX_MFR_ID_SIZE + SYSEX_DEVICE_ID_SIZE +
+    SYSEX_TAG_SIZE;
+// Offset of the payload within a received Chunk, which excludes the 0xF0
+// start byte (chunk[0..2] = manufacturer ID, chunk[3] = device ID,
+// chunk[4] = tag).
+static constexpr size_t SYSEX_CHUNK_PAYLOAD_OFFSET =
+    SYSEX_MFR_ID_SIZE + SYSEX_DEVICE_ID_SIZE + SYSEX_TAG_SIZE;
+
 template <typename FileOperations> struct Protocol {
   static constexpr uint64_t TIMEOUT_US = 5000000; // 5 seconds
 
@@ -73,6 +88,11 @@ template <typename FileOperations> struct Protocol {
 
     // Firmware Update Commands (0x20-0x23) are handled by
     // sysex::FirmwareUpdate in drum/sysex/firmware_update.h.
+
+    // Sequencer State Commands
+    RequestSequencerState = 0x30,
+    SequencerStateResponse = 0x31,
+    SetSequencerState = 0x32,
   };
 
   enum class Result {
@@ -82,6 +102,8 @@ template <typename FileOperations> struct Protocol {
     PrintFirmwareVersion,
     PrintSerialNumber,
     PrintStorageInfo,
+    PrintSequencerState,
+    SetSequencerState,
     FileError,
     ShortMessage,
     NotSysex,
@@ -109,6 +131,13 @@ template <typename FileOperations> struct Protocol {
     if (is_file_bytes_command(chunk)) {
       return handle_file_bytes_fast(iterator + 1, chunk.cend(), send_reply,
                                     now);
+    }
+
+    // SetSequencerState carries a raw 7-bit payload (see
+    // sequencer_state_codec.h); skip the legacy 3-to-16bit body decoding and
+    // let the handler read the payload directly from the chunk.
+    if (get_tag_from_chunk(chunk) == Tag::SetSequencerState) {
+      return Result::SetSequencerState;
     }
 
     const uint16_t tag = (*iterator++);
@@ -221,6 +250,8 @@ private:
       return Result::PrintSerialNumber;
     case Tag::RequestStorageInfo:
       return Result::PrintStorageInfo;
+    case Tag::RequestSequencerState:
+      return Result::PrintSequencerState;
     default:
       break;
     }

--- a/drum/sysex/sequencer_state_codec.h
+++ b/drum/sysex/sequencer_state_codec.h
@@ -13,8 +13,7 @@ namespace sysex {
 /**
  * @brief Codec for encoding/decoding sequencer state to/from SysEx messages.
  *
- * Wire payload format (37 bytes total, all 7-bit safe):
- * - 1 byte:  payload format version (currently SEQUENCER_STATE_PAYLOAD_VERSION)
+ * Wire payload format (36 bytes total, all 7-bit safe):
  * - 32 bytes: velocities for all steps (4 tracks x 8 steps), track-major
  *   Layout: [T0S0, T0S1, ..., T0S7, T1S0, T1S1, ..., T3S7]
  * - 4 bytes: active notes per track [T0, T1, T2, T3]
@@ -23,23 +22,17 @@ namespace sysex {
  * constrains every byte to 7 bits, so no additional range validation is
  * needed here.
  *
- * NOTE: If the payload layout ever changes, bump
- * SEQUENCER_STATE_PAYLOAD_VERSION so old and new firmware/clients can detect
- * a mismatch instead of misinterpreting bytes.
+ * NOTE: If the payload layout ever changes, introduce a new SysEx tag for the
+ * new format instead of changing this layout in place, so existing tools keep
+ * working.
  */
 
-static constexpr uint8_t SEQUENCER_STATE_PAYLOAD_VERSION = 1;
-static constexpr size_t SEQUENCER_STATE_VERSION_SIZE = 1;
-
-static constexpr size_t SEQUENCER_STATE_DATA_SIZE =
+static constexpr size_t SEQUENCER_STATE_PAYLOAD_SIZE =
     (drum::config::NUM_TRACKS * drum::config::NUM_STEPS_PER_TRACK) +
     drum::config::NUM_TRACKS;
 
-static constexpr size_t SEQUENCER_STATE_PAYLOAD_SIZE =
-    SEQUENCER_STATE_VERSION_SIZE + SEQUENCER_STATE_DATA_SIZE;
-
 /**
- * @brief Encodes sequencer state into a versioned, 7-bit safe SysEx payload.
+ * @brief Encodes sequencer state into a 7-bit safe SysEx payload.
  *
  * @param state The sequencer state to encode
  * @param output Output buffer for encoded data (must be at least
@@ -56,8 +49,6 @@ encode_sequencer_state(const drum::SequencerPersistentState &state,
 
   size_t pos = 0;
 
-  output[pos++] = SEQUENCER_STATE_PAYLOAD_VERSION;
-
   for (size_t track = 0; track < drum::config::NUM_TRACKS; ++track) {
     for (size_t step = 0; step < drum::config::NUM_STEPS_PER_TRACK; ++step) {
       output[pos++] = state.tracks[track].velocities[step] & 0x7F;
@@ -72,14 +63,12 @@ encode_sequencer_state(const drum::SequencerPersistentState &state,
 }
 
 /**
- * @brief Decodes a versioned SysEx payload into sequencer state.
+ * @brief Decodes a SysEx payload into sequencer state.
  *
- * Rejects payloads that are too short or whose version byte does not match
- * the version this firmware understands.
+ * Rejects payloads that are too short.
  *
- * @param input SysEx payload data (including the leading version byte)
- * @return Decoded state if valid, nullopt if payload is invalid or the
- * version is unsupported
+ * @param input SysEx payload data
+ * @return Decoded state if valid, nullopt if the payload is too short
  */
 inline etl::optional<drum::SequencerPersistentState>
 decode_sequencer_state(const etl::span<const uint8_t> &input) {
@@ -88,11 +77,6 @@ decode_sequencer_state(const etl::span<const uint8_t> &input) {
   }
 
   size_t pos = 0;
-
-  const uint8_t version = input[pos++];
-  if (version != SEQUENCER_STATE_PAYLOAD_VERSION) {
-    return etl::nullopt;
-  }
 
   drum::SequencerPersistentState state;
 

--- a/drum/sysex/sequencer_state_codec.h
+++ b/drum/sysex/sequencer_state_codec.h
@@ -1,0 +1,114 @@
+#ifndef DRUM_SYSEX_SEQUENCER_STATE_CODEC_H
+#define DRUM_SYSEX_SEQUENCER_STATE_CODEC_H
+
+#include "drum/config.h"
+#include "drum/sequencer_persistence.h"
+#include "etl/array.h"
+#include "etl/optional.h"
+#include "etl/span.h"
+#include <cstdint>
+
+namespace sysex {
+
+/**
+ * @brief Codec for encoding/decoding sequencer state to/from SysEx messages.
+ *
+ * Wire payload format (37 bytes total, all 7-bit safe):
+ * - 1 byte:  payload format version (currently SEQUENCER_STATE_PAYLOAD_VERSION)
+ * - 32 bytes: velocities for all steps (4 tracks x 8 steps), track-major
+ *   Layout: [T0S0, T0S1, ..., T0S7, T1S0, T1S1, ..., T3S7]
+ * - 4 bytes: active notes per track [T0, T1, T2, T3]
+ *
+ * All values are already MIDI-compliant (0-127); SysEx transport already
+ * constrains every byte to 7 bits, so no additional range validation is
+ * needed here.
+ *
+ * NOTE: If the payload layout ever changes, bump
+ * SEQUENCER_STATE_PAYLOAD_VERSION so old and new firmware/clients can detect
+ * a mismatch instead of misinterpreting bytes.
+ */
+
+static constexpr uint8_t SEQUENCER_STATE_PAYLOAD_VERSION = 1;
+static constexpr size_t SEQUENCER_STATE_VERSION_SIZE = 1;
+
+static constexpr size_t SEQUENCER_STATE_DATA_SIZE =
+    (drum::config::NUM_TRACKS * drum::config::NUM_STEPS_PER_TRACK) +
+    drum::config::NUM_TRACKS;
+
+static constexpr size_t SEQUENCER_STATE_PAYLOAD_SIZE =
+    SEQUENCER_STATE_VERSION_SIZE + SEQUENCER_STATE_DATA_SIZE;
+
+/**
+ * @brief Encodes sequencer state into a versioned, 7-bit safe SysEx payload.
+ *
+ * @param state The sequencer state to encode
+ * @param output Output buffer for encoded data (must be at least
+ * SEQUENCER_STATE_PAYLOAD_SIZE)
+ * @return Number of bytes written to output, or 0 if the output buffer is
+ * too small
+ */
+inline size_t
+encode_sequencer_state(const drum::SequencerPersistentState &state,
+                       etl::span<uint8_t> output) {
+  if (output.size() < SEQUENCER_STATE_PAYLOAD_SIZE) {
+    return 0;
+  }
+
+  size_t pos = 0;
+
+  output[pos++] = SEQUENCER_STATE_PAYLOAD_VERSION;
+
+  for (size_t track = 0; track < drum::config::NUM_TRACKS; ++track) {
+    for (size_t step = 0; step < drum::config::NUM_STEPS_PER_TRACK; ++step) {
+      output[pos++] = state.tracks[track].velocities[step] & 0x7F;
+    }
+  }
+
+  for (size_t track = 0; track < drum::config::NUM_TRACKS; ++track) {
+    output[pos++] = state.active_notes[track] & 0x7F;
+  }
+
+  return pos;
+}
+
+/**
+ * @brief Decodes a versioned SysEx payload into sequencer state.
+ *
+ * Rejects payloads that are too short or whose version byte does not match
+ * the version this firmware understands.
+ *
+ * @param input SysEx payload data (including the leading version byte)
+ * @return Decoded state if valid, nullopt if payload is invalid or the
+ * version is unsupported
+ */
+inline etl::optional<drum::SequencerPersistentState>
+decode_sequencer_state(const etl::span<const uint8_t> &input) {
+  if (input.size() < SEQUENCER_STATE_PAYLOAD_SIZE) {
+    return etl::nullopt;
+  }
+
+  size_t pos = 0;
+
+  const uint8_t version = input[pos++];
+  if (version != SEQUENCER_STATE_PAYLOAD_VERSION) {
+    return etl::nullopt;
+  }
+
+  drum::SequencerPersistentState state;
+
+  for (size_t track = 0; track < drum::config::NUM_TRACKS; ++track) {
+    for (size_t step = 0; step < drum::config::NUM_STEPS_PER_TRACK; ++step) {
+      state.tracks[track].velocities[step] = input[pos++];
+    }
+  }
+
+  for (size_t track = 0; track < drum::config::NUM_TRACKS; ++track) {
+    state.active_notes[track] = input[pos++];
+  }
+
+  return state;
+}
+
+} // namespace sysex
+
+#endif // DRUM_SYSEX_SEQUENCER_STATE_CODEC_H

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -11,9 +11,11 @@
 namespace drum {
 
 SysExHandler::SysExHandler(ConfigurationManager &config_manager,
+                           SettingsManager &settings_manager,
                            musin::Logger &logger,
                            musin::filesystem::Filesystem &filesystem)
-    : config_manager_(config_manager), logger_(logger), filesystem_(filesystem),
+    : config_manager_(config_manager), settings_manager_(settings_manager),
+      logger_(logger), filesystem_(filesystem),
       file_ops_(logger, filesystem), protocol_(file_ops_, logger),
       sds_protocol_(file_ops_, logger), firmware_writer_(logger),
       firmware_update_(firmware_writer_, logger) {
@@ -185,6 +187,20 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
         chunk.cbegin() + sysex::SYSEX_CHUNK_PAYLOAD_OFFSET;
     const auto payload = etl::span<const uint8_t>{payload_start, chunk.cend()};
     handle_set_sequencer_state(payload);
+    break;
+  }
+  case sysex::Protocol<StandardFileOps>::Result::GetSetting: {
+    const auto payload_start =
+        chunk.cbegin() + sysex::SYSEX_CHUNK_PAYLOAD_OFFSET;
+    const auto payload = etl::span<const uint8_t>{payload_start, chunk.cend()};
+    send_setting_value(payload);
+    break;
+  }
+  case sysex::Protocol<StandardFileOps>::Result::SetSetting: {
+    const auto payload_start =
+        chunk.cbegin() + sysex::SYSEX_CHUNK_PAYLOAD_OFFSET;
+    const auto payload = etl::span<const uint8_t>{payload_start, chunk.cend()};
+    handle_set_setting(payload);
     break;
   }
   default:
@@ -407,6 +423,65 @@ void SysExHandler::handle_set_sequencer_state(
 
   logger_.info("SysEx: Sequencer state applied successfully");
   sender(sysex::Protocol<StandardFileOps>::Tag::Ack);
+}
+
+namespace {
+void send_reply_tag(sysex::Protocol<StandardFileOps>::Tag tag) {
+  uint8_t msg[] = {0xF0,
+                   drum::config::sysex::MANUFACTURER_ID_0,
+                   drum::config::sysex::MANUFACTURER_ID_1,
+                   drum::config::sysex::MANUFACTURER_ID_2,
+                   drum::config::sysex::DEVICE_ID,
+                   static_cast<uint8_t>(tag),
+                   0xF7};
+  MIDI::sendSysEx(sizeof(msg), msg);
+}
+} // namespace
+
+void SysExHandler::send_setting_value(
+    const etl::span<const uint8_t> &payload) const {
+  if (payload.empty()) {
+    logger_.error("SysEx: GetSetting without setting id");
+    send_reply_tag(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  const auto id = static_cast<settings::Id>(payload[0]);
+  if (settings::find_descriptor(id) == nullptr) {
+    logger_.warn("SysEx: GetSetting for unknown id",
+                 static_cast<uint32_t>(payload[0]));
+    send_reply_tag(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  uint8_t message[] = {
+      0xF0,
+      drum::config::sysex::MANUFACTURER_ID_0,
+      drum::config::sysex::MANUFACTURER_ID_1,
+      drum::config::sysex::MANUFACTURER_ID_2,
+      drum::config::sysex::DEVICE_ID,
+      static_cast<uint8_t>(sysex::Protocol<StandardFileOps>::Tag::SettingValue),
+      payload[0],
+      settings_manager_.get(id),
+      0xF7};
+  MIDI::sendSysEx(sizeof(message), message);
+}
+
+void SysExHandler::handle_set_setting(const etl::span<const uint8_t> &payload) {
+  if (payload.size() < 2) {
+    logger_.error("SysEx: SetSetting payload too short");
+    send_reply_tag(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  const auto id = static_cast<settings::Id>(payload[0]);
+  if (!settings_manager_.set(id, payload[1])) {
+    send_reply_tag(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  logger_.info("SysEx: Setting applied", static_cast<uint32_t>(payload[0]));
+  send_reply_tag(sysex::Protocol<StandardFileOps>::Tag::Ack);
 }
 
 void SysExHandler::send_universal_identity_response() const {

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -1,4 +1,5 @@
 #include "drum/sysex_handler.h"
+#include "drum/sysex/sequencer_state_codec.h"
 #include "events.h"
 #include "musin/midi/midi_wrapper.h"
 #include "version.h"
@@ -176,6 +177,16 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
   case sysex::Protocol<StandardFileOps>::Result::PrintStorageInfo:
     send_storage_info();
     break;
+  case sysex::Protocol<StandardFileOps>::Result::PrintSequencerState:
+    send_sequencer_state();
+    break;
+  case sysex::Protocol<StandardFileOps>::Result::SetSequencerState: {
+    const auto payload_start =
+        chunk.cbegin() + sysex::SYSEX_CHUNK_PAYLOAD_OFFSET;
+    const auto payload = etl::span<const uint8_t>{payload_start, chunk.cend()};
+    handle_set_sequencer_state(payload);
+    break;
+  }
   default:
     // Other results are handled internally by the protocol or are errors.
     break;
@@ -316,6 +327,86 @@ void SysExHandler::send_storage_info() const {
   sysex[15] = 0xF7;
 
   MIDI::sendSysEx(sizeof(sysex), sysex);
+}
+
+void SysExHandler::set_sequencer_state_access(
+    SequencerStateAccess *sequencer_state_access) {
+  sequencer_state_access_ = sequencer_state_access;
+}
+
+void SysExHandler::send_sequencer_state() const {
+  if (!sequencer_state_access_) {
+    logger_.error("SysEx: Cannot send sequencer state - accessor not set");
+    return;
+  }
+
+  logger_.info("Sending sequencer state via SysEx");
+
+  const auto state = sequencer_state_access_->get_current_state();
+
+  etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
+  const size_t encoded_size =
+      sysex::encode_sequencer_state(state, etl::span{payload});
+
+  if (encoded_size != sysex::SEQUENCER_STATE_PAYLOAD_SIZE) {
+    logger_.error("SysEx: Failed to encode sequencer state");
+    return;
+  }
+
+  uint8_t message[sysex::SYSEX_HEADER_SIZE +
+                  sysex::SEQUENCER_STATE_PAYLOAD_SIZE + sysex::SYSEX_END_SIZE];
+  message[0] = 0xF0;
+  message[1] = drum::config::sysex::MANUFACTURER_ID_0;
+  message[2] = drum::config::sysex::MANUFACTURER_ID_1;
+  message[3] = drum::config::sysex::MANUFACTURER_ID_2;
+  message[4] = drum::config::sysex::DEVICE_ID;
+  message[5] = static_cast<uint8_t>(
+      sysex::Protocol<StandardFileOps>::Tag::SequencerStateResponse);
+
+  for (size_t i = 0; i < encoded_size; ++i) {
+    message[sysex::SYSEX_HEADER_SIZE + i] = payload[i];
+  }
+  message[sysex::SYSEX_HEADER_SIZE + encoded_size] = 0xF7;
+
+  MIDI::sendSysEx(sizeof(message), message);
+}
+
+void SysExHandler::handle_set_sequencer_state(
+    const etl::span<const uint8_t> &payload) {
+  auto sender = [](sysex::Protocol<StandardFileOps>::Tag tag) {
+    uint8_t msg[] = {0xF0,
+                     drum::config::sysex::MANUFACTURER_ID_0,
+                     drum::config::sysex::MANUFACTURER_ID_1,
+                     drum::config::sysex::MANUFACTURER_ID_2,
+                     drum::config::sysex::DEVICE_ID,
+                     static_cast<uint8_t>(tag),
+                     0xF7};
+    MIDI::sendSysEx(sizeof(msg), msg);
+  };
+
+  if (!sequencer_state_access_) {
+    logger_.error("SysEx: Cannot set sequencer state - accessor not set");
+    sender(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  logger_.info("Received set sequencer state command");
+
+  const auto maybe_state = sysex::decode_sequencer_state(payload);
+  if (!maybe_state.has_value()) {
+    logger_.error("SysEx: Failed to decode sequencer state payload");
+    sender(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  if (!sequencer_state_access_->apply_state(maybe_state.value())) {
+    logger_.error("SysEx: Failed to apply sequencer state");
+    sender(sysex::Protocol<StandardFileOps>::Tag::Nack);
+    return;
+  }
+
+  logger_.info("SysEx: Sequencer state applied successfully");
+  sender(sysex::Protocol<StandardFileOps>::Tag::Ack);
 }
 
 void SysExHandler::send_universal_identity_response() const {

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -15,10 +15,9 @@ SysExHandler::SysExHandler(ConfigurationManager &config_manager,
                            musin::Logger &logger,
                            musin::filesystem::Filesystem &filesystem)
     : config_manager_(config_manager), settings_manager_(settings_manager),
-      logger_(logger), filesystem_(filesystem),
-      file_ops_(logger, filesystem), protocol_(file_ops_, logger),
-      sds_protocol_(file_ops_, logger), firmware_writer_(logger),
-      firmware_update_(firmware_writer_, logger) {
+      logger_(logger), filesystem_(filesystem), file_ops_(logger, filesystem),
+      protocol_(file_ops_, logger), sds_protocol_(file_ops_, logger),
+      firmware_writer_(logger), firmware_update_(firmware_writer_, logger) {
 }
 
 void SysExHandler::update(absolute_time_t now) {

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -3,6 +3,7 @@
 
 #include "drum/configuration_manager.h"
 #include "drum/sequencer_state_access.h"
+#include "drum/settings_manager.h"
 #include "drum/standard_file_ops.h"
 #include "drum/sysex/firmware_update.h"
 #include "drum/sysex/protocol.h"
@@ -25,7 +26,8 @@ class SysExHandler
           etl::observer<drum::Events::SysExTransferStateChangeEvent>,
           drum::config::MAX_SYSEX_EVENT_OBSERVERS> {
 public:
-  SysExHandler(ConfigurationManager &config_manager, musin::Logger &logger,
+  SysExHandler(ConfigurationManager &config_manager,
+               SettingsManager &settings_manager, musin::Logger &logger,
                musin::filesystem::Filesystem &filesystem);
 
   void update(absolute_time_t now);
@@ -67,8 +69,11 @@ private:
   void send_universal_identity_response() const;
   void send_sequencer_state() const;
   void handle_set_sequencer_state(const etl::span<const uint8_t> &payload);
+  void send_setting_value(const etl::span<const uint8_t> &payload) const;
+  void handle_set_setting(const etl::span<const uint8_t> &payload);
 
   ConfigurationManager &config_manager_;
+  SettingsManager &settings_manager_;
   musin::Logger &logger_;
   musin::filesystem::Filesystem &filesystem_;
   SequencerStateAccess *sequencer_state_access_ = nullptr;

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -2,6 +2,7 @@
 #define DRUM_SYSEX_HANDLER_H
 
 #include "drum/configuration_manager.h"
+#include "drum/sequencer_state_access.h"
 #include "drum/standard_file_ops.h"
 #include "drum/sysex/firmware_update.h"
 #include "drum/sysex/protocol.h"
@@ -49,6 +50,13 @@ public:
    */
   void set_firmware_update_allowed(bool allowed);
 
+  /**
+   * @brief Wires the sequencer state accessor used for SysEx sequencer
+   * state read/write. Must be called before RequestSequencerState /
+   * SetSequencerState messages can be handled.
+   */
+  void set_sequencer_state_access(SequencerStateAccess *sequencer_state_access);
+
 private:
   void handle_firmware_update_message(const sysex::Chunk &chunk,
                                       absolute_time_t now);
@@ -57,10 +65,13 @@ private:
   void print_serial_number() const;
   void send_storage_info() const;
   void send_universal_identity_response() const;
+  void send_sequencer_state() const;
+  void handle_set_sequencer_state(const etl::span<const uint8_t> &payload);
 
   ConfigurationManager &config_manager_;
   musin::Logger &logger_;
   musin::filesystem::Filesystem &filesystem_;
+  SequencerStateAccess *sequencer_state_access_ = nullptr;
 
   StandardFileOps file_ops_;
   sysex::Protocol<StandardFileOps> protocol_;

--- a/test/drum/CMakeLists.txt
+++ b/test/drum/CMakeLists.txt
@@ -120,6 +120,28 @@ target_link_libraries(drum-test-sds PRIVATE
     etl::etl
 )
 
+# Test target: SysEx Sequencer State (codec unit tests)
+add_executable(drum-test-sysex-sequencer-state
+    sysex_sequencer_state_test.cpp
+)
+
+target_include_directories(drum-test-sysex-sequencer-state PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../musin/include_overrides
+    ${CMAKE_CURRENT_LIST_DIR}/../../musin/ports/pico/libraries/arduino_midi_library/src
+    ${CMAKE_CURRENT_LIST_DIR}/../../
+    ${CMAKE_CURRENT_LIST_DIR}/../
+    ${CMAKE_CURRENT_LIST_DIR}/../musin/include_overrides
+)
+
+target_compile_definitions(drum-test-sysex-sequencer-state PRIVATE
+    AUDIO_BLOCK_SAMPLES=20
+)
+
+target_link_libraries(drum-test-sysex-sequencer-state PRIVATE
+    Catch2::Catch2WithMain
+    etl::etl
+)
+
 include(CTest)
 include(Catch)
 catch_discover_tests(drum-test-storage)
@@ -127,3 +149,4 @@ catch_discover_tests(drum-test-swing)
 catch_discover_tests(drum-test-firmware-update)
 catch_discover_tests(drum-test-sample-slots)
 catch_discover_tests(drum-test-sds)
+catch_discover_tests(drum-test-sysex-sequencer-state)

--- a/test/drum/CMakeLists.txt
+++ b/test/drum/CMakeLists.txt
@@ -142,6 +142,20 @@ target_link_libraries(drum-test-sysex-sequencer-state PRIVATE
     etl::etl
 )
 
+# Test target: Settings registry and validation
+add_executable(drum-test-settings
+    settings_test.cpp
+)
+
+target_include_directories(drum-test-settings PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../../
+)
+
+target_link_libraries(drum-test-settings PRIVATE
+    Catch2::Catch2WithMain
+    etl::etl
+)
+
 include(CTest)
 include(Catch)
 catch_discover_tests(drum-test-storage)
@@ -150,3 +164,4 @@ catch_discover_tests(drum-test-firmware-update)
 catch_discover_tests(drum-test-sample-slots)
 catch_discover_tests(drum-test-sds)
 catch_discover_tests(drum-test-sysex-sequencer-state)
+catch_discover_tests(drum-test-settings)

--- a/test/drum/settings_test.cpp
+++ b/test/drum/settings_test.cpp
@@ -1,0 +1,68 @@
+#include "drum/settings.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using drum::settings::DESCRIPTORS;
+using drum::settings::find_descriptor;
+using drum::settings::Id;
+using drum::settings::Settings;
+
+TEST_CASE("Settings defaults", "[settings]") {
+  Settings settings;
+
+  SECTION("Every setting starts at its descriptor default") {
+    for (const auto &descriptor : DESCRIPTORS) {
+      REQUIRE(settings.get(descriptor.id) == descriptor.default_value);
+    }
+  }
+
+  SECTION("MIDI channel defaults to 10 (GM percussion)") {
+    REQUIRE(settings.get(Id::MidiChannel) == 10);
+  }
+}
+
+TEST_CASE("Settings set validation", "[settings]") {
+  Settings settings;
+
+  SECTION("Accepts values within range") {
+    REQUIRE(settings.set(Id::MidiChannel, 1));
+    REQUIRE(settings.get(Id::MidiChannel) == 1);
+    REQUIRE(settings.set(Id::MidiChannel, 16));
+    REQUIRE(settings.get(Id::MidiChannel) == 16);
+  }
+
+  SECTION("Rejects out-of-range values and keeps the previous value") {
+    REQUIRE(settings.set(Id::MidiChannel, 5));
+    REQUIRE_FALSE(settings.set(Id::MidiChannel, 0));
+    REQUIRE_FALSE(settings.set(Id::MidiChannel, 17));
+    REQUIRE_FALSE(settings.set(Id::MidiChannel, 127));
+    REQUIRE(settings.get(Id::MidiChannel) == 5);
+  }
+
+  SECTION("Rejects unknown setting ids") {
+    REQUIRE_FALSE(settings.set(static_cast<Id>(0x7F), 1));
+  }
+}
+
+TEST_CASE("Settings descriptor lookup", "[settings]") {
+  SECTION("Known id resolves to its descriptor") {
+    const auto *descriptor = find_descriptor(Id::MidiChannel);
+    REQUIRE(descriptor != nullptr);
+    REQUIRE(descriptor->name == "midi_channel");
+    REQUIRE(descriptor->min == 1);
+    REQUIRE(descriptor->max == 16);
+  }
+
+  SECTION("Unknown id resolves to nullptr") {
+    REQUIRE(find_descriptor(static_cast<Id>(0x7F)) == nullptr);
+  }
+
+  SECTION("Ids and names are unique across the registry") {
+    for (size_t i = 0; i < DESCRIPTORS.size(); ++i) {
+      for (size_t j = i + 1; j < DESCRIPTORS.size(); ++j) {
+        REQUIRE(DESCRIPTORS[i].id != DESCRIPTORS[j].id);
+        REQUIRE(DESCRIPTORS[i].name != DESCRIPTORS[j].name);
+      }
+    }
+  }
+}

--- a/test/drum/sysex_sequencer_state_test.cpp
+++ b/test/drum/sysex_sequencer_state_test.cpp
@@ -1,0 +1,185 @@
+#include "test_support.h"
+
+#include <cstddef>
+#include <cstdint>
+
+#include "drum/sequencer_persistence.h"
+#include "drum/sysex/protocol.h"
+#include "drum/sysex/sequencer_state_codec.h"
+#include "etl/array.h"
+#include "etl/span.h"
+
+using drum::SequencerPersistentState;
+
+// Regression test: sysex::Chunk (see musin/midi/sysex_chunk.h) excludes the
+// 0xF0/0xF7 framing bytes, so the payload within a received chunk starts
+// after [mfr0, mfr1, mfr2, device_id, tag] -- SYSEX_CHUNK_PAYLOAD_OFFSET (5),
+// NOT SYSEX_HEADER_SIZE (6), which additionally counts the 0xF0 start byte
+// used only when building outgoing full SysEx byte arrays.
+TEST_CASE("Chunk payload offset excludes the 0xF0 start byte") {
+  CONST_BODY(({
+    REQUIRE(sysex::SYSEX_CHUNK_PAYLOAD_OFFSET ==
+            sysex::SYSEX_MFR_ID_SIZE + sysex::SYSEX_DEVICE_ID_SIZE +
+                sysex::SYSEX_TAG_SIZE);
+    REQUIRE(sysex::SYSEX_CHUNK_PAYLOAD_OFFSET ==
+            sysex::SYSEX_HEADER_SIZE - sysex::SYSEX_START_SIZE);
+  }));
+}
+
+TEST_CASE("Encode sequencer state includes version byte") {
+  CONST_BODY(({
+    SequencerPersistentState state;
+
+    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
+    const size_t encoded_size =
+        sysex::encode_sequencer_state(state, etl::span{payload});
+
+    REQUIRE(encoded_size == sysex::SEQUENCER_STATE_PAYLOAD_SIZE);
+    REQUIRE(payload[0] == sysex::SEQUENCER_STATE_PAYLOAD_VERSION);
+  }));
+}
+
+TEST_CASE("Encode sequencer state") {
+  CONST_BODY(({
+    SequencerPersistentState state;
+
+    constexpr size_t NUM_STEPS = 8;
+    constexpr size_t VERSION_SIZE = 1;
+    constexpr size_t VELOCITIES_SIZE = 32;
+
+    state.tracks[0].velocities[0] = 100;
+    state.tracks[0].velocities[1] = 80;
+    state.tracks[1].velocities[2] = 60;
+    state.tracks[2].velocities[3] = 40;
+    state.tracks[3].velocities[7] = 127;
+
+    state.active_notes[0] = 37;
+    state.active_notes[1] = 38;
+    state.active_notes[2] = 46;
+    state.active_notes[3] = 54;
+
+    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
+    const size_t encoded_size =
+        sysex::encode_sequencer_state(state, etl::span{payload});
+
+    REQUIRE(encoded_size == sysex::SEQUENCER_STATE_PAYLOAD_SIZE);
+
+    REQUIRE(payload[VERSION_SIZE + 0 * NUM_STEPS + 0] == 100);
+    REQUIRE(payload[VERSION_SIZE + 0 * NUM_STEPS + 1] == 80);
+    REQUIRE(payload[VERSION_SIZE + 0 * NUM_STEPS + 2] == 0);
+    REQUIRE(payload[VERSION_SIZE + 1 * NUM_STEPS + 2] == 60);
+    REQUIRE(payload[VERSION_SIZE + 2 * NUM_STEPS + 3] == 40);
+    REQUIRE(payload[VERSION_SIZE + 3 * NUM_STEPS + 7] == 127);
+
+    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 0] == 37);
+    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 1] == 38);
+    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 2] == 46);
+    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 3] == 54);
+  }));
+}
+
+TEST_CASE("Decode sequencer state") {
+  CONST_BODY(({
+    constexpr size_t NUM_STEPS = 8;
+    constexpr size_t VERSION_SIZE = 1;
+    constexpr size_t VELOCITIES_SIZE = 32;
+
+    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
+    payload.fill(0);
+    payload[0] = sysex::SEQUENCER_STATE_PAYLOAD_VERSION;
+
+    payload[VERSION_SIZE + 0 * NUM_STEPS + 0] = 100;
+    payload[VERSION_SIZE + 0 * NUM_STEPS + 1] = 80;
+    payload[VERSION_SIZE + 1 * NUM_STEPS + 2] = 60;
+    payload[VERSION_SIZE + 2 * NUM_STEPS + 3] = 40;
+    payload[VERSION_SIZE + 3 * NUM_STEPS + 7] = 127;
+
+    payload[VERSION_SIZE + VELOCITIES_SIZE + 0] = 37;
+    payload[VERSION_SIZE + VELOCITIES_SIZE + 1] = 38;
+    payload[VERSION_SIZE + VELOCITIES_SIZE + 2] = 46;
+    payload[VERSION_SIZE + VELOCITIES_SIZE + 3] = 54;
+
+    const auto maybe_state =
+        sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});
+
+    REQUIRE(maybe_state.has_value());
+
+    const auto &state = maybe_state.value();
+    REQUIRE(state.tracks[0].velocities[0] == 100);
+    REQUIRE(state.tracks[0].velocities[1] == 80);
+    REQUIRE(state.tracks[1].velocities[2] == 60);
+    REQUIRE(state.tracks[2].velocities[3] == 40);
+    REQUIRE(state.tracks[3].velocities[7] == 127);
+
+    REQUIRE(state.active_notes[0] == 37);
+    REQUIRE(state.active_notes[1] == 38);
+    REQUIRE(state.active_notes[2] == 46);
+    REQUIRE(state.active_notes[3] == 54);
+  }));
+}
+
+TEST_CASE("Decode rejects unknown version byte") {
+  CONST_BODY(({
+    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
+    payload.fill(0);
+    payload[0] = sysex::SEQUENCER_STATE_PAYLOAD_VERSION + 1;
+
+    const auto maybe_state =
+        sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});
+
+    REQUIRE(!maybe_state.has_value());
+  }));
+}
+
+TEST_CASE("Decode rejects too-short payload") {
+  CONST_BODY(({
+    etl::array<uint8_t, 10> payload;
+    payload.fill(0);
+    payload[0] = sysex::SEQUENCER_STATE_PAYLOAD_VERSION;
+
+    const auto maybe_state =
+        sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});
+
+    REQUIRE(!maybe_state.has_value());
+  }));
+}
+
+TEST_CASE("Encode and decode roundtrip") {
+  CONST_BODY(({
+    SequencerPersistentState original_state;
+
+    for (size_t track = 0; track < 4; ++track) {
+      for (size_t step = 0; step < 8; ++step) {
+        original_state.tracks[track].velocities[step] =
+            static_cast<uint8_t>((track * 8 + step) * 3);
+      }
+    }
+
+    original_state.active_notes[0] = 37;
+    original_state.active_notes[1] = 38;
+    original_state.active_notes[2] = 46;
+    original_state.active_notes[3] = 54;
+
+    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
+    sysex::encode_sequencer_state(original_state, etl::span{payload});
+
+    const auto maybe_decoded =
+        sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});
+
+    REQUIRE(maybe_decoded.has_value());
+
+    const auto &decoded_state = maybe_decoded.value();
+
+    for (size_t track = 0; track < 4; ++track) {
+      for (size_t step = 0; step < 8; ++step) {
+        REQUIRE(decoded_state.tracks[track].velocities[step] ==
+                original_state.tracks[track].velocities[step]);
+      }
+    }
+
+    for (size_t track = 0; track < 4; ++track) {
+      REQUIRE(decoded_state.active_notes[track] ==
+              original_state.active_notes[track]);
+    }
+  }));
+}

--- a/test/drum/sysex_sequencer_state_test.cpp
+++ b/test/drum/sysex_sequencer_state_test.cpp
@@ -26,25 +26,11 @@ TEST_CASE("Chunk payload offset excludes the 0xF0 start byte") {
   }));
 }
 
-TEST_CASE("Encode sequencer state includes version byte") {
-  CONST_BODY(({
-    SequencerPersistentState state;
-
-    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
-    const size_t encoded_size =
-        sysex::encode_sequencer_state(state, etl::span{payload});
-
-    REQUIRE(encoded_size == sysex::SEQUENCER_STATE_PAYLOAD_SIZE);
-    REQUIRE(payload[0] == sysex::SEQUENCER_STATE_PAYLOAD_VERSION);
-  }));
-}
-
 TEST_CASE("Encode sequencer state") {
   CONST_BODY(({
     SequencerPersistentState state;
 
     constexpr size_t NUM_STEPS = 8;
-    constexpr size_t VERSION_SIZE = 1;
     constexpr size_t VELOCITIES_SIZE = 32;
 
     state.tracks[0].velocities[0] = 100;
@@ -64,40 +50,38 @@ TEST_CASE("Encode sequencer state") {
 
     REQUIRE(encoded_size == sysex::SEQUENCER_STATE_PAYLOAD_SIZE);
 
-    REQUIRE(payload[VERSION_SIZE + 0 * NUM_STEPS + 0] == 100);
-    REQUIRE(payload[VERSION_SIZE + 0 * NUM_STEPS + 1] == 80);
-    REQUIRE(payload[VERSION_SIZE + 0 * NUM_STEPS + 2] == 0);
-    REQUIRE(payload[VERSION_SIZE + 1 * NUM_STEPS + 2] == 60);
-    REQUIRE(payload[VERSION_SIZE + 2 * NUM_STEPS + 3] == 40);
-    REQUIRE(payload[VERSION_SIZE + 3 * NUM_STEPS + 7] == 127);
+    REQUIRE(payload[0 * NUM_STEPS + 0] == 100);
+    REQUIRE(payload[0 * NUM_STEPS + 1] == 80);
+    REQUIRE(payload[0 * NUM_STEPS + 2] == 0);
+    REQUIRE(payload[1 * NUM_STEPS + 2] == 60);
+    REQUIRE(payload[2 * NUM_STEPS + 3] == 40);
+    REQUIRE(payload[3 * NUM_STEPS + 7] == 127);
 
-    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 0] == 37);
-    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 1] == 38);
-    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 2] == 46);
-    REQUIRE(payload[VERSION_SIZE + VELOCITIES_SIZE + 3] == 54);
+    REQUIRE(payload[VELOCITIES_SIZE + 0] == 37);
+    REQUIRE(payload[VELOCITIES_SIZE + 1] == 38);
+    REQUIRE(payload[VELOCITIES_SIZE + 2] == 46);
+    REQUIRE(payload[VELOCITIES_SIZE + 3] == 54);
   }));
 }
 
 TEST_CASE("Decode sequencer state") {
   CONST_BODY(({
     constexpr size_t NUM_STEPS = 8;
-    constexpr size_t VERSION_SIZE = 1;
     constexpr size_t VELOCITIES_SIZE = 32;
 
     etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
     payload.fill(0);
-    payload[0] = sysex::SEQUENCER_STATE_PAYLOAD_VERSION;
 
-    payload[VERSION_SIZE + 0 * NUM_STEPS + 0] = 100;
-    payload[VERSION_SIZE + 0 * NUM_STEPS + 1] = 80;
-    payload[VERSION_SIZE + 1 * NUM_STEPS + 2] = 60;
-    payload[VERSION_SIZE + 2 * NUM_STEPS + 3] = 40;
-    payload[VERSION_SIZE + 3 * NUM_STEPS + 7] = 127;
+    payload[0 * NUM_STEPS + 0] = 100;
+    payload[0 * NUM_STEPS + 1] = 80;
+    payload[1 * NUM_STEPS + 2] = 60;
+    payload[2 * NUM_STEPS + 3] = 40;
+    payload[3 * NUM_STEPS + 7] = 127;
 
-    payload[VERSION_SIZE + VELOCITIES_SIZE + 0] = 37;
-    payload[VERSION_SIZE + VELOCITIES_SIZE + 1] = 38;
-    payload[VERSION_SIZE + VELOCITIES_SIZE + 2] = 46;
-    payload[VERSION_SIZE + VELOCITIES_SIZE + 3] = 54;
+    payload[VELOCITIES_SIZE + 0] = 37;
+    payload[VELOCITIES_SIZE + 1] = 38;
+    payload[VELOCITIES_SIZE + 2] = 46;
+    payload[VELOCITIES_SIZE + 3] = 54;
 
     const auto maybe_state =
         sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});
@@ -118,24 +102,10 @@ TEST_CASE("Decode sequencer state") {
   }));
 }
 
-TEST_CASE("Decode rejects unknown version byte") {
-  CONST_BODY(({
-    etl::array<uint8_t, sysex::SEQUENCER_STATE_PAYLOAD_SIZE> payload;
-    payload.fill(0);
-    payload[0] = sysex::SEQUENCER_STATE_PAYLOAD_VERSION + 1;
-
-    const auto maybe_state =
-        sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});
-
-    REQUIRE(!maybe_state.has_value());
-  }));
-}
-
 TEST_CASE("Decode rejects too-short payload") {
   CONST_BODY(({
     etl::array<uint8_t, 10> payload;
     payload.fill(0);
-    payload[0] = sysex::SEQUENCER_STATE_PAYLOAD_VERSION;
 
     const auto maybe_state =
         sysex::decode_sequencer_state(etl::span<const uint8_t>{payload});

--- a/test/sender/src/Command.ts
+++ b/test/sender/src/Command.ts
@@ -10,4 +10,7 @@ export enum Command {
   Ack = 0x13,
   Nack = 0x14,
   FormatFilesystem = 0x15,
+  RequestSequencerState = 0x30,
+  SequencerStateResponse = 0x31,
+  SetSequencerState = 0x32,
 }

--- a/test/sender/src/SysexProtocol.ts
+++ b/test/sender/src/SysexProtocol.ts
@@ -4,11 +4,6 @@ import { Command } from './Command';
 const SYSEX_MANUFACTURER_ID = [0x00, 0x22, 0x01];
 const SYSEX_DEVICE_ID = 0x65;
 
-// Bump this if the sequencer state payload layout ever changes; must match
-// SEQUENCER_STATE_PAYLOAD_VERSION in drum/sysex/sequencer_state_codec.h.
-const SEQUENCER_STATE_PAYLOAD_VERSION = 1;
-
-
 
 export class SysexProtocol {
   private transport: IMidiTransport;
@@ -87,18 +82,7 @@ export class SysexProtocol {
             const NUM_STEPS = 8;
             const VELOCITIES_SIZE = NUM_TRACKS * NUM_STEPS;
 
-            // message[6] is the payload format version byte.
-            const version = message[6];
-            if (version !== SEQUENCER_STATE_PAYLOAD_VERSION) {
-              clearTimeout(this.replyPromise.timer);
-              this.replyPromise.reject(
-                new Error(`Unsupported sequencer state payload version: ${version}`)
-              );
-              this.replyPromise = null;
-              return;
-            }
-
-            const dataStart = 7; // skip header (6) + version byte (1)
+            const dataStart = 6; // payload starts right after the tag byte
 
             // Extract velocities (32 bytes)
             const velocities: number[][] = [];
@@ -250,8 +234,8 @@ export class SysexProtocol {
       throw new Error(`Expected ${NUM_TRACKS} active notes, got ${activeNotes.length}`);
     }
 
-    // Build the versioned payload: [version, 32 velocity bytes, 4 active note bytes].
-    const data: number[] = [SEQUENCER_STATE_PAYLOAD_VERSION];
+    // Build the payload: [32 velocity bytes, 4 active note bytes].
+    const data: number[] = [];
 
     for (let track = 0; track < NUM_TRACKS; track++) {
       if (velocities[track].length !== NUM_STEPS) {

--- a/test/sender/src/SysexProtocol.ts
+++ b/test/sender/src/SysexProtocol.ts
@@ -4,6 +4,10 @@ import { Command } from './Command';
 const SYSEX_MANUFACTURER_ID = [0x00, 0x22, 0x01];
 const SYSEX_DEVICE_ID = 0x65;
 
+// Bump this if the sequencer state payload layout ever changes; must match
+// SEQUENCER_STATE_PAYLOAD_VERSION in drum/sysex/sequencer_state_codec.h.
+const SEQUENCER_STATE_PAYLOAD_VERSION = 1;
+
 
 
 export class SysexProtocol {
@@ -75,6 +79,44 @@ export class SysexProtocol {
             const free_bytes = (message[10] << 21) | (message[11] << 14) | (message[12] << 7) | message[13];
             clearTimeout(this.replyPromise.timer);
             this.replyPromise.resolve({ total: total_bytes, free: free_bytes });
+            this.replyPromise = null;
+          }
+        } else if (tag === Command.SequencerStateResponse) {
+          if (this.replyPromise) {
+            const NUM_TRACKS = 4;
+            const NUM_STEPS = 8;
+            const VELOCITIES_SIZE = NUM_TRACKS * NUM_STEPS;
+
+            // message[6] is the payload format version byte.
+            const version = message[6];
+            if (version !== SEQUENCER_STATE_PAYLOAD_VERSION) {
+              clearTimeout(this.replyPromise.timer);
+              this.replyPromise.reject(
+                new Error(`Unsupported sequencer state payload version: ${version}`)
+              );
+              this.replyPromise = null;
+              return;
+            }
+
+            const dataStart = 7; // skip header (6) + version byte (1)
+
+            // Extract velocities (32 bytes)
+            const velocities: number[][] = [];
+            for (let track = 0; track < NUM_TRACKS; track++) {
+              velocities[track] = [];
+              for (let step = 0; step < NUM_STEPS; step++) {
+                velocities[track][step] = message[dataStart + track * NUM_STEPS + step];
+              }
+            }
+
+            // Extract active notes (4 bytes)
+            const activeNotes: number[] = [];
+            for (let track = 0; track < NUM_TRACKS; track++) {
+              activeNotes[track] = message[dataStart + VELOCITIES_SIZE + track];
+            }
+
+            clearTimeout(this.replyPromise.timer);
+            this.replyPromise.resolve({ velocities, activeNotes });
             this.replyPromise = null;
           }
         }
@@ -181,6 +223,52 @@ export class SysexProtocol {
         }, 2000)
       };
     });
+  }
+
+  async getSequencerState(): Promise<{ velocities: number[][], activeNotes: number[] }> {
+    await this.sendMessage([Command.RequestSequencerState]);
+    return new Promise((resolve, reject) => {
+      this.replyPromise = {
+        resolve: resolve,
+        reject: reject,
+        timer: setTimeout(() => {
+          this.replyPromise = null;
+          reject(new Error('Timeout waiting for sequencer state reply.'));
+        }, 2000)
+      };
+    });
+  }
+
+  async setSequencerState(velocities: number[][], activeNotes: number[]): Promise<void> {
+    const NUM_TRACKS = 4;
+    const NUM_STEPS = 8;
+
+    if (velocities.length !== NUM_TRACKS) {
+      throw new Error(`Expected ${NUM_TRACKS} tracks, got ${velocities.length}`);
+    }
+    if (activeNotes.length !== NUM_TRACKS) {
+      throw new Error(`Expected ${NUM_TRACKS} active notes, got ${activeNotes.length}`);
+    }
+
+    // Build the versioned payload: [version, 32 velocity bytes, 4 active note bytes].
+    const data: number[] = [SEQUENCER_STATE_PAYLOAD_VERSION];
+
+    for (let track = 0; track < NUM_TRACKS; track++) {
+      if (velocities[track].length !== NUM_STEPS) {
+        throw new Error(`Track ${track}: expected ${NUM_STEPS} steps, got ${velocities[track].length}`);
+      }
+      for (let step = 0; step < NUM_STEPS; step++) {
+        data.push(velocities[track][step] & 0x7F);
+      }
+    }
+
+    for (let track = 0; track < NUM_TRACKS; track++) {
+      data.push(activeNotes[track] & 0x7F);
+    }
+
+    // The payload is sent as raw 7-bit bytes; the device reads it directly
+    // from the SysEx body (no 3-to-16bit packing, unlike BeginFileWrite).
+    await this.sendCommandAndWait(Command.SetSequencerState, data);
   }
 
   async sendFileChunk(chunk: Buffer): Promise<void> {

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -60,6 +60,14 @@ const SET_SEQUENCER_STATE = 0x32;
 const SEQUENCER_NUM_TRACKS = 4;
 const SEQUENCER_NUM_STEPS = 8;
 
+// Settings Commands (generic key-value; ids match drum/settings.h)
+const GET_SETTING = 0x40;
+const SETTING_VALUE = 0x41;
+const SET_SETTING = 0x42;
+const SETTINGS = {
+  midi_channel: { id: 0x01, min: 1, max: 16, description: 'MIDI channel for notes and CCs (1-16)' },
+};
+
 // Firmware Update Commands (UF2 streamed to the inactive A/B partition)
 const BEGIN_FIRMWARE_UPDATE = 0x20;
 const FIRMWARE_BYTES = 0x21;
@@ -394,6 +402,40 @@ async function get_sequencer_state(asJson = false) {
   }
 
   return state;
+}
+
+// Look up a setting by name, with a helpful error listing known names
+function findSetting(name) {
+  const setting = SETTINGS[name];
+  if (!setting) {
+    throw new Error(`Unknown setting '${name}'. Known settings: ${Object.keys(SETTINGS).join(', ')}`);
+  }
+  return setting;
+}
+
+// Get one named setting, or all settings when name is undefined
+async function get_setting(name) {
+  const names = name ? [name] : Object.keys(SETTINGS);
+  for (const settingName of names) {
+    const setting = findSetting(settingName);
+    sendCustomMessage([GET_SETTING, setting.id]);
+    const reply = await waitForCustomReply();
+    if (reply[5] !== SETTING_VALUE || reply[6] !== setting.id) {
+      throw new Error(`Unexpected reply for '${settingName}'. Tag: ${reply[5]}`);
+    }
+    console.log(`${settingName}: ${reply[7]}`);
+  }
+}
+
+// Set one named setting; the device validates and persists the value
+async function set_setting(name, valueStr) {
+  const setting = findSetting(name);
+  const value = parseInt(valueStr, 10);
+  if (isNaN(value) || value < setting.min || value > setting.max) {
+    throw new Error(`Invalid value '${valueStr}' for '${name}'. Must be ${setting.min}-${setting.max}.`);
+  }
+  await sendCustomCommandAndWait(SET_SETTING, [setting.id, value]);
+  console.log(`${name} set to ${value}.`);
 }
 
 // Validate and normalize a sequencer state object ({ velocities, activeNotes })
@@ -1151,6 +1193,8 @@ if (!command) {
   console.log("  drumtool.js flash <firmware.uf2>");
   console.log("  drumtool.js get-sequencer [--json]");
   console.log("  drumtool.js set-sequencer <state.json|->");
+  console.log("  drumtool.js get-setting [name]");
+  console.log("  drumtool.js set-setting <name> <value>");
   console.log("");
   console.log("Commands:");
   console.log("  send           - Transfer audio samples (WAV or raw PCM) using SDS protocol");
@@ -1162,6 +1206,13 @@ if (!command) {
   console.log("  flash          - Update firmware over MIDI (A/B partition, auto-revert on failure)");
   console.log("  get-sequencer  - Read the sequencer pattern (velocities + active notes)");
   console.log("  set-sequencer  - Write a sequencer pattern from a JSON file ('-' for stdin)");
+  console.log("  get-setting    - Read a device setting (all settings when no name given)");
+  console.log("  set-setting    - Write a device setting (persisted on the device)");
+  console.log("");
+  console.log("Settings:");
+  for (const [name, setting] of Object.entries(SETTINGS)) {
+    console.log(`  ${name.padEnd(14)} - ${setting.description}`);
+  }
   console.log("");
   console.log("Send Arguments:");
   console.log("  file:slot      - Audio file path and target slot (0-127)");
@@ -1187,6 +1238,7 @@ if (!command) {
   console.log("  drumtool.js reboot-bootloader                 # Enter bootloader mode");
   console.log("  drumtool.js get-sequencer --json > state.json # Save sequencer pattern");
   console.log("  drumtool.js set-sequencer state.json          # Restore sequencer pattern");
+  console.log("  drumtool.js set-setting midi_channel 1        # Use MIDI channel 1");
   console.log("");
   process.exit(1);
 }
@@ -1270,10 +1322,23 @@ async function main() {
         console.error(`Error: File not found: ${file}`);
         process.exit(1);
       }
+    } else if (command === 'get-setting') {
+      const name = process.argv[3];
+      if (name) {
+        findSetting(name); // Throws with a helpful message for unknown names
+      }
+    } else if (command === 'set-setting') {
+      const name = process.argv[3];
+      const value = process.argv[4];
+      if (!name || value === undefined) {
+        console.error("Error: 'set-setting' requires a setting name and a value.");
+        process.exit(1);
+      }
+      findSetting(name); // Throws with a helpful message for unknown names
     } else if (command !== 'version' && command !== 'storage' && command !== 'format' &&
                command !== 'reboot-bootloader' && command !== 'identity' &&
                command !== 'get-sequencer') {
-      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', 'flash', 'get-sequencer', or 'set-sequencer'.`);
+      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', 'flash', 'get-sequencer', 'set-sequencer', 'get-setting', or 'set-setting'.`);
       process.exit(1);
     }
 
@@ -1315,6 +1380,10 @@ async function main() {
       await get_sequencer_state(process.argv.includes('--json'));
     } else if (command === 'set-sequencer') {
       await set_sequencer_state(process.argv[3]);
+    } else if (command === 'get-setting') {
+      await get_setting(process.argv[3]);
+    } else if (command === 'set-setting') {
+      await set_setting(process.argv[3], process.argv[4]);
     }
   } catch (error) {
     console.error(`\nError: ${error.message}`);

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -53,6 +53,13 @@ const FORMAT_FILESYSTEM = 0x15;
 const CUSTOM_ACK = 0x13;
 const CUSTOM_NACK = 0x14;
 
+// Sequencer State Commands
+const REQUEST_SEQUENCER_STATE = 0x30;
+const SEQUENCER_STATE_RESPONSE = 0x31;
+const SET_SEQUENCER_STATE = 0x32;
+const SEQUENCER_NUM_TRACKS = 4;
+const SEQUENCER_NUM_STEPS = 8;
+
 // Firmware Update Commands (UF2 streamed to the inactive A/B partition)
 const BEGIN_FIRMWARE_UPDATE = 0x20;
 const FIRMWARE_BYTES = 0x21;
@@ -111,7 +118,7 @@ function find_dato_drum() {
     output.openPort(outPort);
     input.openPort(inPort);
     input.ignoreTypes(false, false, false);
-    console.log(`Opened MIDI ports: ${portName}`);
+    console.error(`Opened MIDI ports: ${portName}`);
     return { output, input };
   } catch (e) {
     console.error(`Error opening MIDI ports for ${portName}: ${e.message}`);
@@ -347,6 +354,92 @@ async function get_storage_info() {
     console.error(`Error requesting storage info: ${e.message}`);
     throw e;
   }
+}
+
+// Get sequencer state
+// Payload: 32 velocity bytes (track-major, 4 tracks x 8 steps) followed by
+// 4 active-note bytes, all raw 7-bit values.
+async function get_sequencer_state(asJson = false) {
+  sendCustomMessage([REQUEST_SEQUENCER_STATE]);
+  const reply = await waitForCustomReply();
+  if (reply[5] !== SEQUENCER_STATE_RESPONSE) {
+    throw new Error(`Unexpected reply received. Tag: ${reply[5]}`);
+  }
+
+  const payloadSize = SEQUENCER_NUM_TRACKS * SEQUENCER_NUM_STEPS + SEQUENCER_NUM_TRACKS;
+  const payload = reply.slice(6, reply.length - 1);
+  if (payload.length < payloadSize) {
+    throw new Error(`Insufficient reply data: expected ${payloadSize} payload bytes, got ${payload.length}`);
+  }
+
+  const velocities = [];
+  for (let track = 0; track < SEQUENCER_NUM_TRACKS; track++) {
+    velocities.push(payload.slice(track * SEQUENCER_NUM_STEPS, (track + 1) * SEQUENCER_NUM_STEPS));
+  }
+  const activeNotes = payload.slice(
+    SEQUENCER_NUM_TRACKS * SEQUENCER_NUM_STEPS,
+    SEQUENCER_NUM_TRACKS * SEQUENCER_NUM_STEPS + SEQUENCER_NUM_TRACKS
+  );
+
+  const state = { velocities, activeNotes };
+
+  if (asJson) {
+    console.log(JSON.stringify(state, null, 2));
+  } else {
+    console.log('Sequencer state:');
+    for (let track = 0; track < SEQUENCER_NUM_TRACKS; track++) {
+      const steps = velocities[track].map(v => v.toString().padStart(3)).join(' ');
+      console.log(`  Track ${track} (note ${activeNotes[track]}): ${steps}`);
+    }
+  }
+
+  return state;
+}
+
+// Validate and normalize a sequencer state object ({ velocities, activeNotes })
+function validateSequencerState(state) {
+  if (!state || !Array.isArray(state.velocities) || !Array.isArray(state.activeNotes)) {
+    throw new Error("State must be an object with 'velocities' and 'activeNotes' arrays.");
+  }
+  if (state.velocities.length !== SEQUENCER_NUM_TRACKS) {
+    throw new Error(`Expected ${SEQUENCER_NUM_TRACKS} velocity tracks, got ${state.velocities.length}`);
+  }
+  if (state.activeNotes.length !== SEQUENCER_NUM_TRACKS) {
+    throw new Error(`Expected ${SEQUENCER_NUM_TRACKS} active notes, got ${state.activeNotes.length}`);
+  }
+  const check7bit = (value, what) => {
+    if (!Number.isInteger(value) || value < 0 || value > 127) {
+      throw new Error(`${what} must be an integer 0-127, got ${value}`);
+    }
+  };
+  state.velocities.forEach((track, t) => {
+    if (!Array.isArray(track) || track.length !== SEQUENCER_NUM_STEPS) {
+      throw new Error(`Track ${t} must have ${SEQUENCER_NUM_STEPS} velocity values.`);
+    }
+    track.forEach((v, s) => check7bit(v, `Velocity for track ${t} step ${s}`));
+  });
+  state.activeNotes.forEach((note, t) => check7bit(note, `Active note for track ${t}`));
+}
+
+// Set sequencer state from a JSON file (or stdin with '-')
+async function set_sequencer_state(filePath) {
+  const source = filePath === '-' ? '/dev/stdin' : filePath;
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(source, 'utf8'));
+  } catch (e) {
+    throw new Error(`Could not read state from '${filePath}': ${e.message}`);
+  }
+  validateSequencerState(state);
+
+  const payload = [];
+  for (let track = 0; track < SEQUENCER_NUM_TRACKS; track++) {
+    payload.push(...state.velocities[track]);
+  }
+  payload.push(...state.activeNotes);
+
+  await sendCustomCommandAndWait(SET_SEQUENCER_STATE, payload);
+  console.log('Sequencer state set successfully.');
 }
 
 // Format bytes for human-readable display
@@ -1056,6 +1149,8 @@ if (!command) {
   console.log("  drumtool.js reboot-bootloader");
   console.log("  drumtool.js identity");
   console.log("  drumtool.js flash <firmware.uf2>");
+  console.log("  drumtool.js get-sequencer [--json]");
+  console.log("  drumtool.js set-sequencer <state.json|->");
   console.log("");
   console.log("Commands:");
   console.log("  send           - Transfer audio samples (WAV or raw PCM) using SDS protocol");
@@ -1065,6 +1160,8 @@ if (!command) {
   console.log("  reboot-bootloader - Reboot device into bootloader mode");
   console.log("  identity       - Test universal SysEx identity request");
   console.log("  flash          - Update firmware over MIDI (A/B partition, auto-revert on failure)");
+  console.log("  get-sequencer  - Read the sequencer pattern (velocities + active notes)");
+  console.log("  set-sequencer  - Write a sequencer pattern from a JSON file ('-' for stdin)");
   console.log("");
   console.log("Send Arguments:");
   console.log("  file:slot      - Audio file path and target slot (0-127)");
@@ -1088,6 +1185,8 @@ if (!command) {
   console.log("  drumtool.js storage                           # Check storage usage");
   console.log("  drumtool.js format                            # Format filesystem");
   console.log("  drumtool.js reboot-bootloader                 # Enter bootloader mode");
+  console.log("  drumtool.js get-sequencer --json > state.json # Save sequencer pattern");
+  console.log("  drumtool.js set-sequencer state.json          # Restore sequencer pattern");
   console.log("");
   process.exit(1);
 }
@@ -1161,14 +1260,25 @@ async function main() {
         console.error(`Error: File not found: ${file}`);
         process.exit(1);
       }
+    } else if (command === 'set-sequencer') {
+      const file = process.argv[3];
+      if (!file) {
+        console.error("Error: 'set-sequencer' command requires a JSON state file argument (or '-' for stdin).");
+        process.exit(1);
+      }
+      if (file !== '-' && !fs.existsSync(file)) {
+        console.error(`Error: File not found: ${file}`);
+        process.exit(1);
+      }
     } else if (command !== 'version' && command !== 'storage' && command !== 'format' &&
-               command !== 'reboot-bootloader' && command !== 'identity') {
-      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', or 'flash'.`);
+               command !== 'reboot-bootloader' && command !== 'identity' &&
+               command !== 'get-sequencer') {
+      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', 'flash', 'get-sequencer', or 'set-sequencer'.`);
       process.exit(1);
     }
 
     // Initialize MIDI connection after arguments are validated
-    console.log("Initializing MIDI connection...");
+    console.error("Initializing MIDI connection...");
     const midi_ports = find_dato_drum();
     if (!midi_ports) {
       console.error("Failed to initialize MIDI. Exiting.");
@@ -1201,6 +1311,10 @@ async function main() {
       await test_universal_identity();
     } else if (command === 'flash') {
       await flash_firmware(process.argv[3]);
+    } else if (command === 'get-sequencer') {
+      await get_sequencer_state(process.argv.includes('--json'));
+    } else if (command === 'set-sequencer') {
+      await set_sequencer_state(process.argv[3]);
     }
   } catch (error) {
     console.error(`\nError: ${error.message}`);


### PR DESCRIPTION
Closes #549

Adds SysEx commands to read and write the sequencer pattern state (step velocities + active notes per track), re-implemented on top of current main from the earlier `feat/sysex-state-read-write` branch. Also introduces a generic persistent settings system with SysEx key-value access, starting with a configurable MIDI channel.

## Sequencer state protocol
- `RequestSequencerState` (0x30) → device replies with `SequencerStateResponse` (0x31)
- `SetSequencerState` (0x32) → device applies state and replies Ack/Nack
- Tags start at 0x30 to stay clear of the firmware-update range (0x20–0x23)
- Payload is 36 raw 7-bit bytes: 32 step velocities (track-major) + 4 active notes. Future layout changes should introduce a new SysEx tag.

## Sequencer state implementation
- `drum/sysex/sequencer_state_codec.h`: header-only encode/decode against `SequencerPersistentState`
- `drum/sequencer_state_access.h`: small interface implemented by `SequencerController`, so the SysEx layer avoids template coupling
- `SequencerController::get_current_state()` / `apply_state()` wrap the existing persistence helpers; applying state marks storage dirty for the debounced flash save
- `SetSequencerState` is intercepted as a raw-payload tag before the legacy 3-to-16-bit body decoder
- TS sender: `getSequencerState()` / `setSequencerState()` in `SysexProtocol.ts`

## Device settings
- Settings registry (`drum/settings.h`): each setting has a 7-bit wire id, short name, valid range and compile-time default
- Persistence (`drum/settings_manager.*`): one file per setting under `/settings/` on littlefs, filename = setting name, content = raw value byte. Missing/invalid file → default applies, so there is no store versioning or migration; unknown files are ignored (downgrade-safe)
- SysEx commands: `GetSetting` (0x40) → `SettingValue` (0x41), `SetSetting` (0x42) → Ack/Nack. Unknown ids and out-of-range values are Nacked
- First setting: `midi_channel` (id 0x01, range 1–16, default 10). Replaces the compile-time `MIDI_IN_CHANNEL`/`MIDI_OUT_CHANNEL` constants; `MidiManager` and `MessageRouter` read the live setting, so changes apply immediately without reboot
- Adding a setting = one `Descriptor` line + one drumtool table entry + one README row

## drumtool
- `get-sequencer [--json]` / `set-sequencer <state.json|->` — read/write the pattern; JSON round-trips for backup/restore
- `get-setting [name]` / `set-setting <name> <value>` — read/write device settings
- MIDI init status messages moved to stderr so redirected JSON output stays clean

## Testing
- Host tests: 44/44 pass, including new codec tests (roundtrip, short-payload rejection, payload offset) and settings tests (defaults, range validation, unknown-id rejection, registry uniqueness)
- Verified on hardware end-to-end: sequencer get/set round-trip, firmware flashed over MIDI (A/B), `midi_channel` set → read-back → persists across reboot; raw out-of-range and unknown-id SysEx correctly Nacked

## Docs
- Both protocols documented in `drum/README.md` (Sequencer State Commands, Settings Commands); removed the stale "configurable via web interface" note