### PR TITLE
feat: slider gain/pitch/decay assignment via slider_mode setting

### DIFF
--- a/drum/README.md
+++ b/drum/README.md
@@ -295,6 +295,8 @@ or invalid file means the default applies.
 | Setting | ID | Range | Default | Description |
 |---------|-----|-------|---------|-------------|
 | `midi_channel` | 0x01 | 1-16 | 10 | MIDI channel for incoming and outgoing notes and CCs |
+| `slider_mode` | 0x02 | 0-2 | 0 | Track slider assignment: 0 = pitch, 1 = gain, 2 = both |
+| `sample_decay` | 0x03 | 0-100 | 100 | Percentage of the sample's playback duration at which gain starts fading linearly to zero; 100 disables the fade |
 
 #### GetSetting (0x40)
 Requests the current value of one setting.

--- a/drum/README.md
+++ b/drum/README.md
@@ -295,7 +295,7 @@ or invalid file means the default applies.
 | Setting | ID | Range | Default | Description |
 |---------|-----|-------|---------|-------------|
 | `midi_channel` | 0x01 | 1-16 | 10 | MIDI channel for incoming and outgoing notes and CCs |
-| `slider_mode` | 0x02 | 0-7 | 1 | Bit mask of what the track slider controls: bit 0 = pitch, bit 1 = gain, bit 2 = decay. Decay fades the voice linearly to silence from the slider-set fraction of the sample's playback duration (slider at max = no fade) |
+| `slider_mode` | 0x02 | 0-7 | 1 | Bit mask of what the track slider controls: bit 0 = pitch, bit 1 = gain, bit 2 = decay. Decay ramps gain linearly from full at the trigger to silence at the slider-set fraction of the sample's playback duration (slider at max = no fade) |
 
 #### GetSetting (0x40)
 Requests the current value of one setting.

--- a/drum/README.md
+++ b/drum/README.md
@@ -295,8 +295,7 @@ or invalid file means the default applies.
 | Setting | ID | Range | Default | Description |
 |---------|-----|-------|---------|-------------|
 | `midi_channel` | 0x01 | 1-16 | 10 | MIDI channel for incoming and outgoing notes and CCs |
-| `slider_mode` | 0x02 | 0-2 | 0 | Track slider assignment: 0 = pitch, 1 = gain, 2 = both |
-| `sample_decay` | 0x03 | 0-100 | 100 | Percentage of the sample's playback duration at which gain starts fading linearly to zero; 100 disables the fade |
+| `slider_mode` | 0x02 | 0-7 | 1 | Bit mask of what the track slider controls: bit 0 = pitch, bit 1 = gain, bit 2 = decay. Decay fades the voice linearly to silence from the slider-set fraction of the sample's playback duration (slider at max = no fade) |
 
 #### GetSetting (0x40)
 Requests the current value of one setting.

