### PR TITLE
fix: keep drumpad hold timer running when pressure dips below trigger

### DIFF
--- a/musin/ui/drumpad.cpp
+++ b/musin/ui/drumpad.cpp
@@ -73,9 +73,9 @@ void Drumpad::update_state_machine(std::uint16_t current_adc_value,
     break;
 
   case DrumpadState::Peaking:
-    if (current_adc_value < _trigger_threshold) {
-      _current_state = DrumpadState::Falling;
-    }
+    // A dip below _trigger_threshold does not abort the hold: as long as
+    // contact stays above _noise_threshold, the hold timer keeps running so
+    // retrigger arms in sync with has_recent_velocity_hit (ring lifetime).
     if (time_in_state >= _hold_time_us) {
       _current_state = DrumpadState::Holding;
       notify_event(DrumpadEvent::Type::Hold, std::nullopt, current_adc_value);

--- a/test/musin/ui/drumpad_test.cpp
+++ b/test/musin/ui/drumpad_test.cpp
@@ -11,15 +11,15 @@ namespace {
 
 // active_low = false so the raw ADC value passed to update() is used directly,
 // keeping the threshold arithmetic in the tests easy to follow.
-constexpr musin::ui::DrumpadConfig test_config = {
-    .noise_threshold = 150,
-    .trigger_threshold = 800,
-    .high_pressure_threshold = 2500,
-    .active_low = false,
-    .debounce_time_us = 5000,
-    .hold_time_us = 50000,
-    .max_velocity_time_us = 50000,
-    .min_velocity_time_us = 100};
+constexpr musin::ui::DrumpadConfig test_config = {.noise_threshold = 150,
+                                                  .trigger_threshold = 800,
+                                                  .high_pressure_threshold =
+                                                      2500,
+                                                  .active_low = false,
+                                                  .debounce_time_us = 5000,
+                                                  .hold_time_us = 50000,
+                                                  .max_velocity_time_us = 50000,
+                                                  .min_velocity_time_us = 100};
 
 // Drive the pad from Idle to Peaking, emitting a Press once trigger is crossed.
 void press_to_peaking(Drumpad &pad, uint16_t adc) {
@@ -86,6 +86,26 @@ TEST_CASE("Holding below trigger after a press still engages Single") {
   pad.init();
   press_to_peaking(pad, 1000);        // crosses trigger, Press fired
   hold_until_mode_resolved(pad, 500); // settles to 150..799 range while held
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Single);
+}
+
+// Same regression, but the pad is scanned while pressure sits below trigger
+// before hold_time_us expires. Previously this update moved Peaking to
+// Falling, a dead end where the hold timer no longer ran, so retrigger never
+// engaged even though the ring stayed lit until release.
+TEST_CASE("Scan below trigger before hold expiry still engages Single") {
+  Drumpad pad(0, test_config);
+  pad.init();
+  press_to_peaking(pad, 1000); // crosses trigger, Press fired
+
+  advance_mock_time_us(10000);
+  pad.update(500); // pressure sags below trigger, above noise, before hold
+  REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Off);
+
+  advance_mock_time_us(50000);
+  pad.update(500); // hold timer expires while contact persists
+  REQUIRE(pad.is_held());
+  pad.update(500); // Holding-state logic resolves retrigger mode
   REQUIRE(pad.get_retrigger_mode() == RetriggerMode::Single);
 }
 


### PR DESCRIPTION
## Problem
Pads sometimes showed the ring visualization without the drums retriggering. The ring is driven by `has_recent_velocity_hit` (lit from Press until Release), but retrigger only arms when the pad state machine reaches `Holding`. If pad pressure sagged below `trigger_threshold` (800) before `hold_time_us` (50 ms) expired, `Peaking` transitioned to `Falling` — a dead end whose only exit is a full release below the noise floor. The hold timer stopped running there, so retrigger never armed while the ring stayed lit.

## Fix
`Peaking` no longer aborts to `Falling` on a dip below `trigger_threshold`. The hold timer keeps running as long as contact stays above `noise_threshold` (150), so retrigger arms in sync with the ring lifetime — matching the intent already documented in the `Holding` state comment. Full release and the high-pressure `Double` upgrade are unchanged.

## Behavior note
A lingering release that takes longer than 50 ms to decay through the 150–800 ADC band now starts retriggering where it previously fell silent. If that proves annoying on hardware, `noise_threshold` is the tuning knob.

## Tests
New regression test `Scan below trigger before hold expiry still engages Single` covers the mid-hold scan below trigger that previously trapped the state machine in `Falling`. Full host suite passes (114 tests, 0 failures).