### PR TITLE
fix: reload sample from flash after SysEx sample transfer

### DIFF
--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -169,6 +169,10 @@ int main() {
   // Connect SysExHandler to SequencerController for sequencer state transfer
   sysex_handler.set_sequencer_state_access(&sequencer_controller);
 
+  // A completed SDS sample transfer must drop any RAM copy of the slot so
+  // the rewritten file is re-read from flash (issue #572).
+  sysex_handler.set_sample_slot_manager(&sample_slot_manager);
+
   // Register observers for SysEx state changes
   sysex_handler.add_observer(message_router);
   sysex_handler.add_observer(sequencer_controller);

--- a/drum/sample_slot_manager.cpp
+++ b/drum/sample_slot_manager.cpp
@@ -75,6 +75,18 @@ void SampleSlotManager::commit_staging() {
   staging_ready_ = false;
 }
 
+void SampleSlotManager::invalidate_sample(size_t sample_index) {
+  for (VoiceSlot &slot : voice_slots_) {
+    if (slot.sample_index.has_value() &&
+        slot.sample_index.value() == sample_index) {
+      slot.sample_index.reset();
+    }
+  }
+  if (staging_ready_ && staging_sample_index_ == sample_index) {
+    staging_ready_ = false;
+  }
+}
+
 const int16_t *SampleSlotManager::voice_data(uint8_t voice_index) const {
   if (voice_index >= NUM_VOICE_SLOTS) {
     return nullptr;

--- a/drum/sample_slot_manager.h
+++ b/drum/sample_slot_manager.h
@@ -66,6 +66,15 @@ public:
    */
   void commit_staging();
 
+  /**
+   * @brief Forgets any RAM copy of the given sample slot.
+   *
+   * Voices keep playing their current buffer, but the next trigger for
+   * this sample index re-reads the file from flash. Used after a SysEx
+   * transfer rewrites a sample so stale RAM data is not reused.
+   */
+  void invalidate_sample(size_t sample_index);
+
   const int16_t *voice_data(uint8_t voice_index) const;
   uint32_t voice_length(uint8_t voice_index) const;
   etl::optional<size_t> voice_sample_index(uint8_t voice_index) const;

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -1,4 +1,5 @@
 #include "drum/sysex_handler.h"
+#include "drum/sample_slot_manager.h"
 #include "drum/sysex/sequencer_state_codec.h"
 #include "events.h"
 #include "musin/midi/midi_wrapper.h"
@@ -120,12 +121,19 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
     // Extract SDS payload (skip 0x7E and channel)
     const auto sds_payload =
         etl::span<const uint8_t>{chunk.cbegin() + 2, chunk.cend()};
+    // Capture the active slot before processing: a completing data packet
+    // returns the protocol to Idle, after which the slot is no longer
+    // reported.
+    const auto active_sample_slot = sds_protocol_.current_sample_number_opt();
     auto result = sds_protocol_.process_message(sds_payload, sds_sender,
                                                 get_absolute_time());
 
     switch (result) {
     case sds::Result::SampleComplete:
       logger_.info("SDS: Sample transfer completed successfully");
+      if (sample_slot_manager_ != nullptr && active_sample_slot.has_value()) {
+        sample_slot_manager_->invalidate_sample(active_sample_slot.value());
+      }
       on_file_received();
       break;
     case sds::Result::ChecksumError:
@@ -347,6 +355,11 @@ void SysExHandler::send_storage_info() const {
 void SysExHandler::set_sequencer_state_access(
     SequencerStateAccess *sequencer_state_access) {
   sequencer_state_access_ = sequencer_state_access;
+}
+
+void SysExHandler::set_sample_slot_manager(
+    SampleSlotManager *sample_slot_manager) {
+  sample_slot_manager_ = sample_slot_manager;
 }
 
 void SysExHandler::send_sequencer_state() const {

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -21,6 +21,8 @@ extern "C" {
 
 namespace drum {
 
+class SampleSlotManager;
+
 class SysExHandler
     : public etl::observable<
           etl::observer<drum::Events::SysExTransferStateChangeEvent>,
@@ -59,6 +61,12 @@ public:
    */
   void set_sequencer_state_access(SequencerStateAccess *sequencer_state_access);
 
+  /**
+   * @brief Wires the sample slot manager so a completed SDS sample
+   * transfer invalidates any RAM copy of the rewritten slot.
+   */
+  void set_sample_slot_manager(SampleSlotManager *sample_slot_manager);
+
 private:
   void handle_firmware_update_message(const sysex::Chunk &chunk,
                                       absolute_time_t now);
@@ -77,6 +85,7 @@ private:
   musin::Logger &logger_;
   musin::filesystem::Filesystem &filesystem_;
   SequencerStateAccess *sequencer_state_access_ = nullptr;
+  SampleSlotManager *sample_slot_manager_ = nullptr;
 
   StandardFileOps file_ops_;
   sysex::Protocol<StandardFileOps> protocol_;

--- a/test/drum/sample_slot_manager_test.cpp
+++ b/test/drum/sample_slot_manager_test.cpp
@@ -91,6 +91,48 @@ TEST_CASE("Request for a sample the voice already holds is a no-op") {
   remove(path.c_str());
 }
 
+TEST_CASE("Invalidated sample is re-read from disk on the next request") {
+  drum::SampleSlotManager manager(logger);
+  auto path = write_pcm_file("slot_test_g.pcm", 1000, 100);
+
+  REQUIRE(manager.request_load(1, 9, path.c_str()));
+  manager.commit_staging();
+  REQUIRE(manager.voice_has_sample(1, 9));
+
+  // Simulate a SysEx transfer rewriting the file on flash.
+  write_pcm_file("slot_test_g.pcm", 1000, 500);
+  manager.invalidate_sample(9);
+
+  REQUIRE_FALSE(manager.voice_has_sample(1, 9));
+  // The old audio stays playable until the reload commits.
+  REQUIRE(manager.voice_length(1) == 1000);
+  REQUIRE(manager.voice_data(1)[0] == 100);
+
+  REQUIRE(manager.request_load(1, 9, path.c_str()));
+  manager.commit_staging();
+  REQUIRE(manager.voice_has_sample(1, 9));
+  REQUIRE(manager.voice_data(1)[0] == 500);
+  remove(path.c_str());
+}
+
+TEST_CASE("Invalidation drops a matching staged load") {
+  drum::SampleSlotManager manager(logger);
+  auto path = write_pcm_file("slot_test_h.pcm", 1000, 100);
+
+  REQUIRE(manager.request_load(0, 4, path.c_str()));
+  REQUIRE(manager.staging_ready_for(0, 4));
+
+  manager.invalidate_sample(4);
+  REQUIRE_FALSE(manager.staging_ready_for_voice(0));
+
+  // Other samples are unaffected.
+  REQUIRE(manager.request_load(2, 6, path.c_str()));
+  manager.commit_staging();
+  manager.invalidate_sample(4);
+  REQUIRE(manager.voice_has_sample(2, 6));
+  remove(path.c_str());
+}
+
 TEST_CASE("Missing file is reported as failure") {
   drum::SampleSlotManager manager(logger);
   REQUIRE_FALSE(manager.request_load(0, 3, "./does_not_exist.pcm"));


### PR DESCRIPTION
Fixes #572.

## Problem
When a sample is uploaded over SysEx (SDS), only the flash-resident file is rewritten. The active slot's sample stays buffered in RAM, so the new audio is only heard after selecting another sample and coming back.

## Fix
- `SampleSlotManager::invalidate_sample()` clears the identity of any voice slot holding the rewritten sample (audio data stays playable until the reload commits) and drops a matching uncommitted staged load.
- `SysExHandler` captures the active SDS slot before processing each message (a completing data packet returns the protocol to Idle, after which the slot is no longer reported) and invalidates it on `SampleComplete`, via a new `set_sample_slot_manager()` hook wired in `main.cpp`.

The next trigger of the affected slot re-reads the file from flash on the main loop — same cost as switching samples.

## Testing
- Two new `SampleSlotManager` tests: invalidated sample is re-read with new content; invalidation drops a matching staged load and leaves other samples untouched.
- All 47 host tests pass; flash firmware build succeeds.