--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -63,13 +63,11 @@ void __not_in_flash_func(AudioEngine::Voice::fill_buffer)(
 
   uint32_t position = frames_rendered;
   for (int16_t &sample : out_samples) {
-    if (position >= decay_start_frame) {
-      float gain = 0.0f;
-      if (position < total_frames) {
-        gain = static_cast<float>(total_frames - position) * decay_scale;
-      }
-      sample = static_cast<int16_t>(static_cast<float>(sample) * gain);
+    float gain = 0.0f;
+    if (position < decay_end_frame) {
+      gain = static_cast<float>(decay_end_frame - position) * decay_scale;
     }
+    sample = static_cast<int16_t>(static_cast<float>(sample) * gain);
     ++position;
   }
   frames_rendered = position;
@@ -163,18 +161,20 @@ void AudioEngine::play_on_voice(uint8_t voice_index, size_t sample_index,
   const float normalized_velocity = static_cast<float>(velocity) / 127.0f;
   const float gain = normalized_velocity * voice.current_gain;
 
-  // Decay envelope: from current_decay of the sample's playback duration,
-  // gain ramps linearly to zero at the end. 1.0 disables the envelope.
+  // Decay envelope: gain ramps linearly from full at the trigger to zero at
+  // current_decay of the sample's playback duration, silencing the rest.
+  // 1.0 disables the envelope. A floor keeps very low values click-free.
+  constexpr uint32_t MIN_DECAY_FRAMES = 128;
   const float speed = std::max(voice.current_pitch, 0.2f);
   const uint32_t total_frames = static_cast<uint32_t>(
       static_cast<float>(slot_manager_.voice_length(voice_index)) / speed);
-  const uint32_t decay_start_frame = static_cast<uint32_t>(
-      static_cast<float>(total_frames) * voice.current_decay);
-  const bool decay_active =
-      voice.current_decay < 1.0f && total_frames > decay_start_frame;
+  const uint32_t decay_end_frame =
+      std::max(static_cast<uint32_t>(static_cast<float>(total_frames) *
+                                     voice.current_decay),
+               MIN_DECAY_FRAMES);
+  const bool decay_active = voice.current_decay < 1.0f;
   const float decay_scale =
-      decay_active ? 1.0f / static_cast<float>(total_frames - decay_start_frame)
-                   : 0.0f;
+      decay_active ? 1.0f / static_cast<float>(decay_end_frame) : 0.0f;
 
   // The render runs in the DMA interrupt; keep it from reading the voice
   // mid-retrigger.
@@ -183,8 +183,7 @@ void AudioEngine::play_on_voice(uint8_t voice_index, size_t sample_index,
                           slot_manager_.voice_length(voice_index));
   mixer_.gain(voice_index, gain);
   voice.decay_active = decay_active;
-  voice.decay_start_frame = decay_start_frame;
-  voice.total_frames = total_frames;
+  voice.decay_end_frame = decay_end_frame;
   voice.decay_scale = decay_scale;
   voice.frames_rendered = 0;
   voice.sound.play(voice.current_pitch);

--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -76,11 +76,9 @@ void __not_in_flash_func(AudioEngine::Voice::fill_buffer)(
 }
 
 AudioEngine::AudioEngine(const SampleRepository &repository,
-                         SampleSlotManager &slot_manager,
-                         const settings::Settings &settings,
-                         musin::Logger &logger)
+                         SampleSlotManager &slot_manager, musin::Logger &logger)
     : sample_repository_(repository), slot_manager_(slot_manager),
-      settings_(settings), logger_(logger),
+      logger_(logger),
       voice_sources_{&voices_[0], &voices_[1], &voices_[2], &voices_[3]},
       mixer_(voice_sources_), crusher_(mixer_), lowpass_(crusher_),
       highpass_(lowpass_) {
@@ -165,15 +163,15 @@ void AudioEngine::play_on_voice(uint8_t voice_index, size_t sample_index,
   const float normalized_velocity = static_cast<float>(velocity) / 127.0f;
   const float gain = normalized_velocity * voice.current_gain;
 
-  // Decay envelope: from decay_percent of the sample's playback duration,
-  // gain ramps linearly to zero at the end. 100 disables the envelope.
-  const uint8_t decay_percent = settings_.get(settings::Id::SampleDecay);
+  // Decay envelope: from current_decay of the sample's playback duration,
+  // gain ramps linearly to zero at the end. 1.0 disables the envelope.
   const float speed = std::max(voice.current_pitch, 0.2f);
   const uint32_t total_frames = static_cast<uint32_t>(
       static_cast<float>(slot_manager_.voice_length(voice_index)) / speed);
-  const uint32_t decay_start_frame = (total_frames * decay_percent) / 100;
+  const uint32_t decay_start_frame = static_cast<uint32_t>(
+      static_cast<float>(total_frames) * voice.current_decay);
   const bool decay_active =
-      decay_percent < 100 && total_frames > decay_start_frame;
+      voice.current_decay < 1.0f && total_frames > decay_start_frame;
   const float decay_scale =
       decay_active ? 1.0f / static_cast<float>(total_frames - decay_start_frame)
                    : 0.0f;
@@ -217,6 +215,13 @@ void AudioEngine::set_track_gain(uint8_t voice_index, float value) {
     return;
   }
   voices_[voice_index].current_gain = std::clamp(value, 0.0f, 1.0f);
+}
+
+void AudioEngine::set_track_decay(uint8_t voice_index, float value) {
+  if (!is_initialized_ || voice_index >= NUM_VOICES) {
+    return;
+  }
+  voices_[voice_index].current_decay = std::clamp(value, 0.0f, 1.0f);
 }
 
 void AudioEngine::set_volume(float volume) {

--- a/drum/audio_engine.cpp
+++ b/drum/audio_engine.cpp
@@ -52,11 +52,36 @@ float map_value_filter_fast(float normalized_value) {
 AudioEngine::Voice::Voice() : sound(reader) {
 }
 
+// Runs in the I2S DMA interrupt: must stay RAM-resident (see AGENTS.md).
+void __not_in_flash_func(AudioEngine::Voice::fill_buffer)(
+    AudioBlock &out_samples) {
+  sound.fill_buffer(out_samples);
+
+  if (!decay_active) {
+    return;
+  }
+
+  uint32_t position = frames_rendered;
+  for (int16_t &sample : out_samples) {
+    if (position >= decay_start_frame) {
+      float gain = 0.0f;
+      if (position < total_frames) {
+        gain = static_cast<float>(total_frames - position) * decay_scale;
+      }
+      sample = static_cast<int16_t>(static_cast<float>(sample) * gain);
+    }
+    ++position;
+  }
+  frames_rendered = position;
+}
+
 AudioEngine::AudioEngine(const SampleRepository &repository,
-                         SampleSlotManager &slot_manager, musin::Logger &logger)
+                         SampleSlotManager &slot_manager,
+                         const settings::Settings &settings,
+                         musin::Logger &logger)
     : sample_repository_(repository), slot_manager_(slot_manager),
-      logger_(logger), voice_sources_{&voices_[0].sound, &voices_[1].sound,
-                                      &voices_[2].sound, &voices_[3].sound},
+      settings_(settings), logger_(logger),
+      voice_sources_{&voices_[0], &voices_[1], &voices_[2], &voices_[3]},
       mixer_(voice_sources_), crusher_(mixer_), lowpass_(crusher_),
       highpass_(lowpass_) {
   // Initialize to a known, silent state.
@@ -138,7 +163,20 @@ void AudioEngine::play_on_voice(uint8_t voice_index, size_t sample_index,
   }
 
   const float normalized_velocity = static_cast<float>(velocity) / 127.0f;
-  const float gain = map_value_linear(normalized_velocity, 0.0f, 1.0f);
+  const float gain = normalized_velocity * voice.current_gain;
+
+  // Decay envelope: from decay_percent of the sample's playback duration,
+  // gain ramps linearly to zero at the end. 100 disables the envelope.
+  const uint8_t decay_percent = settings_.get(settings::Id::SampleDecay);
+  const float speed = std::max(voice.current_pitch, 0.2f);
+  const uint32_t total_frames = static_cast<uint32_t>(
+      static_cast<float>(slot_manager_.voice_length(voice_index)) / speed);
+  const uint32_t decay_start_frame = (total_frames * decay_percent) / 100;
+  const bool decay_active =
+      decay_percent < 100 && total_frames > decay_start_frame;
+  const float decay_scale =
+      decay_active ? 1.0f / static_cast<float>(total_frames - decay_start_frame)
+                   : 0.0f;
 
   // The render runs in the DMA interrupt; keep it from reading the voice
   // mid-retrigger.
@@ -146,6 +184,11 @@ void AudioEngine::play_on_voice(uint8_t voice_index, size_t sample_index,
   voice.reader.set_source(slot_manager_.voice_data(voice_index),
                           slot_manager_.voice_length(voice_index));
   mixer_.gain(voice_index, gain);
+  voice.decay_active = decay_active;
+  voice.decay_start_frame = decay_start_frame;
+  voice.total_frames = total_frames;
+  voice.decay_scale = decay_scale;
+  voice.frames_rendered = 0;
   voice.sound.play(voice.current_pitch);
   restore_interrupts(saved_irq);
 }
@@ -167,6 +210,13 @@ void AudioEngine::set_pitch(uint8_t voice_index, float value) {
   voices_[voice_index].current_pitch = pitch_multiplier;
   // TODO: Consider if pitch should affect currently playing sound (requires
   // Sound modification) voices_[voice_index].sound.set_speed(pitch_multiplier);
+}
+
+void AudioEngine::set_track_gain(uint8_t voice_index, float value) {
+  if (!is_initialized_ || voice_index >= NUM_VOICES) {
+    return;
+  }
+  voices_[voice_index].current_gain = std::clamp(value, 0.0f, 1.0f);
 }
 
 void AudioEngine::set_volume(float volume) {

--- a/drum/audio_engine.h
+++ b/drum/audio_engine.h
@@ -16,8 +16,6 @@
 #include "musin/audio/sound.h"
 #include "musin/hal/logger.h"
 
-#include "drum/settings.h"
-
 namespace drum {
 
 class SampleRepository;  // Forward declaration
@@ -42,6 +40,7 @@ private:
     Sound sound;
     float current_pitch = 1.0f;
     float current_gain = 1.0f;
+    float current_decay = 1.0f; // Fraction of duration where the fade starts.
 
     // Decay envelope state, set at trigger time and consumed in the ISR.
     bool decay_active = false;
@@ -57,8 +56,7 @@ private:
 
 public:
   AudioEngine(const SampleRepository &repository,
-              SampleSlotManager &slot_manager,
-              const settings::Settings &settings, musin::Logger &logger);
+              SampleSlotManager &slot_manager, musin::Logger &logger);
   ~AudioEngine() = default;
 
   // Delete copy and move operations
@@ -120,6 +118,15 @@ public:
   void set_track_gain(uint8_t voice_index, float value);
 
   /**
+   * @brief Sets the decay for a specific voice/track for the *next* time it's
+   * triggered. The voice fades linearly to silence from this fraction of the
+   * sample's playback duration; 1.0 disables the fade.
+   * @param voice_index The voice/track index (0 to NUM_VOICES - 1).
+   * @param value The decay value, normalized (0.0f to 1.0f).
+   */
+  void set_track_decay(uint8_t voice_index, float value);
+
+  /**
    * @brief Sets the master output volume.
    * @param volume The desired volume level (0.0f to 1.0f).
    */
@@ -169,7 +176,6 @@ public:
 private:
   const SampleRepository &sample_repository_;
   SampleSlotManager &slot_manager_;
-  const settings::Settings &settings_;
   musin::Logger &logger_;
   etl::array<Voice, NUM_VOICES> voices_;
   etl::array<BufferSource *, NUM_VOICES> voice_sources_;

--- a/drum/audio_engine.h
+++ b/drum/audio_engine.h
@@ -16,6 +16,8 @@
 #include "musin/audio/sound.h"
 #include "musin/hal/logger.h"
 
+#include "drum/settings.h"
+
 namespace drum {
 
 class SampleRepository;  // Forward declaration
@@ -30,18 +32,33 @@ class AudioEngine : public etl::observer<drum::Events::NoteEvent> {
 private:
   /**
    * @brief Internal structure representing a single audio voice.
+   *
+   * Renders its Sound and applies an optional linear decay envelope that
+   * fades the voice to silence over the tail of the sample. fill_buffer runs
+   * in the I2S DMA interrupt and must stay RAM-resident.
    */
-  struct Voice {
+  struct Voice : BufferSource {
     musin::MemorySampleReader reader;
     Sound sound;
     float current_pitch = 1.0f;
+    float current_gain = 1.0f;
+
+    // Decay envelope state, set at trigger time and consumed in the ISR.
+    bool decay_active = false;
+    uint32_t decay_start_frame = 0;
+    uint32_t total_frames = 0;
+    float decay_scale = 0.0f; // 1 / (total_frames - decay_start_frame)
+    uint32_t frames_rendered = 0;
 
     Voice();
+
+    void fill_buffer(AudioBlock &out_samples) override;
   };
 
 public:
   AudioEngine(const SampleRepository &repository,
-              SampleSlotManager &slot_manager, musin::Logger &logger);
+              SampleSlotManager &slot_manager,
+              const settings::Settings &settings, musin::Logger &logger);
   ~AudioEngine() = default;
 
   // Delete copy and move operations
@@ -95,6 +112,14 @@ public:
   void set_pitch(uint8_t voice_index, float value);
 
   /**
+   * @brief Sets the gain for a specific voice/track for the *next* time it's
+   * triggered. Scales the velocity-derived gain.
+   * @param voice_index The voice/track index (0 to NUM_VOICES - 1).
+   * @param value The gain value, normalized (0.0f to 1.0f).
+   */
+  void set_track_gain(uint8_t voice_index, float value);
+
+  /**
    * @brief Sets the master output volume.
    * @param volume The desired volume level (0.0f to 1.0f).
    */
@@ -144,6 +169,7 @@ public:
 private:
   const SampleRepository &sample_repository_;
   SampleSlotManager &slot_manager_;
+  const settings::Settings &settings_;
   musin::Logger &logger_;
   etl::array<Voice, NUM_VOICES> voices_;
   etl::array<BufferSource *, NUM_VOICES> voice_sources_;

--- a/drum/audio_engine.h
+++ b/drum/audio_engine.h
@@ -40,13 +40,12 @@ private:
     Sound sound;
     float current_pitch = 1.0f;
     float current_gain = 1.0f;
-    float current_decay = 1.0f; // Fraction of duration where the fade starts.
+    float current_decay = 1.0f; // Fraction of duration where gain reaches 0.
 
     // Decay envelope state, set at trigger time and consumed in the ISR.
     bool decay_active = false;
-    uint32_t decay_start_frame = 0;
-    uint32_t total_frames = 0;
-    float decay_scale = 0.0f; // 1 / (total_frames - decay_start_frame)
+    uint32_t decay_end_frame = 0;
+    float decay_scale = 0.0f; // 1 / decay_end_frame
     uint32_t frames_rendered = 0;
 
     Voice();
@@ -119,8 +118,8 @@ public:
 
   /**
    * @brief Sets the decay for a specific voice/track for the *next* time it's
-   * triggered. The voice fades linearly to silence from this fraction of the
-   * sample's playback duration; 1.0 disables the fade.
+   * triggered. Gain ramps linearly from full at the trigger to silence at
+   * this fraction of the sample's playback duration; 1.0 disables the fade.
    * @param voice_index The voice/track index (0 to NUM_VOICES - 1).
    * @param value The decay value, normalized (0.0f to 1.0f).
    */

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -60,7 +60,7 @@ static drum::SysExHandler sysex_handler(config_manager, settings_manager,
                                         logger, filesystem);
 static drum::SampleSlotManager sample_slot_manager(logger);
 static drum::AudioEngine audio_engine(sample_repository, sample_slot_manager,
-                                      logger);
+                                      settings, logger);
 static musin::timing::InternalClock internal_clock(120.0f);
 static musin::timing::MidiClockProcessor midi_clock_processor;
 static musin::timing::SyncIn sync_in(DATO_SUBMARINE_SYNC_IN_PIN,

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -60,7 +60,7 @@ static drum::SysExHandler sysex_handler(config_manager, settings_manager,
                                         logger, filesystem);
 static drum::SampleSlotManager sample_slot_manager(logger);
 static drum::AudioEngine audio_engine(sample_repository, sample_slot_manager,
-                                      settings, logger);
+                                      logger);
 static musin::timing::InternalClock internal_clock(120.0f);
 static musin::timing::MidiClockProcessor midi_clock_processor;
 static musin::timing::SyncIn sync_in(DATO_SUBMARINE_SYNC_IN_PIN,

--- a/drum/message_router.cpp
+++ b/drum/message_router.cpp
@@ -170,9 +170,19 @@ void MessageRouter::set_parameter(Parameter param_id, float value,
   if ((_output_mode == OutputMode::AUDIO || _output_mode == OutputMode::BOTH) &&
       _local_control_mode == LocalControlMode::ON) {
     switch (param_id) {
-    case Parameter::PITCH:
-      _audio_engine.set_pitch(track_index.value(), value);
+    case Parameter::PITCH: {
+      const auto slider_mode = static_cast<settings::SliderMode>(
+          settings_.get(settings::Id::SliderMode));
+      if (slider_mode == settings::SliderMode::Pitch ||
+          slider_mode == settings::SliderMode::PitchAndGain) {
+        _audio_engine.set_pitch(track_index.value(), value);
+      }
+      if (slider_mode == settings::SliderMode::Gain ||
+          slider_mode == settings::SliderMode::PitchAndGain) {
+        _audio_engine.set_track_gain(track_index.value(), value);
+      }
       break;
+    }
     case Parameter::FILTER_FREQUENCY:
       _audio_engine.set_filter_frequency(value);
       break;

--- a/drum/message_router.cpp
+++ b/drum/message_router.cpp
@@ -171,15 +171,15 @@ void MessageRouter::set_parameter(Parameter param_id, float value,
       _local_control_mode == LocalControlMode::ON) {
     switch (param_id) {
     case Parameter::PITCH: {
-      const auto slider_mode = static_cast<settings::SliderMode>(
-          settings_.get(settings::Id::SliderMode));
-      if (slider_mode == settings::SliderMode::Pitch ||
-          slider_mode == settings::SliderMode::PitchAndGain) {
+      const uint8_t slider_mode = settings_.get(settings::Id::SliderMode);
+      if (slider_mode & settings::slider_mode::PITCH) {
         _audio_engine.set_pitch(track_index.value(), value);
       }
-      if (slider_mode == settings::SliderMode::Gain ||
-          slider_mode == settings::SliderMode::PitchAndGain) {
+      if (slider_mode & settings::slider_mode::GAIN) {
         _audio_engine.set_track_gain(track_index.value(), value);
+      }
+      if (slider_mode & settings::slider_mode::DECAY) {
+        _audio_engine.set_track_decay(track_index.value(), value);
       }
       break;
     }

--- a/drum/settings.h
+++ b/drum/settings.h
@@ -17,18 +17,17 @@ namespace drum::settings {
 enum class Id : uint8_t {
   MidiChannel = 0x01,
   SliderMode = 0x02,
-  SampleDecay = 0x03,
 };
 
 /**
- * @brief Values for the SliderMode setting: what the per-track slider
- * controls on the audio engine.
+ * @brief Bit mask values for the SliderMode setting: which parameters the
+ * per-track slider controls on the audio engine. Any combination is valid.
  */
-enum class SliderMode : uint8_t {
-  Pitch = 0,
-  Gain = 1,
-  PitchAndGain = 2,
-};
+namespace slider_mode {
+inline constexpr uint8_t PITCH = 1u << 0;
+inline constexpr uint8_t GAIN = 1u << 1;
+inline constexpr uint8_t DECAY = 1u << 2;
+} // namespace slider_mode
 
 /**
  * @brief Describes one setting: wire id, short name, valid range and default.
@@ -44,10 +43,9 @@ struct Descriptor {
   uint8_t default_value;
 };
 
-inline constexpr etl::array<Descriptor, 3> DESCRIPTORS{{
+inline constexpr etl::array<Descriptor, 2> DESCRIPTORS{{
     {Id::MidiChannel, "midi_channel", 1, 16, 10},
-    {Id::SliderMode, "slider_mode", 0, 2, 0},
-    {Id::SampleDecay, "sample_decay", 0, 100, 100},
+    {Id::SliderMode, "slider_mode", 0, 7, slider_mode::PITCH},
 }};
 
 /**

--- a/drum/settings.h
+++ b/drum/settings.h
@@ -16,6 +16,18 @@ namespace drum::settings {
  */
 enum class Id : uint8_t {
   MidiChannel = 0x01,
+  SliderMode = 0x02,
+  SampleDecay = 0x03,
+};
+
+/**
+ * @brief Values for the SliderMode setting: what the per-track slider
+ * controls on the audio engine.
+ */
+enum class SliderMode : uint8_t {
+  Pitch = 0,
+  Gain = 1,
+  PitchAndGain = 2,
 };
 
 /**
@@ -32,8 +44,10 @@ struct Descriptor {
   uint8_t default_value;
 };
 
-inline constexpr etl::array<Descriptor, 1> DESCRIPTORS{{
+inline constexpr etl::array<Descriptor, 3> DESCRIPTORS{{
     {Id::MidiChannel, "midi_channel", 1, 16, 10},
+    {Id::SliderMode, "slider_mode", 0, 2, 0},
+    {Id::SampleDecay, "sample_decay", 0, 100, 100},
 }};
 
 /**

--- a/test/drum/settings_test.cpp
+++ b/test/drum/settings_test.cpp
@@ -20,13 +20,8 @@ TEST_CASE("Settings defaults", "[settings]") {
     REQUIRE(settings.get(Id::MidiChannel) == 10);
   }
 
-  SECTION("Slider defaults to controlling pitch") {
-    REQUIRE(settings.get(Id::SliderMode) ==
-            static_cast<uint8_t>(drum::settings::SliderMode::Pitch));
-  }
-
-  SECTION("Sample decay defaults to 100 (no fade)") {
-    REQUIRE(settings.get(Id::SampleDecay) == 100);
+  SECTION("Slider defaults to controlling pitch only") {
+    REQUIRE(settings.get(Id::SliderMode) == drum::settings::slider_mode::PITCH);
   }
 }
 
@@ -52,18 +47,13 @@ TEST_CASE("Settings set validation", "[settings]") {
     REQUIRE_FALSE(settings.set(static_cast<Id>(0x7F), 1));
   }
 
-  SECTION("Slider mode accepts pitch, gain and both") {
-    REQUIRE(settings.set(Id::SliderMode, 2));
-    REQUIRE(settings.get(Id::SliderMode) == 2);
-    REQUIRE_FALSE(settings.set(Id::SliderMode, 3));
-    REQUIRE(settings.get(Id::SliderMode) == 2);
-  }
-
-  SECTION("Sample decay accepts 0-100 percent") {
-    REQUIRE(settings.set(Id::SampleDecay, 0));
-    REQUIRE(settings.set(Id::SampleDecay, 100));
-    REQUIRE_FALSE(settings.set(Id::SampleDecay, 101));
-    REQUIRE(settings.get(Id::SampleDecay) == 100);
+  SECTION("Slider mode accepts any combination of pitch, gain and decay") {
+    using namespace drum::settings::slider_mode;
+    REQUIRE(settings.set(Id::SliderMode, PITCH | GAIN | DECAY));
+    REQUIRE(settings.get(Id::SliderMode) == 7);
+    REQUIRE(settings.set(Id::SliderMode, 0));
+    REQUIRE_FALSE(settings.set(Id::SliderMode, 8));
+    REQUIRE(settings.get(Id::SliderMode) == 0);
   }
 }
 

--- a/test/drum/settings_test.cpp
+++ b/test/drum/settings_test.cpp
@@ -19,6 +19,15 @@ TEST_CASE("Settings defaults", "[settings]") {
   SECTION("MIDI channel defaults to 10 (GM percussion)") {
     REQUIRE(settings.get(Id::MidiChannel) == 10);
   }
+
+  SECTION("Slider defaults to controlling pitch") {
+    REQUIRE(settings.get(Id::SliderMode) ==
+            static_cast<uint8_t>(drum::settings::SliderMode::Pitch));
+  }
+
+  SECTION("Sample decay defaults to 100 (no fade)") {
+    REQUIRE(settings.get(Id::SampleDecay) == 100);
+  }
 }
 
 TEST_CASE("Settings set validation", "[settings]") {
@@ -41,6 +50,20 @@ TEST_CASE("Settings set validation", "[settings]") {
 
   SECTION("Rejects unknown setting ids") {
     REQUIRE_FALSE(settings.set(static_cast<Id>(0x7F), 1));
+  }
+
+  SECTION("Slider mode accepts pitch, gain and both") {
+    REQUIRE(settings.set(Id::SliderMode, 2));
+    REQUIRE(settings.get(Id::SliderMode) == 2);
+    REQUIRE_FALSE(settings.set(Id::SliderMode, 3));
+    REQUIRE(settings.get(Id::SliderMode) == 2);
+  }
+
+  SECTION("Sample decay accepts 0-100 percent") {
+    REQUIRE(settings.set(Id::SampleDecay, 0));
+    REQUIRE(settings.set(Id::SampleDecay, 100));
+    REQUIRE_FALSE(settings.set(Id::SampleDecay, 101));
+    REQUIRE(settings.get(Id::SampleDecay) == 100);
   }
 }
 

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -66,8 +66,7 @@ const SETTING_VALUE = 0x41;
 const SET_SETTING = 0x42;
 const SETTINGS = {
   midi_channel: { id: 0x01, min: 1, max: 16, description: 'MIDI channel for notes and CCs (1-16)' },
-  slider_mode: { id: 0x02, min: 0, max: 2, description: 'Track slider assignment: 0=pitch, 1=gain, 2=both' },
-  sample_decay: { id: 0x03, min: 0, max: 100, description: 'Percent of sample duration where fade to zero begins (100=off)' },
+  slider_mode: { id: 0x02, min: 0, max: 7, description: 'Track slider bit mask: 1=pitch, 2=gain, 4=decay (combinable)' },
 };
 
 // Firmware Update Commands (UF2 streamed to the inactive A/B partition)

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -66,6 +66,8 @@ const SETTING_VALUE = 0x41;
 const SET_SETTING = 0x42;
 const SETTINGS = {
   midi_channel: { id: 0x01, min: 1, max: 16, description: 'MIDI channel for notes and CCs (1-16)' },
+  slider_mode: { id: 0x02, min: 0, max: 2, description: 'Track slider assignment: 0=pitch, 1=gain, 2=both' },
+  sample_decay: { id: 0x03, min: 0, max: 100, description: 'Percent of sample duration where fade to zero begins (100=off)' },
 };
 
 // Firmware Update Commands (UF2 streamed to the inactive A/B partition)


### PR DESCRIPTION
## Summary

Stacked on #567 (uses the settings registry introduced there).

Adds a `slider_mode` device setting (id 0x02, persisted, SysEx-accessible) that assigns the per-track slider to any combination of three voice parameters via a 3-bit mask:

| Bit | Value | Controls |
|-----|-------|----------|
| 0 | 1 | Pitch (existing behavior, default) |
| 1 | 2 | Gain — scales the velocity-derived mixer gain |
| 2 | 4 | Decay — gain ramps linearly from full at the trigger to zero at the slider-set fraction of the sample's playback duration (max = no fade) |

All three latch on the next trigger. The decay envelope is applied per-voice inside the I2S DMA interrupt: `Voice` is now a `BufferSource` wrapping `Sound`, with `fill_buffer` kept RAM-resident (`__not_in_flash_func`) and verified flash-free by walking the disassembly per AGENTS.md. Envelope parameters are written under the same IRQ-disabled section as the retrigger.

The outgoing MIDI CC for the sliders (21-24) is unchanged; the mask only affects local routing.

## Usage

```
node tools/drumtool/drumtool.js set-setting slider_mode 7   # pitch + gain + decay
```

## Test plan
- [x] Host tests pass (44/44), including new mask range/default cases
- [x] Firmware builds (XIP); `Voice::fill_buffer` confirmed at a RAM address with no branches into flash
- [x] Hardware-verified: pitch, gain and decay all audible from the slider