### PR TITLE
fix: make UF2 flash bounds checks overflow-safe

### DIFF
--- a/musin/flash/firmware_writer.cpp
+++ b/musin/flash/firmware_writer.cpp
@@ -199,8 +199,9 @@ bool FirmwareWriter::flush_sector() {
     return true;
   }
   if (current_sector_base_ < target_offset_ ||
-      current_sector_base_ + FLASH_SECTOR_SIZE >
-          target_offset_ + target_size_) {
+      target_size_ < FLASH_SECTOR_SIZE ||
+      current_sector_base_ - target_offset_ >
+          target_size_ - FLASH_SECTOR_SIZE) {
     logger_.error("FirmwareWriter: Sector outside target partition");
     return false;
   }

--- a/musin/flash/uf2_parser.h
+++ b/musin/flash/uf2_parser.h
@@ -141,8 +141,8 @@ private:
     if (payload_size != PAYLOAD_SIZE) {
       return Result::BadPayloadSize;
     }
-    if (target_addr < FLASH_BASE ||
-        target_addr + PAYLOAD_SIZE > FLASH_BASE + partition_size_) {
+    if (target_addr < FLASH_BASE || partition_size_ < PAYLOAD_SIZE ||
+        target_addr - FLASH_BASE > partition_size_ - PAYLOAD_SIZE) {
       return Result::OutOfRange;
     }
 

--- a/test/musin/flash/uf2_parser_test.cpp
+++ b/test/musin/flash/uf2_parser_test.cpp
@@ -175,6 +175,11 @@ TEST_CASE("Uf2Parser rejects out-of-range targets") {
     REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
                         collector) == Result::OutOfRange);
   }
+  SECTION("target address near uint32_t overflow") {
+    auto block = make_block(0, 1, 0xFFFFFF00);
+    REQUIRE(parser.push(etl::span<const uint8_t>{block.data(), block.size()},
+                        collector) == Result::OutOfRange);
+  }
 }
 
 TEST_CASE("Uf2Parser rejects non-sequential block numbers") {


### PR DESCRIPTION
target_addr + PAYLOAD_SIZE and current_sector_base_ + FLASH_SECTOR_SIZE could wrap past 0xFFFFFFFF for crafted/corrupt input near the top of the address space, letting an out-of-range block pass the bounds check. Rewrite both checks using subtraction so they cannot overflow.