### PR TITLE
feat: show a blue LED before rebooting into the USB bootloader

### DIFF
--- a/drum/events.h
+++ b/drum/events.h
@@ -59,6 +59,12 @@ struct SysExTransferStateChangeEvent {
   std::optional<float> progress = std::nullopt;
 };
 
+/**
+ * @brief Event signaling that the device is about to reboot into the USB
+ * bootloader in response to a SysEx command.
+ */
+struct EnteringBootloaderEvent {};
+
 } // namespace drum::Events
 
 #endif // DRUM_EVENTS_H_

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -170,10 +170,11 @@ int main() {
   sysex_handler.set_sequencer_state_access(&sequencer_controller);
 
   // Register observers for SysEx state changes
-  sysex_handler.add_observer(message_router);
-  sysex_handler.add_observer(sequencer_controller);
-  sysex_handler.add_observer(system_state_machine);
-  sysex_handler.add_observer(pizza_display);
+  sysex_handler.add_transfer_state_observer(message_router);
+  sysex_handler.add_transfer_state_observer(sequencer_controller);
+  sysex_handler.add_transfer_state_observer(system_state_machine);
+  sysex_handler.add_transfer_state_observer(pizza_display);
+  sysex_handler.add_bootloader_event_observer(pizza_display);
 
   // Register observers for events from MessageRouter
   message_router.add_note_event_observer(pizza_display);

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -177,6 +177,9 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
     etl::observable<etl::observer<drum::Events::EnteringBootloaderEvent>,
                     drum::config::MAX_SYSEX_EVENT_OBSERVERS>::
         notify_observers(event);
+    // Hold long enough for the observers' visual feedback to register; the
+    // reboot resets the pads, cutting LED power (LED_ENABLE goes Hi-Z).
+    sleep_ms(500);
     reset_usb_boot(0, 0);
     break;
   }

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -57,7 +57,9 @@ void SysExHandler::update(absolute_time_t now) {
       }
       drum::Events::SysExTransferStateChangeEvent event{
           .is_active = true, .sample_slot = current_sample_slot};
-      this->notify_observers(event);
+      etl::observable<
+          etl::observer<drum::Events::SysExTransferStateChangeEvent>,
+          drum::config::MAX_SYSEX_EVENT_OBSERVERS>::notify_observers(event);
       last_notified_sample_slot_ = current_sample_slot;
     } else {
       logger_.info("SysEx file transfer finished.");
@@ -65,7 +67,9 @@ void SysExHandler::update(absolute_time_t now) {
       // the sample color during the debounce/cooldown period (issue #550).
       drum::Events::SysExTransferStateChangeEvent event{
           .is_active = false, .sample_slot = last_notified_sample_slot_};
-      this->notify_observers(event);
+      etl::observable<
+          etl::observer<drum::Events::SysExTransferStateChangeEvent>,
+          drum::config::MAX_SYSEX_EVENT_OBSERVERS>::notify_observers(event);
       last_notified_sample_slot_ = std::nullopt;
     }
     was_busy_ = current_busy_state;
@@ -85,7 +89,9 @@ void SysExHandler::update(absolute_time_t now) {
     }
     drum::Events::SysExTransferStateChangeEvent event{
         .is_active = true, .sample_slot = current_sample_slot};
-    this->notify_observers(event);
+    etl::observable<
+        etl::observer<drum::Events::SysExTransferStateChangeEvent>,
+        drum::config::MAX_SYSEX_EVENT_OBSERVERS>::notify_observers(event);
     last_notified_sample_slot_ = current_sample_slot;
   }
 
@@ -166,9 +172,14 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
   case sysex::Protocol<StandardFileOps>::Result::FileWritten:
     on_file_received();
     break;
