### PR TITLE
fix: make trace fade duration exact and compile-time checked

### DIFF
--- a/drum/sequencer_controller.cpp
+++ b/drum/sequencer_controller.cpp
@@ -506,9 +506,7 @@ void SequencerController<NumTracks, NumSteps>::record_pad_hit_trace(
 template <size_t NumTracks, size_t NumSteps>
 void SequencerController<NumTracks, NumSteps>::fade_traces(
     uint32_t elapsed_ticks) {
-  constexpr uint32_t DECREMENT_PER_TICK =
-      (TRACE_INITIAL_VELOCITY + TRACE_FADE_TICKS - 1) / TRACE_FADE_TICKS;
-  const uint32_t decrement = DECREMENT_PER_TICK * elapsed_ticks;
+  const uint32_t decrement = TRACE_DECREMENT_PER_TICK * elapsed_ticks;
   for (auto &track_traces : trace_velocities_) {
     for (auto &velocity : track_traces) {
       velocity = (velocity > decrement)

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -307,10 +307,26 @@ private:
 
   // Trace velocities match the MIDI velocity range so the display maps them
   // to brightness exactly like pattern steps.
-  static constexpr uint8_t TRACE_INITIAL_VELOCITY = 127;
+  //
+  // The fade subtracts a whole number of velocity units per 12 PPQN tick, so
+  // the only achievable fade lengths are TRACE_INITIAL_VELOCITY / d ticks for
+  // an integer decrement d. The static_assert below rejects any
+  // TRACE_INITIAL_VELOCITY / TRACE_FADE_STEPS combination that doesn't divide
+  // evenly, instead of silently fading in fewer steps than requested.
+  // Valid combinations must satisfy:
+  //   TRACE_INITIAL_VELOCITY % (TRACE_FADE_STEPS * TICKS_PER_STEP) == 0
+  // e.g. velocity 96 fades in exactly 8 or 16 steps; 127 divides by nothing
+  // useful and is not usable here.
+  static constexpr uint8_t TRACE_INITIAL_VELOCITY = 96;
   static constexpr uint8_t TRACE_FADE_STEPS = 8;
   static constexpr uint32_t TRACE_FADE_TICKS =
       TRACE_FADE_STEPS * musical_timing::TICKS_PER_STEP;
+  static_assert(TRACE_INITIAL_VELOCITY % TRACE_FADE_TICKS == 0,
+                "TRACE_INITIAL_VELOCITY must be an exact multiple of "
+                "TRACE_FADE_STEPS * TICKS_PER_STEP so the integer per-tick "
+                "decrement fades in exactly TRACE_FADE_STEPS steps");
+  static constexpr uint32_t TRACE_DECREMENT_PER_TICK =
+      TRACE_INITIAL_VELOCITY / TRACE_FADE_TICKS;
 
   void initialize_active_notes();
   void initialize_all_sequencers();


### PR DESCRIPTION
## Problem
`TRACE_FADE_STEPS` didn't do what it claims. The per-tick fade decrement was computed with ceiling integer division, so the actual fade length snapped to `ceil(127/d)` ticks for integer `d`. With `TRACE_FADE_STEPS = 8` (or 10) the trace faded in ~7.2 steps; bumping to 11 jumped discontinuously to ~10.7 steps.

## Change
- Derive a named `TRACE_DECREMENT_PER_TICK` constant by exact division in the header.
- `static_assert` that `TRACE_INITIAL_VELOCITY` divides evenly by `TRACE_FADE_STEPS * TICKS_PER_STEP`, so any unachievable combination fails to compile instead of silently fading early.
- Comment documents the integer-decrement limitation and valid combinations.
- `TRACE_INITIAL_VELOCITY` changes 127 → 96, the largest value ≤ 127 divisible by 48 ticks. Traces now fade in exactly 8 steps.

## Behavior note
Traces start at brightness 96/127 instead of full brightness. Worth a quick check on hardware that the trace still reads well on the LEDs.