-  case sysex::Protocol<StandardFileOps>::Result::Reboot:
+  case sysex::Protocol<StandardFileOps>::Result::Reboot: {
+    drum::Events::EnteringBootloaderEvent event{};
+    etl::observable<etl::observer<drum::Events::EnteringBootloaderEvent>,
+                    drum::config::MAX_SYSEX_EVENT_OBSERVERS>::
+        notify_observers(event);
     reset_usb_boot(0, 0);
     break;
+  }
   case sysex::Protocol<StandardFileOps>::Result::PrintFirmwareVersion:
     print_firmware_version();
     break;
@@ -228,7 +239,9 @@ void SysExHandler::notify_firmware_update_progress() {
   last_notified_progress_ = progress;
   drum::Events::SysExTransferStateChangeEvent event{
       .is_active = true, .sample_slot = std::nullopt, .progress = progress};
-  this->notify_observers(event);
+  etl::observable<
+      etl::observer<drum::Events::SysExTransferStateChangeEvent>,
+      drum::config::MAX_SYSEX_EVENT_OBSERVERS>::notify_observers(event);
 }
 
 void SysExHandler::handle_firmware_update_message(const sysex::Chunk &chunk,

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -24,11 +24,36 @@ namespace drum {
 class SysExHandler
     : public etl::observable<
           etl::observer<drum::Events::SysExTransferStateChangeEvent>,
+          drum::config::MAX_SYSEX_EVENT_OBSERVERS>,
+      public etl::observable<
+          etl::observer<drum::Events::EnteringBootloaderEvent>,
           drum::config::MAX_SYSEX_EVENT_OBSERVERS> {
 public:
   SysExHandler(ConfigurationManager &config_manager,
                SettingsManager &settings_manager, musin::Logger &logger,
                musin::filesystem::Filesystem &filesystem);
+
+  /**
+   * @brief Adds an observer for SysExTransferStateChangeEvent, resolving
+   * ambiguity between the two observable base classes.
+   */
+  void add_transfer_state_observer(
+      etl::observer<drum::Events::SysExTransferStateChangeEvent> &observer) {
+    etl::observable<
+        etl::observer<drum::Events::SysExTransferStateChangeEvent>,
+        drum::config::MAX_SYSEX_EVENT_OBSERVERS>::add_observer(observer);
+  }
+
+  /**
+   * @brief Adds an observer for EnteringBootloaderEvent, resolving ambiguity
+   * between the two observable base classes.
+   */
+  void add_bootloader_event_observer(
+      etl::observer<drum::Events::EnteringBootloaderEvent> &observer) {
+    etl::observable<
+        etl::observer<drum::Events::EnteringBootloaderEvent>,
+        drum::config::MAX_SYSEX_EVENT_OBSERVERS>::add_observer(observer);
+  }
 
   void update(absolute_time_t now);
 

--- a/drum/ui/pizza_display.cpp
+++ b/drum/ui/pizza_display.cpp
@@ -60,6 +60,12 @@ void PizzaDisplay::notification(
   }
 }
 
+void PizzaDisplay::notification(drum::Events::EnteringBootloaderEvent) {
+  clear();
+  set_led(0, Color(0x0000FF));
+  show();
+}
+
 void PizzaDisplay::notification(drum::Events::ParameterChangeEvent event) {
   switch (event.param_id) {
   case drum::Parameter::FILTER_FREQUENCY:

--- a/drum/ui/pizza_display.cpp
+++ b/drum/ui/pizza_display.cpp
@@ -63,7 +63,10 @@ void PizzaDisplay::notification(
 void PizzaDisplay::notification(drum::Events::EnteringBootloaderEvent) {
   clear();
   set_led(0, Color(0x0000FF));
-  show();
+  // Block until the frame has latched: the device reboots into the
+  // bootloader immediately after this notification, which would cut short
+  // show()'s throttled, background DMA transfer.
+  _leds.show_blocking();
 }
 
 void PizzaDisplay::notification(drum::Events::ParameterChangeEvent event) {

--- a/drum/ui/pizza_display.h
+++ b/drum/ui/pizza_display.h
@@ -35,7 +35,8 @@ class PizzaDisplay
     : public etl::observer<musin::timing::TempoEvent>,
       public etl::observer<drum::Events::NoteEvent>,
       public etl::observer<drum::Events::SysExTransferStateChangeEvent>,
-      public etl::observer<drum::Events::ParameterChangeEvent> {
+      public etl::observer<drum::Events::ParameterChangeEvent>,
+      public etl::observer<drum::Events::EnteringBootloaderEvent> {
 public:
   friend class ui::SequencerDisplayMode;
   friend class ui::FileTransferDisplayMode;
@@ -143,6 +144,12 @@ public:
    * status.
    */
   void notification(drum::Events::SysExTransferStateChangeEvent event);
+
+  /**
+   * @brief Handles EnteringBootloaderEvent notifications by showing a single
+   * blue LED to indicate the device is about to reboot into the bootloader.
+   */
+  void notification(drum::Events::EnteringBootloaderEvent event);
 
   /**
    * @brief Handles ParameterChangeEvent notifications to update visual effects.

--- a/musin/drivers/ws2812-dma.h
+++ b/musin/drivers/ws2812-dma.h
@@ -106,6 +106,14 @@ public:
    */
   void show();
 
+  /**
+   * @brief Push the current pixel buffer and block until the LEDs have
+   * latched. Bypasses the frame-rate throttle. Intended for showing a final
+   * frame right before a reset or reboot, where show()'s background DMA
+   * transfer would be cut short.
+   */
+  void show_blocking();
+
   void clear();
   void fade_by(uint8_t fade_amount);
   void set_brightness(uint8_t brightness);
@@ -310,6 +318,23 @@ template <size_t NUM_LEDS> void WS2812_DMA<NUM_LEDS>::show() {
   // Switch to the other buffer for the next drawing operations.
   _draw_buffer_index = 1 - _draw_buffer_index;
   _last_show_time = current_time;
+}
+
+template <size_t NUM_LEDS> void WS2812_DMA<NUM_LEDS>::show_blocking() {
+  if (!_initialized) {
+    assert(_initialized);
+    return;
+  }
+
+  _last_show_time = nil_time; // Bypass the frame-rate throttle.
+  show();
+  dma_channel_wait_for_finish_blocking(_dma_channel);
+
+  // The PIO TX FIFO can still hold up to 8 pixels after the DMA completes;
+  // wait for it to drain (24 bits at 800 kHz = 30 us per pixel) plus the
+  // WS2812 latch time before returning.
+  constexpr uint32_t PIO_FIFO_DRAIN_US = 8 * 30;
+  busy_wait_us_32(PIO_FIFO_DRAIN_US + G_LATCH_DELAY_US);
 }
 
 // --- Namespace-level Static Handler Implementations ---


### PR DESCRIPTION
## Summary
- The SysEx `RebootBootloader` command previously called `reset_usb_boot(0, 0)` with zero LED/display feedback — the device would silently vanish as a MIDI device and reappear as USB mass storage.
- Adds `drum::Events::EnteringBootloaderEvent`, published by `SysExHandler` right before the reboot call and consumed by `PizzaDisplay`, which clears the display and lights a single blue LED as a visual cue that the reboot is happening.
- Follows the existing `etl::observer`/`etl::observable` pattern already used for `SysExTransferStateChangeEvent` (same idiom `MessageRouter` uses for its multiple observable event types), so `sysex_handler.cpp` stays fully decoupled from the display/LED code — it only depends on `events.h`.

## Test plan
- [x] Full firmware build succeeds (`drum/build.sh --no-upload`)
- [x] Host test suite passes (`test/run_test_dir.sh drum`)
- [ ] Manually verify on hardware: send the `RebootBootloader` SysEx command and confirm a single blue LED appears before the device reboots into BOOTSEL mode