### PR TITLE
feat: sample download over MIDI SDS dump request

### DIFF
--- a/drum/README.md
+++ b/drum/README.md
@@ -210,9 +210,12 @@ F0 7E 65 03 <sample # LSB> <sample # MSB> F7
 
 - The device replies with a Dump Header for `/NN.pcm` and then streams data
   packets, waiting for the host's ACK/NAK/WAIT/CANCEL after the header and
-  after every packet (NAK retransmits, CANCEL aborts). If the host never
-  responds, the device continues open-loop with a fixed inter-packet delay,
-  as the SDS spec allows.
+  after every packet (NAK retransmits, CANCEL aborts). If a handshaking
+  host's response goes missing, the device retransmits the same packet
+  (every 100 ms) rather than advancing, so a lost packet is never skipped.
+  Only when the host never responds to the header at all does the device
+  fall back to open-loop streaming with a fixed inter-packet delay, as the
+  SDS spec allows.
 - If the requested slot has no sample, the device replies with an SDS
   CANCEL (`F0 7E 65 7D 00 F7`).
 - The device plays back at 44100 Hz only, so outgoing dump headers always

--- a/drum/README.md
+++ b/drum/README.md
@@ -215,9 +215,8 @@ F0 7E 65 03 <sample # LSB> <sample # MSB> F7
   as the SDS spec allows.
 - If the requested slot has no sample, the device replies with an SDS
   CANCEL (`F0 7E 65 7D 00 F7`).
-- Stored samples carry no sample-rate metadata, so outgoing dump headers
-  always claim 44100 Hz. Samples uploaded at other rates download with an
-  incorrect rate in the header (the audio data itself is unchanged).
+- The device plays back at 44100 Hz only, so outgoing dump headers always
+  report 44100 Hz.
 - A download cannot start while an upload is in progress and vice versa;
   the conflicting request is refused (CANCEL/NAK).
 

--- a/drum/README.md
+++ b/drum/README.md
@@ -159,7 +159,7 @@ All custom SysEx messages share the following structure:
 - **Encoded Payload**: Command-specific data, with each pair of 8-bit bytes encoded into three 7-bit bytes.
 - **F7**: Standard SysEx End byte.
 
-A utility tool, `tools/drumtool/drumtool.js`, is provided to handle device communication and sample management using MIDI Sample Dump Standard (SDS) protocol.
+A utility tool, `tools/drumtool/drumtool.js`, is provided to handle device communication and sample management (upload and download) using the MIDI Sample Dump Standard (SDS) protocol.
 
 ### General Commands
 | Command | Tag | Description |
@@ -186,6 +186,45 @@ Transferring files (like samples or `kit.bin`) to the device is a multi-step pro
     - **Command:** `EndFileTransfer` (0x12)
     - **Payload:** None.
     - After sending all data chunks, the sender sends this command. The device closes the file, finalizing the write, and sends a final `Ack`.
+
+### Sample Transfer (MIDI Sample Dump Standard)
+
+Samples are transferred using the standard MIDI SDS protocol on SysEx channel
+`65`, with the DRUM acting as receiver (upload) or sender (download).
+`tools/drumtool/drumtool.js send` and `drumtool.js receive` are the reference
+clients.
+
+#### Upload (host → DRUM)
+The host sends an SDS **Dump Header** (`F0 7E 65 01 ...`) describing a 16-bit
+sample, followed by **Data Packets** (`F0 7E 65 02 ...`, 40 samples each).
+The device ACKs the header and each packet, and stores the audio as raw
+16-bit little-endian PCM in `/NN.pcm`, where `NN` is the two-digit sample
+number from the header.
+
+#### Download (DRUM → host)
+The host requests a sample with an SDS **Dump Request**:
+
+```
+F0 7E 65 03 <sample # LSB> <sample # MSB> F7
+```
+
+- The device replies with a Dump Header for `/NN.pcm` and then streams data
+  packets, waiting for the host's ACK/NAK/WAIT/CANCEL after the header and
+  after every packet (NAK retransmits, CANCEL aborts). If the host never
+  responds, the device continues open-loop with a fixed inter-packet delay,
+  as the SDS spec allows.
+- If the requested slot has no sample, the device replies with an SDS
+  CANCEL (`F0 7E 65 7D 00 F7`).
+- Stored samples carry no sample-rate metadata, so outgoing dump headers
+  always claim 44100 Hz. Samples uploaded at other rates download with an
+  incorrect rate in the header (the audio data itself is unchanged).
+- A download cannot start while an upload is in progress and vice versa;
+  the conflicting request is refused (CANCEL/NAK).
+
+```bash
+tools/drumtool/drumtool.js receive 0 kick.wav    # slot 0 as 44.1kHz WAV
+tools/drumtool/drumtool.js receive 30 --raw      # slot 30 as raw 16-bit PCM
+```
 
 ### Firmware Update Protocol
 

--- a/drum/events.h
+++ b/drum/events.h
@@ -57,6 +57,9 @@ struct SysExTransferStateChangeEvent {
   // Optional transfer progress (0.0f to 1.0f). Present during firmware
   // updates, absent for file/sample transfers.
   std::optional<float> progress = std::nullopt;
+  // If true, skip the debounce period and return to sequencer immediately.
+  // Used for outgoing SDS dumps where the device just sends data.
+  bool skip_debounce = false;
 };
 
 } // namespace drum::Events

--- a/drum/midi_manager.cpp
+++ b/drum/midi_manager.cpp
@@ -44,11 +44,25 @@ void MidiManager::init() {
 }
 
 void MidiManager::process_input() {
-  MIDI::read();
-
-  while (const sysex::Chunk *chunk = musin::midi::peek_incoming_sysex_chunk()) {
-    handle_sysex(*chunk);
-    musin::midi::pop_incoming_sysex_chunk();
+  // Drain every buffered message instead of one per loop iteration: each
+  // read() returns after at most one complete message, and a single call per
+  // loop paces inbound SysEx far below what USB delivers during sample
+  // transfers. The loop is bounded because the transport buffers only refill
+  // from usb::background_update(); the cap guards the loop period against a
+  // pathological flood.
+  constexpr int MAX_MESSAGES_PER_UPDATE = 32;
+  for (int i = 0; i < MAX_MESSAGES_PER_UPDATE; ++i) {
+    const bool message_parsed = MIDI::read();
+    // The SysEx chunk queue is only two entries deep, so consume chunks
+    // between reads or back-to-back SysEx messages would be dropped.
+    while (const sysex::Chunk *chunk =
+               musin::midi::peek_incoming_sysex_chunk()) {
+      handle_sysex(*chunk);
+      musin::midi::pop_incoming_sysex_chunk();
+    }
+    if (!message_parsed) {
+      break;
+    }
   }
 
   musin::midi::IncomingMidiMessage message;

--- a/drum/standard_file_ops.h
+++ b/drum/standard_file_ops.h
@@ -1,8 +1,10 @@
 #ifndef PRINTING_FILE_OPS_H_CVXHHJDO
 #define PRINTING_FILE_OPS_H_CVXHHJDO
 
+#include "etl/optional.h"
 #include "etl/span.h"
 #include "etl/string_view.h"
+#include "etl/utility.h"
 #include "musin/filesystem/filesystem.h"
 #include "musin/hal/logger.h"
 
@@ -84,6 +86,78 @@ struct StandardFileOps {
     musin::Logger &logger;
     FILE *file_pointer = nullptr;
   };
+
+  struct ReadHandle {
+    ReadHandle(const ReadHandle &) = delete;
+    ReadHandle &operator=(const ReadHandle &) = delete;
+
+    ReadHandle(ReadHandle &&other) noexcept
+        : file_pointer(other.file_pointer), size_(other.size_) {
+      other.file_pointer = nullptr;
+    }
+
+    ReadHandle &operator=(ReadHandle &&other) noexcept {
+      if (this != &other) {
+        close();
+        file_pointer = other.file_pointer;
+        size_ = other.size_;
+        other.file_pointer = nullptr;
+      }
+      return *this;
+    }
+
+    explicit ReadHandle(const etl::string_view &path) {
+      file_pointer = fopen(path.data(), "rb");
+      if (file_pointer) {
+        if (fseek(file_pointer, 0, SEEK_END) == 0) {
+          const long end = ftell(file_pointer);
+          size_ = end > 0 ? static_cast<size_t>(end) : 0;
+        }
+        fseek(file_pointer, 0, SEEK_SET);
+      }
+    }
+
+    ~ReadHandle() {
+      close();
+    }
+
+    void close() {
+      if (file_pointer) {
+        fclose(file_pointer);
+        file_pointer = nullptr;
+      }
+    }
+
+    bool is_valid() const {
+      return file_pointer != nullptr;
+    }
+
+    size_t size() const {
+      return size_;
+    }
+
+    size_t read(const etl::span<uint8_t> &bytes) {
+      if (!file_pointer) {
+        return 0;
+      }
+      return fread(bytes.data(), sizeof(uint8_t), bytes.size(), file_pointer);
+    }
+
+  private:
+    FILE *file_pointer = nullptr;
+    size_t size_ = 0;
+  };
+
+  etl::optional<ReadHandle> open_read(const etl::string_view &path) {
+    logger.info("Opening file for reading:");
+    logger.info(path);
+    ReadHandle handle(path);
+    if (!handle.is_valid()) {
+      logger.warn("Failed opening file for reading");
+      return etl::nullopt;
+    }
+    return etl::optional<ReadHandle>(etl::move(handle));
+  }
 
   // Handle should close upon destruction
   // TODO: Return optional instead, if handle could not be opened.

--- a/drum/sysex/sds_dump_sender.h
+++ b/drum/sysex/sds_dump_sender.h
@@ -9,8 +9,10 @@
  * Request. The device acts as the SDS dump source: it sends the Dump Header,
  * waits for the host handshake, then sends data packets one at a time, each
  * gated on the host's ACK/NAK/WAIT/CANCEL response. If the host never
- * responds, the transfer continues open-loop with a fixed inter-packet
- * interval, as permitted by the SDS spec.
+ * responds to the header, the transfer continues open-loop with a fixed
+ * inter-packet interval, as permitted by the SDS spec. Once handshaking, a
+ * missing packet response triggers retransmission of the same packet (the
+ * packet or its ACK was lost in transit) rather than advancing.
  *
  * Sending is paced from the main loop via update(); no blocking occurs, so
  * audio and the sequencer keep running during a download.
@@ -31,11 +33,15 @@ namespace sds {
 
 template <typename FileOperations> class DumpSender {
 public:
-  // Handshake timeouts from the SDS spec: two seconds after the header,
-  // 20 ms after each data packet. A missing response switches the transfer
-  // to open-loop mode instead of aborting it.
+  // If the host never responds to the header within two seconds (SDS spec),
+  // it is assumed to be a non-handshaking receiver and the dump proceeds
+  // open-loop.
   static constexpr uint64_t HEADER_RESPONSE_TIMEOUT_US = 2000000;
-  static constexpr uint64_t PACKET_RESPONSE_TIMEOUT_US = 20000;
+  // Once the host has handshaked, a missing packet response means the packet
+  // (or its ACK) was lost in transit. Retransmit rather than advance: the
+  // host is still waiting for exactly this packet, and skipping it would
+  // lose data irrecoverably.
+  static constexpr uint64_t RETRANSMIT_INTERVAL_US = 100000;
   // Open-loop pacing: slow enough that the small SysEx output queue and a
   // DIN MIDI link (~41 ms per 127-byte packet at 31250 baud) can keep up.
   static constexpr uint64_t OPEN_LOOP_INTERVAL_US = 50000;
@@ -96,6 +102,7 @@ public:
     send_dump_header(send_message);
     state_ = State::AwaitingHeaderResponse;
     last_activity_time_ = now;
+    last_send_time_ = now;
     logger_.info("SDS: Dump started, bytes:",
                  static_cast<uint32_t>(total_bytes_));
     return Result::OK;
@@ -122,7 +129,7 @@ public:
       return Result::OK;
     case NAK:
       wait_pending_ = false;
-      resend_last(send_message);
+      resend_last(send_message, now);
       return Result::OK;
     case WAIT:
       wait_pending_ = true;
@@ -152,6 +159,7 @@ public:
       return Result::OK; // Host asked us to wait; stall timeout still applies.
     }
 
+    const int64_t since_send = absolute_time_diff_us(last_send_time_, now);
     switch (state_) {
     case State::AwaitingHeaderResponse:
       if (elapsed > static_cast<int64_t>(HEADER_RESPONSE_TIMEOUT_US)) {
@@ -161,13 +169,15 @@ public:
       }
       return Result::OK;
     case State::AwaitingPacketResponse:
-      if (elapsed > static_cast<int64_t>(PACKET_RESPONSE_TIMEOUT_US)) {
-        state_ = State::OpenLoop;
-        return advance_open_loop(send_message, now);
+      // The host handshaked earlier but this packet's response is missing:
+      // the packet or its ACK was lost. Retransmit until the host answers
+      // or the stall timeout gives up on it.
+      if (since_send > static_cast<int64_t>(RETRANSMIT_INTERVAL_US)) {
+        resend_last(send_message, now);
       }
       return Result::OK;
     case State::OpenLoop:
-      if (elapsed > static_cast<int64_t>(OPEN_LOOP_INTERVAL_US)) {
+      if (since_send > static_cast<int64_t>(OPEN_LOOP_INTERVAL_US)) {
         return advance_open_loop(send_message, now);
       }
       return Result::OK;
@@ -197,7 +207,10 @@ private:
   size_t bytes_sent_ = 0;
   uint8_t packet_num_ = 0;
   bool wait_pending_ = false;
+  // Last host response (or transfer start); drives the stall timeout.
   absolute_time_t last_activity_time_{};
+  // Last outgoing header/packet; drives retransmit and open-loop pacing.
+  absolute_time_t last_send_time_{};
   etl::array<uint8_t, PACKET_SIZE> last_packet_{};
   bool header_is_last_sent_ = true;
   etl::array<uint8_t, 17> header_{};
@@ -284,16 +297,22 @@ private:
     packet_num_ = (packet_num_ + 1) & 0x7F;
     if (state_ != State::OpenLoop) {
       state_ = State::AwaitingPacketResponse;
+    } else {
+      // No host responses are expected open-loop; sending is the only
+      // activity that can keep the stall timeout at bay.
+      last_activity_time_ = now;
     }
-    last_activity_time_ = now;
+    last_send_time_ = now;
   }
 
-  template <typename SendMessage> void resend_last(SendMessage send_message) {
+  template <typename SendMessage>
+  void resend_last(SendMessage send_message, absolute_time_t now) {
     if (header_is_last_sent_) {
       send_message(etl::span<const uint8_t>{header_});
     } else {
       send_message(etl::span<const uint8_t>{last_packet_});
     }
+    last_send_time_ = now;
   }
 
   template <typename SendMessage>

--- a/drum/sysex/sds_dump_sender.h
+++ b/drum/sysex/sds_dump_sender.h
@@ -121,7 +121,11 @@ public:
     switch (type) {
     case ACK:
       wait_pending_ = false;
-      if (state_ == State::AwaitingPacketResponse && transfer_complete()) {
+      // Complete only after the final packet went out (bytes_sent_ is zero
+      // while the header awaits its response). Checked in every sending
+      // state: a late-handshaking host may ACK the final open-loop packet,
+      // and advancing would emit a spurious zero-filled packet past the end.
+      if (transfer_complete()) {
         finish();
         logger_.info("SDS: Dump complete");
         return Result::SampleComplete;

--- a/drum/sysex/sds_dump_sender.h
+++ b/drum/sysex/sds_dump_sender.h
@@ -1,0 +1,313 @@
+#ifndef SDS_DUMP_SENDER_H_SDS_AUDIO
+#define SDS_DUMP_SENDER_H_SDS_AUDIO
+
+/**
+ * @file sds_dump_sender.h
+ * @brief MIDI Sample Dump Standard (SDS) sender for sample download
+ *
+ * Streams a stored sample file back to the host in response to an SDS Dump
+ * Request. The device acts as the SDS dump source: it sends the Dump Header,
+ * waits for the host handshake, then sends data packets one at a time, each
+ * gated on the host's ACK/NAK/WAIT/CANCEL response. If the host never
+ * responds, the transfer continues open-loop with a fixed inter-packet
+ * interval, as permitted by the SDS spec.
+ *
+ * Sending is paced from the main loop via update(); no blocking occurs, so
+ * audio and the sequencer keep running during a download.
+ *
+ * The device does not persist sample rates, so outgoing headers always claim
+ * 44100 Hz (see SAMPLE_RATE_HZ).
+ */
+
+#include "drum/sysex/sds_protocol.h"
+#include "etl/algorithm.h"
+#include "etl/array.h"
+#include "etl/optional.h"
+#include "etl/span.h"
+
+#include <cstdio>
+
+namespace sds {
+
+template <typename FileOperations> class DumpSender {
+public:
+  // Handshake timeouts from the SDS spec: two seconds after the header,
+  // 20 ms after each data packet. A missing response switches the transfer
+  // to open-loop mode instead of aborting it.
+  static constexpr uint64_t HEADER_RESPONSE_TIMEOUT_US = 2000000;
+  static constexpr uint64_t PACKET_RESPONSE_TIMEOUT_US = 20000;
+  // Open-loop pacing: slow enough that the small SysEx output queue and a
+  // DIN MIDI link (~41 ms per 127-byte packet at 31250 baud) can keep up.
+  static constexpr uint64_t OPEN_LOOP_INTERVAL_US = 50000;
+  // A host that sent WAIT but never followed up is assumed gone.
+  static constexpr uint64_t STALL_TIMEOUT_US = 30000000;
+  // Sample rate reported in outgoing dump headers; the stored .pcm files
+  // carry no rate metadata.
+  static constexpr uint32_t SAMPLE_RATE_HZ = 44100;
+  static constexpr size_t BYTES_PER_PACKET = 80; // 40 16-bit samples
+  static constexpr size_t PACKET_SIZE = 123;     // type + num + 120 + checksum
+
+  enum class State {
+    Idle,
+    AwaitingHeaderResponse,
+    AwaitingPacketResponse,
+    OpenLoop
+  };
+
+  constexpr DumpSender(FileOperations &file_ops, musin::Logger &logger)
+      : file_ops_(file_ops), logger_(logger) {
+  }
+
+  // Handle a Dump Request message: [DUMP_REQUEST, sample# low, sample# high].
+  // Sends the Dump Header on success, or CANCEL when the slot has no sample.
+  template <typename SendMessage>
+  Result handle_dump_request(const etl::span<const uint8_t> &message,
+                             SendMessage send_message, absolute_time_t now) {
+    if (message.size() < 3) {
+      send_cancel(send_message);
+      return Result::InvalidMessage;
+    }
+    if (state_ != State::Idle) {
+      logger_.warn("SDS: Dump request while a dump is already active");
+      send_cancel(send_message);
+      return Result::StateError;
+    }
+
+    sample_number_ = ((static_cast<uint16_t>(message[1]) & 0x7F)) |
+                     ((static_cast<uint16_t>(message[2]) & 0x7F) << 7);
+
+    char filename[16];
+    snprintf(filename, sizeof(filename), "/%02u.pcm", sample_number_);
+
+    file_ = file_ops_.open_read(filename);
+    if (!file_.has_value() || file_->size() < 2) {
+      logger_.warn("SDS: Dump request for missing sample:",
+                   static_cast<uint32_t>(sample_number_));
+      file_.reset();
+      send_cancel(send_message);
+      return Result::FileError;
+    }
+
+    total_bytes_ = file_->size() & ~static_cast<size_t>(1); // whole words only
+    bytes_sent_ = 0;
+    packet_num_ = 0;
+    wait_pending_ = false;
+
+    send_dump_header(send_message);
+    state_ = State::AwaitingHeaderResponse;
+    last_activity_time_ = now;
+    logger_.info("SDS: Dump started, bytes:",
+                 static_cast<uint32_t>(total_bytes_));
+    return Result::OK;
+  }
+
+  // Handle a host handshake response (ACK/NAK/WAIT/CANCEL) during a dump.
+  template <typename SendMessage>
+  Result handle_response(uint8_t type, SendMessage send_message,
+                         absolute_time_t now) {
+    if (state_ == State::Idle) {
+      return Result::StateError;
+    }
+    last_activity_time_ = now;
+
+    switch (type) {
+    case ACK:
+      wait_pending_ = false;
+      if (state_ == State::AwaitingPacketResponse && transfer_complete()) {
+        finish();
+        logger_.info("SDS: Dump complete");
+        return Result::SampleComplete;
+      }
+      send_next_packet(send_message, now);
+      return Result::OK;
+    case NAK:
+      wait_pending_ = false;
+      resend_last(send_message);
+      return Result::OK;
+    case WAIT:
+      wait_pending_ = true;
+      return Result::OK;
+    case CANCEL:
+      logger_.info("SDS: Dump cancelled by host");
+      finish();
+      return Result::Cancelled;
+    default:
+      return Result::InvalidMessage;
+    }
+  }
+
+  // Drives handshake timeouts and open-loop pacing; call from the main loop.
+  template <typename SendMessage>
+  Result update(SendMessage send_message, absolute_time_t now) {
+    if (state_ == State::Idle) {
+      return Result::OK;
+    }
+    const int64_t elapsed = absolute_time_diff_us(last_activity_time_, now);
+    if (elapsed > static_cast<int64_t>(STALL_TIMEOUT_US)) {
+      logger_.warn("SDS: Dump stalled, aborting");
+      finish();
+      return Result::Cancelled;
+    }
+    if (wait_pending_) {
+      return Result::OK; // Host asked us to wait; stall timeout still applies.
+    }
+
+    switch (state_) {
+    case State::AwaitingHeaderResponse:
+      if (elapsed > static_cast<int64_t>(HEADER_RESPONSE_TIMEOUT_US)) {
+        logger_.info("SDS: No header response, continuing open-loop");
+        state_ = State::OpenLoop;
+        send_next_packet(send_message, now);
+      }
+      return Result::OK;
+    case State::AwaitingPacketResponse:
+      if (elapsed > static_cast<int64_t>(PACKET_RESPONSE_TIMEOUT_US)) {
+        state_ = State::OpenLoop;
+        return advance_open_loop(send_message, now);
+      }
+      return Result::OK;
+    case State::OpenLoop:
+      if (elapsed > static_cast<int64_t>(OPEN_LOOP_INTERVAL_US)) {
+        return advance_open_loop(send_message, now);
+      }
+      return Result::OK;
+    default:
+      return Result::OK;
+    }
+  }
+
+  constexpr bool is_busy() const {
+    return state_ != State::Idle;
+  }
+
+  constexpr etl::optional<uint16_t> current_sample_number_opt() const {
+    if (state_ != State::Idle) {
+      return sample_number_;
+    }
+    return etl::nullopt;
+  }
+
+private:
+  FileOperations &file_ops_;
+  musin::Logger &logger_;
+  State state_ = State::Idle;
+  etl::optional<typename FileOperations::ReadHandle> file_;
+  uint16_t sample_number_ = 0;
+  size_t total_bytes_ = 0;
+  size_t bytes_sent_ = 0;
+  uint8_t packet_num_ = 0;
+  bool wait_pending_ = false;
+  absolute_time_t last_activity_time_{};
+  etl::array<uint8_t, PACKET_SIZE> last_packet_{};
+  bool header_is_last_sent_ = true;
+  etl::array<uint8_t, 17> header_{};
+
+  constexpr bool transfer_complete() const {
+    return bytes_sent_ >= total_bytes_;
+  }
+
+  void finish() {
+    file_.reset();
+    state_ = State::Idle;
+    wait_pending_ = false;
+  }
+
+  template <typename SendMessage> void send_cancel(SendMessage send_message) {
+    const etl::array<uint8_t, 2> msg{CANCEL, 0};
+    send_message(etl::span<const uint8_t>{msg});
+  }
+
+  // Encode a 21-bit value into three 7-bit bytes, LSB first (SDS format).
+  static constexpr void encode_21bit(uint32_t value, uint8_t *out) {
+    out[0] = value & 0x7F;
+    out[1] = (value >> 7) & 0x7F;
+    out[2] = (value >> 14) & 0x7F;
+  }
+
+  template <typename SendMessage>
+  void send_dump_header(SendMessage send_message) {
+    constexpr uint32_t period_ns = 1000000000U / SAMPLE_RATE_HZ;
+    const uint32_t length_words = total_bytes_ / 2;
+
+    header_[0] = DUMP_HEADER;
+    header_[1] = sample_number_ & 0x7F;
+    header_[2] = (sample_number_ >> 7) & 0x7F;
+    header_[3] = 16; // bit depth
+    encode_21bit(period_ns, &header_[4]);
+    encode_21bit(length_words, &header_[7]);
+    encode_21bit(length_words, &header_[10]); // loop start = length
+    encode_21bit(length_words, &header_[13]); // loop end = length
+    header_[16] = 0x7F;                       // no loop
+
+    header_is_last_sent_ = true;
+    send_message(etl::span<const uint8_t>{header_});
+  }
+
+  // Pack a signed 16-bit sample into the SDS left-justified 3-byte format
+  // (inverse of Protocol::unpack_16bit_sample).
+  static constexpr void pack_16bit_sample(int16_t sample, uint8_t *out) {
+    const uint16_t unsigned_sample =
+        static_cast<uint16_t>(static_cast<int32_t>(sample) + 0x8000);
+    out[0] = (unsigned_sample >> 9) & 0x7F;
+    out[1] = (unsigned_sample >> 2) & 0x7F;
+    out[2] = (unsigned_sample << 5) & 0x7F;
+  }
+
+  template <typename SendMessage>
+  void send_next_packet(SendMessage send_message, absolute_time_t now) {
+    etl::array<uint8_t, BYTES_PER_PACKET> raw{}; // zero-padded final packet
+    const size_t remaining = total_bytes_ - bytes_sent_;
+    const size_t to_read = etl::min(remaining, BYTES_PER_PACKET);
+
+    if (file_->read(etl::span<uint8_t>{raw.data(), to_read}) != to_read) {
+      logger_.error("SDS: Sample file read failed, aborting dump");
+      send_cancel(send_message);
+      finish();
+      return;
+    }
+
+    last_packet_[0] = DATA_PACKET;
+    last_packet_[1] = packet_num_;
+    for (size_t i = 0; i < BYTES_PER_PACKET / 2; ++i) {
+      const int16_t sample =
+          static_cast<int16_t>(static_cast<uint16_t>(raw[i * 2]) |
+                               (static_cast<uint16_t>(raw[i * 2 + 1]) << 8));
+      pack_16bit_sample(sample, &last_packet_[2 + i * 3]);
+    }
+    last_packet_[122] = calculate_data_checksum(
+        packet_num_, etl::span<const uint8_t>{&last_packet_[2], 120});
+
+    header_is_last_sent_ = false;
+    send_message(etl::span<const uint8_t>{last_packet_});
+
+    bytes_sent_ += to_read;
+    packet_num_ = (packet_num_ + 1) & 0x7F;
+    if (state_ != State::OpenLoop) {
+      state_ = State::AwaitingPacketResponse;
+    }
+    last_activity_time_ = now;
+  }
+
+  template <typename SendMessage> void resend_last(SendMessage send_message) {
+    if (header_is_last_sent_) {
+      send_message(etl::span<const uint8_t>{header_});
+    } else {
+      send_message(etl::span<const uint8_t>{last_packet_});
+    }
+  }
+
+  template <typename SendMessage>
+  Result advance_open_loop(SendMessage send_message, absolute_time_t now) {
+    if (transfer_complete()) {
+      finish();
+      logger_.info("SDS: Dump complete (open-loop)");
+      return Result::SampleComplete;
+    }
+    send_next_packet(send_message, now);
+    return Result::OK;
+  }
+};
+
+} // namespace sds
+
+#endif // SDS_DUMP_SENDER_H_SDS_AUDIO

--- a/drum/sysex/sds_dump_sender.h
+++ b/drum/sysex/sds_dump_sender.h
@@ -42,9 +42,10 @@ public:
   // host is still waiting for exactly this packet, and skipping it would
   // lose data irrecoverably.
   static constexpr uint64_t RETRANSMIT_INTERVAL_US = 100000;
-  // Open-loop pacing: slow enough that the small SysEx output queue and a
-  // DIN MIDI link (~41 ms per 127-byte packet at 31250 baud) can keep up.
-  static constexpr uint64_t OPEN_LOOP_INTERVAL_US = 50000;
+  // Open-loop pacing. SysEx goes out over USB only, where a 127-byte packet
+  // is on the wire in a few milliseconds; 10 ms leaves headroom for the
+  // receiver to store each packet, well under the ~20 ms SDS convention.
+  static constexpr uint64_t OPEN_LOOP_INTERVAL_US = 10000;
   // A host that sent WAIT but never followed up is assumed gone.
   static constexpr uint64_t STALL_TIMEOUT_US = 30000000;
   // Sample rate reported in outgoing dump headers; the stored .pcm files

--- a/drum/sysex/sds_protocol.h
+++ b/drum/sysex/sds_protocol.h
@@ -59,6 +59,19 @@ enum class Result {
   StateError
 };
 
+// XOR checksum over non-realtime id, channel, message type, packet number
+// and all data bytes, as defined by the SDS spec. Shared by the receive
+// protocol and the dump sender.
+constexpr uint8_t
+calculate_data_checksum(uint8_t packet_num,
+                        const etl::span<const uint8_t> &data) {
+  uint8_t checksum = 0x7E ^ 0x65 ^ DATA_PACKET ^ packet_num; // 0x65 = DRUM
+  for (const uint8_t byte : data) {
+    checksum ^= byte;
+  }
+  return checksum & 0x7F;
+}
+
 // Sample metadata from Dump Header
 struct SampleInfo {
   uint16_t sample_number;
@@ -204,19 +217,6 @@ private:
     return static_cast<int16_t>(unsigned_sample - 0x8000);
   }
 
-  // Calculate checksum for data packet validation
-  static constexpr uint8_t
-  calculate_checksum(uint8_t packet_num, const etl::span<const uint8_t> &data) {
-    // XOR of: 0x7E (non-realtime), channel, 0x02 (data packet), packet_num, and
-    // all data
-    uint8_t checksum =
-        0x7E ^ 0x65 ^ DATA_PACKET ^ packet_num; // 0x65 = DRUM channel
-    for (const uint8_t byte : data) {
-      checksum ^= byte;
-    }
-    return checksum & 0x7F;
-  }
-
   // Handle Cancel message
   constexpr Result handle_cancel_message() {
     logger_.info("SDS: Transfer cancelled by host.");
@@ -321,7 +321,7 @@ private:
 
     // Verify checksum
     const uint8_t calculated_checksum =
-        calculate_checksum(packet_num, data_span);
+        calculate_data_checksum(packet_num, data_span);
     if (received_checksum != calculated_checksum) {
       logger_.error("SDS: Checksum mismatch, expected:",
                     static_cast<uint32_t>(calculated_checksum));

--- a/drum/sysex/sds_protocol.h
+++ b/drum/sysex/sds_protocol.h
@@ -331,13 +331,25 @@ private:
       return Result::ChecksumError;
     }
 
-    // Check packet sequence
+    // Check packet sequence. A retransmission of the previous packet means
+    // our ACK was lost in transit: re-ACK it without writing, or the data
+    // would be appended twice and corrupt the sample. Anything else
+    // out-of-sequence is NAKed so the host retries the packet we expect.
     if (packet_num != expected_packet_num_) {
+      const uint8_t previous_packet_num = (expected_packet_num_ - 1) & 0x7F;
+      if (packet_num == previous_packet_num && bytes_received_ > 0) {
+        logger_.warn("SDS: Duplicate packet re-ACKed:",
+                     static_cast<uint32_t>(packet_num));
+        last_activity_time_ = now;
+        send_reply(ACK, packet_num);
+        return Result::OK;
+      }
       logger_.warn("SDS: Unexpected packet number, expected:",
                    static_cast<uint32_t>(expected_packet_num_));
       logger_.warn("SDS: Unexpected packet number, got:",
                    static_cast<uint32_t>(packet_num));
-      // For now, accept out-of-order packets (could improve this)
+      send_reply(NAK, expected_packet_num_);
+      return Result::InvalidMessage;
     }
 
     last_activity_time_ = now;

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -82,12 +82,13 @@ void SysExHandler::update(absolute_time_t now) {
       last_notified_sample_slot_ = current_sample_slot;
     } else {
       logger_.info("SysEx file transfer finished.");
-      // Pass through the last known sample slot so the display can preserve
-      // the sample color during the debounce/cooldown period (issue #550).
       drum::Events::SysExTransferStateChangeEvent event{
-          .is_active = false, .sample_slot = last_notified_sample_slot_};
+          .is_active = false,
+          .sample_slot = last_notified_sample_slot_,
+          .skip_debounce = sds_dump_was_active_};
       this->notify_observers(event);
       last_notified_sample_slot_ = std::nullopt;
+      sds_dump_was_active_ = false;
     }
     was_busy_ = current_busy_state;
   }
@@ -153,6 +154,7 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
       } else {
         sds_dump_sender_.handle_dump_request(sds_payload, send_sds_message,
                                              get_absolute_time());
+        sds_dump_was_active_ = true;
       }
       return;
     }

--- a/drum/sysex_handler.cpp
+++ b/drum/sysex_handler.cpp
@@ -1,6 +1,8 @@
 #include "drum/sysex_handler.h"
 #include "drum/sample_slot_manager.h"
 #include "drum/sysex/sequencer_state_codec.h"
+#include "etl/algorithm.h"
+#include "etl/array.h"
 #include "events.h"
 #include "musin/midi/midi_wrapper.h"
 #include "version.h"
@@ -11,6 +13,19 @@
 
 namespace drum {
 
+namespace {
+// Wraps an SDS payload (message type onward) in F0 7E <channel> ... F7.
+void send_sds_message(const etl::span<const uint8_t> &payload) {
+  etl::array<uint8_t, 128> msg;
+  msg[0] = 0xF0;
+  msg[1] = 0x7E;
+  msg[2] = 0x65;
+  etl::copy(payload.begin(), payload.end(), msg.begin() + 3);
+  msg[3 + payload.size()] = 0xF7;
+  MIDI::sendSysEx(payload.size() + 4, msg.data());
+}
+} // namespace
+
 SysExHandler::SysExHandler(ConfigurationManager &config_manager,
                            SettingsManager &settings_manager,
                            musin::Logger &logger,
@@ -18,12 +33,14 @@ SysExHandler::SysExHandler(ConfigurationManager &config_manager,
     : config_manager_(config_manager), settings_manager_(settings_manager),
       logger_(logger), filesystem_(filesystem), file_ops_(logger, filesystem),
       protocol_(file_ops_, logger), sds_protocol_(file_ops_, logger),
-      firmware_writer_(logger), firmware_update_(firmware_writer_, logger) {
+      sds_dump_sender_(file_ops_, logger), firmware_writer_(logger),
+      firmware_update_(firmware_writer_, logger) {
 }
 
 void SysExHandler::update(absolute_time_t now) {
   protocol_.check_timeout(now);
   sds_protocol_.check_timeout(now);
+  sds_dump_sender_.update(send_sds_message, now);
   firmware_update_.check_timeout(now);
 
   if (firmware_reboot_pending_ &&
@@ -45,6 +62,9 @@ void SysExHandler::update(absolute_time_t now) {
   if (auto slot_opt = sds_protocol_.current_sample_number_opt();
       slot_opt.has_value()) {
     current_sample_slot = static_cast<uint8_t>(slot_opt.value() & 0x7F);
+  } else if (auto dump_slot = sds_dump_sender_.current_sample_number_opt();
+             dump_slot.has_value()) {
+    current_sample_slot = static_cast<uint8_t>(dump_slot.value() & 0x7F);
   }
 
   // Check for busy state changes (transfer start/stop)
@@ -121,6 +141,36 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
     // Extract SDS payload (skip 0x7E and channel)
     const auto sds_payload =
         etl::span<const uint8_t>{chunk.cbegin() + 2, chunk.cend()};
+    const uint8_t sds_type = sds_payload[0];
+
+    // Dump requests and, while a dump is active, host handshake responses go
+    // to the dump sender. Everything else is the receive path below.
+    if (sds_type == sds::DUMP_REQUEST) {
+      if (sds_protocol_.is_busy()) {
+        logger_.warn("SDS: Dump request refused during sample upload");
+        const etl::array<uint8_t, 2> cancel{sds::CANCEL, 0};
+        send_sds_message(etl::span<const uint8_t>{cancel});
+      } else {
+        sds_dump_sender_.handle_dump_request(sds_payload, send_sds_message,
+                                             get_absolute_time());
+      }
+      return;
+    }
+    if (sds_dump_sender_.is_busy() &&
+        (sds_type == sds::ACK || sds_type == sds::NAK ||
+         sds_type == sds::WAIT || sds_type == sds::CANCEL)) {
+      sds_dump_sender_.handle_response(sds_type, send_sds_message,
+                                       get_absolute_time());
+      return;
+    }
+
+    if (sds_dump_sender_.is_busy()) {
+      logger_.warn("SDS: Upload message refused during sample download");
+      const etl::array<uint8_t, 2> nak{sds::NAK, 0};
+      send_sds_message(etl::span<const uint8_t>{nak});
+      return;
+    }
+
     // Capture the active slot before processing: a completing data packet
     // returns the protocol to Idle, after which the slot is no longer
     // reported.
@@ -217,7 +267,8 @@ void SysExHandler::handle_sysex_message(const sysex::Chunk &chunk) {
 }
 
 bool SysExHandler::is_busy() const {
-  return protocol_.busy() || sds_protocol_.is_busy() || firmware_update_.busy();
+  return protocol_.busy() || sds_protocol_.is_busy() ||
+         sds_dump_sender_.is_busy() || firmware_update_.busy();
 }
 
 void SysExHandler::set_firmware_update_allowed(bool allowed) {

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -7,6 +7,7 @@
 #include "drum/standard_file_ops.h"
 #include "drum/sysex/firmware_update.h"
 #include "drum/sysex/protocol.h"
+#include "drum/sysex/sds_dump_sender.h"
 #include "drum/sysex/sds_protocol.h"
 #include "etl/observer.h"
 #include "musin/flash/firmware_writer.h"
@@ -90,6 +91,7 @@ private:
   StandardFileOps file_ops_;
   sysex::Protocol<StandardFileOps> protocol_;
   sds::Protocol<StandardFileOps> sds_protocol_;
+  sds::DumpSender<StandardFileOps> sds_dump_sender_;
   musin::flash::FirmwareWriter firmware_writer_;
   sysex::FirmwareUpdate<musin::flash::FirmwareWriter> firmware_update_;
   bool new_file_received_ = false;

--- a/drum/sysex_handler.h
+++ b/drum/sysex_handler.h
@@ -101,6 +101,7 @@ private:
   bool firmware_reboot_pending_ = false;
   absolute_time_t firmware_reboot_time_{};
   float last_notified_progress_ = -1.0f;
+  bool sds_dump_was_active_ = false;
 };
 
 } // namespace drum

--- a/drum/system_state_machine.cpp
+++ b/drum/system_state_machine.cpp
@@ -60,9 +60,14 @@ void SystemStateMachine::notification(
       notify_file_transfer_start();
     }
   } else {
-    // Transfer ended - start debounce period instead of immediate transition
+    // Transfer ended - start debounce period (unless this was an outgoing
+    // SDS dump, which should return to sequencer immediately).
     if (get_current_state() == SystemStateId::FileTransfer) {
-      notify_file_transfer_complete();
+      if (event.skip_debounce) {
+        transition_to(SystemStateId::Sequencer);
+      } else {
+        notify_file_transfer_complete();
+      }
     }
   }
 }

--- a/musin/midi/midi_output_queue.cpp
+++ b/musin/midi/midi_output_queue.cpp
@@ -96,7 +96,11 @@ void process_midi_output_queue(musin::Logger &logger) {
     uint32_t irq_status = spin_lock_blocking(midi_queue_lock);
     if (!midi_output_queue.empty()) {
       OutgoingMidiMessage &message_in_queue = midi_output_queue.front();
+      // SysEx bypasses the rate limit: it is sent over USB only (never DIN),
+      // so the 31250-baud pacing that MIN_INTERVAL_US_NON_REALTIME models
+      // does not apply to it.
       if (message_in_queue.type == MidiMessageType::SYSTEM_REALTIME ||
+          message_in_queue.type == MidiMessageType::SYSTEM_EXCLUSIVE ||
           is_nil_time(last_non_realtime_send_time) ||
           absolute_time_diff_us(last_non_realtime_send_time,
                                 get_absolute_time()) >=
@@ -154,7 +158,8 @@ void process_midi_output_queue(musin::Logger &logger) {
     case MidiMessageType::SYSTEM_EXCLUSIVE:
       MIDI::internal::_sendSysEx_actual(sysex_scratch.length,
                                         sysex_scratch.data_buffer.data());
-      last_non_realtime_send_time = get_absolute_time();
+      // USB-only; does not consume DIN bandwidth, so it does not push back
+      // the next DIN-bound message.
       break;
     }
   } else if (rate_limited) {

--- a/musin/midi/midi_wrapper.h
+++ b/musin/midi/midi_wrapper.h
@@ -28,10 +28,12 @@ struct Callbacks {
 };
 
 void init(const Callbacks &callbacks);
-/** @brief Read MIDI messages for a specific channel. */
-void read(uint8_t channel);
-/** @brief Read MIDI messages for all channels (OMNI). */
-void read();
+/** @brief Read MIDI messages for a specific channel.
+ *  @return true if a complete message was parsed and dispatched. */
+bool read(uint8_t channel);
+/** @brief Read MIDI messages for all channels (OMNI).
+ *  @return true if a complete message was parsed and dispatched. */
+bool read();
 void sendRealTime(MidiType message);
 void sendControlChange(uint8_t cc, uint8_t value, uint8_t channel);
 void sendNoteOn(uint8_t inNoteNumber, uint8_t inVelocity, uint8_t inChannel);

--- a/musin/ports/pico/port/midi_wrapper.cpp
+++ b/musin/ports/pico/port/midi_wrapper.cpp
@@ -186,13 +186,17 @@ void MIDI::internal::_sendPitchBend_actual(const byte channel, const int bend) {
 
 void MIDI::internal::_sendSysEx_actual(const unsigned length,
                                        const byte *bytes) {
+  // SysEx goes to USB only. Mirroring to DIN would block the main loop for
+  // ~40 ms per 125-byte packet (blocking UART writes at 31250 baud), pacing
+  // SDS sample dumps down to ~2 KB/s and saturating the DIN port.
+  //
   // The underlying Arduino MIDI library adds the F0/F7 terminators itself.
   // We must pass only the payload.
   // This wrapper function will strip the terminators if they are present.
   if (length >= 2 && bytes[0] == 0xF0 && bytes[length - 1] == 0xF7) {
-    ALL_TRANSPORTS(sendSysEx(length - 2, bytes + 1));
+    usb_midi.sendSysEx(length - 2, bytes + 1);
   } else {
     // If the message is not framed, send it as-is.
-    ALL_TRANSPORTS(sendSysEx(length, bytes));
+    usb_midi.sendSysEx(length, bytes);
   }
 }

--- a/musin/ports/pico/port/midi_wrapper.cpp
+++ b/musin/ports/pico/port/midi_wrapper.cpp
@@ -29,11 +29,13 @@ struct MIDISettings {
   */
   static const bool HandleNullVelocityNoteOnAsNoteOff = true;
 
-  /*! Setting this to true will make MIDI.read parse only one byte of data for
-  each call when data is available. This can speed up your application if
-  receiving a lot of traffic, but might induce MIDI Thru and treatment latency.
+  /*! Parse all buffered bytes per MIDI.read call instead of one per call.
+  One byte per call caps inbound throughput at one byte per main-loop
+  iteration, which throttles SDS sample uploads to a few KB/s. Parser
+  recursion depth is bounded by the transport buffers (tens of bytes),
+  which only refill from usb::background_update between loop iterations.
   */
-  static const bool Use1ByteParsing = true;
+  static const bool Use1ByteParsing = false;
 
   /*! Maximum size of SysEx receivable. Decrease to save RAM if you don't expect
   to receive SysEx, or adjust accordingly.
@@ -106,13 +108,17 @@ void MIDI::init(const Callbacks &callbacks) {
   ALL_TRANSPORTS(setHandleSystemExclusive(callbacks.sysex));
 }
 
-void MIDI::read(const byte channel) {
-  ALL_TRANSPORTS(read(channel));
+bool MIDI::read(const byte channel) {
+  const bool usb_message = usb_midi.read(channel);
+  const bool serial_message = serial_midi.read(channel);
+  return usb_message || serial_message;
 }
 
 // Overload for reading all channels (OMNI)
-void MIDI::read() {
-  ALL_TRANSPORTS(read());
+bool MIDI::read() {
+  const bool usb_message = usb_midi.read();
+  const bool serial_message = serial_midi.read();
+  return usb_message || serial_message;
 }
 
 // --- Public Send Functions (Enqueue Messages) ---

--- a/musin/usb/usb.cpp
+++ b/musin/usb/usb.cpp
@@ -1,7 +1,11 @@
 #include "usb.h"
-#include "device/usbd.h"
 #include "class/midi/midi_device.h"
+#include "device/usbd.h"
 #include "tusb.h"
+
+extern "C" {
+#include "pico/time.h"
+}
 
 #ifndef USB_DEVICE_INSTANCE
 #define USB_DEVICE_INSTANCE 0
@@ -34,13 +38,23 @@ bool midi_read(uint8_t packet[4]) {
 }
 
 void midi_send(const uint8_t packet[4]) {
-  tud_midi_packet_write(packet);
+  // A long SysEx message (e.g. a 127-byte SDS data packet) exceeds the
+  // 64-byte MIDI TX FIFO. When the FIFO is full, drain USB and retry instead
+  // of silently dropping the rest of the message; give up after a deadline
+  // so an unresponsive host cannot stall the main loop.
+  const absolute_time_t deadline = make_timeout_time_ms(10);
+  while (!tud_midi_packet_write(packet)) {
+    if (!tud_ready() || time_reached(deadline)) {
+      return;
+    }
+    tud_task();
+  }
 }
 
 void init(const bool block_until_connected) {
   tusb_init();
 
-  if(block_until_connected) {
+  if (block_until_connected) {
     while (!tud_cdc_connected()) {
       tud_task();
     }

--- a/test/drum/CMakeLists.txt
+++ b/test/drum/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(drum-test-sample-slots PRIVATE
 # Test target: SDS protocol (sample dump standard, header-only)
 add_executable(drum-test-sds
     sds_protocol_test.cpp
+    sds_dump_sender_test.cpp
 )
 
 target_include_directories(drum-test-sds PRIVATE

--- a/test/drum/sds_dump_sender_test.cpp
+++ b/test/drum/sds_dump_sender_test.cpp
@@ -285,6 +285,52 @@ TEST_CASE("A silent host gets the dump open-loop") {
   REQUIRE_FALSE(file_ops.file_is_open);
 }
 
+TEST_CASE("A handshaking host with a lost packet gets retransmissions") {
+  TestFileOps file_ops;
+  // Two packets' worth of data so the transfer is not complete after one.
+  etl::vector<int16_t, 64> samples;
+  for (int i = 0; i < 42; ++i) {
+    samples.push_back(static_cast<int16_t>(i));
+  }
+  for (const int16_t s : samples) {
+    file_ops.content.push_back(static_cast<uint8_t>(s & 0xFF));
+    file_ops.content.push_back(static_cast<uint8_t>((s >> 8) & 0xFF));
+  }
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(4);
+  absolute_time_t now = ONE_SECOND_US;
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out, now);
+  dump_sender.handle_response(sds::ACK, out, now); // header ACK, packet 0 sent
+  REQUIRE(log.size() == 2);
+
+  // Packet 0 (or our view of its ACK) is lost: the host stays silent. The
+  // device must retransmit the same packet, not advance past it.
+  now += Sender::RETRANSMIT_INTERVAL_US + 1;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::OK);
+  REQUIRE(log.size() == 3);
+  REQUIRE(log[2] == log[1]); // identical retransmission
+
+  // Still silent: it keeps retransmitting at the same cadence.
+  now += Sender::RETRANSMIT_INTERVAL_US + 1;
+  dump_sender.update(out, now);
+  REQUIRE(log.size() == 4);
+  REQUIRE(log[3] == log[1]);
+
+  // The late ACK finally arrives and the transfer resumes with packet 1.
+  dump_sender.handle_response(sds::ACK, out, now);
+  REQUIRE(log.size() == 5);
+  REQUIRE(log[4][1] == 1); // next packet number, not another retransmit
+
+  // A host that never comes back eventually trips the stall timeout.
+  now += Sender::STALL_TIMEOUT_US + 1;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::Cancelled);
+  REQUIRE_FALSE(dump_sender.is_busy());
+}
+
 TEST_CASE("A host that sends WAIT and then vanishes trips the stall timeout") {
   TestFileOps file_ops;
   fill_with_samples(file_ops.content, {500, -500});

--- a/test/drum/sds_dump_sender_test.cpp
+++ b/test/drum/sds_dump_sender_test.cpp
@@ -285,6 +285,34 @@ TEST_CASE("A silent host gets the dump open-loop") {
   REQUIRE_FALSE(file_ops.file_is_open);
 }
 
+TEST_CASE("A late ACK of the final open-loop packet completes the dump "
+          "without a spurious extra packet") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {500, -500, 250, -250});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(9);
+  absolute_time_t now = ONE_SECOND_US;
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out, now);
+
+  // Silent host: the single (final) packet goes out open-loop.
+  now += Sender::HEADER_RESPONSE_TIMEOUT_US + 1;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::OK);
+  REQUIRE(log.size() == 2);
+  REQUIRE(log[1][0] == sds::DATA_PACKET);
+
+  // The host wakes up and ACKs that final packet: the dump is complete and
+  // nothing further is sent.
+  REQUIRE(dump_sender.handle_response(sds::ACK, out, now) ==
+          sds::Result::SampleComplete);
+  REQUIRE(log.size() == 2);
+  REQUIRE_FALSE(dump_sender.is_busy());
+  REQUIRE_FALSE(file_ops.file_is_open);
+}
+
 TEST_CASE("A handshaking host with a lost packet gets retransmissions") {
   TestFileOps file_ops;
   // Two packets' worth of data so the transfer is not complete after one.

--- a/test/drum/sds_dump_sender_test.cpp
+++ b/test/drum/sds_dump_sender_test.cpp
@@ -1,0 +1,334 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+#include "etl/array.h"
+#include "etl/optional.h"
+#include "etl/span.h"
+#include "etl/vector.h"
+
+#include "musin/hal/null_logger.h"
+
+#include "drum/sysex/sds_dump_sender.h"
+
+extern absolute_time_t mock_current_time;
+
+namespace {
+
+// File mock backed by an in-memory sample. open_read succeeds only for the
+// configured content; an empty content simulates a missing file.
+struct TestFileOps {
+  struct ReadHandle {
+    TestFileOps &parent;
+    size_t position = 0;
+
+    explicit ReadHandle(TestFileOps &parent) : parent(parent) {
+      parent.file_is_open = true;
+    }
+
+    ReadHandle(const ReadHandle &) = delete;
+    ReadHandle &operator=(const ReadHandle &) = delete;
+
+    ReadHandle(ReadHandle &&other) noexcept
+        : parent(other.parent), position(other.position) {
+      other.owns_file = false;
+    }
+
+    size_t size() const {
+      return parent.content.size();
+    }
+
+    size_t read(const etl::span<uint8_t> &out) {
+      size_t count = 0;
+      while (count < out.size() && position < parent.content.size()) {
+        out[count++] = parent.content[position++];
+      }
+      return count;
+    }
+
+    ~ReadHandle() {
+      if (owns_file) {
+        parent.file_is_open = false;
+      }
+    }
+
+  private:
+    bool owns_file = true;
+  };
+
+  etl::optional<ReadHandle> open_read(const etl::string_view &path) {
+    last_opened_path.assign(path.begin(), path.end());
+    open_count++;
+    if (content.empty()) {
+      return etl::nullopt;
+    }
+    return etl::optional<ReadHandle>(ReadHandle(*this));
+  }
+
+  etl::vector<char, 32> last_opened_path;
+  etl::vector<uint8_t, 512> content;
+  bool file_is_open = false;
+  unsigned open_count = 0;
+};
+
+using Sender = sds::DumpSender<TestFileOps>;
+
+// Records every outgoing SDS message payload. Holds a reference to shared
+// storage so pass-by-value copies inside the sender still record here.
+using MessageLog = etl::vector<etl::vector<uint8_t, 128>, 32>;
+struct MockSender {
+  MessageLog &messages;
+  void operator()(const etl::span<const uint8_t> &payload) {
+    messages.emplace_back();
+    messages.back().assign(payload.begin(), payload.end());
+  }
+};
+
+constexpr uint64_t ONE_SECOND_US = 1000000;
+
+etl::array<uint8_t, 3> make_dump_request(uint16_t sample_number) {
+  return {sds::DUMP_REQUEST, static_cast<uint8_t>(sample_number & 0x7F),
+          static_cast<uint8_t>((sample_number >> 7) & 0x7F)};
+}
+
+// Decodes one 16-bit sample from the SDS left-justified 3-byte format.
+int16_t unpack_sample(const uint8_t *bytes) {
+  const uint16_t unsigned_sample =
+      ((static_cast<uint16_t>(bytes[0]) & 0x7F) << 9) |
+      ((static_cast<uint16_t>(bytes[1]) & 0x7F) << 2) |
+      ((static_cast<uint16_t>(bytes[2]) & 0x7F) >> 5);
+  return static_cast<int16_t>(unsigned_sample - 0x8000);
+}
+
+void fill_with_samples(etl::vector<uint8_t, 512> &content,
+                       std::initializer_list<int16_t> samples) {
+  for (const int16_t s : samples) {
+    content.push_back(static_cast<uint8_t>(s & 0xFF));
+    content.push_back(static_cast<uint8_t>((s >> 8) & 0xFF));
+  }
+}
+
+TEST_CASE("Dump request sends a header describing the stored sample") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {0, 100, -100, 32767});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(30);
+  const auto result = dump_sender.handle_dump_request(
+      etl::span<const uint8_t>{request}, out, ONE_SECOND_US);
+
+  REQUIRE(result == sds::Result::OK);
+  REQUIRE(dump_sender.is_busy());
+  REQUIRE(etl::string_view(file_ops.last_opened_path.data(),
+                           file_ops.last_opened_path.size()) == "/30.pcm");
+
+  REQUIRE(log.size() == 1);
+  const auto &header = log[0];
+  REQUIRE(header.size() == 17);
+  REQUIRE(header[0] == sds::DUMP_HEADER);
+  REQUIRE(header[1] == 30); // sample number low
+  REQUIRE(header[2] == 0);  // sample number high
+  REQUIRE(header[3] == 16); // bit depth
+
+  const uint32_t period_ns = header[4] | (header[5] << 7) | (header[6] << 14);
+  REQUIRE(1000000000U / period_ns == 44101); // integer-truncated 44.1 kHz
+
+  const uint32_t length_words =
+      header[7] | (header[8] << 7) | (header[9] << 14);
+  REQUIRE(length_words == 4);
+  REQUIRE(header[16] == 0x7F); // no loop
+}
+
+TEST_CASE("Dump request for a missing sample replies CANCEL and stays idle") {
+  TestFileOps file_ops; // empty content = missing file
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(12);
+  const auto result = dump_sender.handle_dump_request(
+      etl::span<const uint8_t>{request}, out, ONE_SECOND_US);
+
+  REQUIRE(result == sds::Result::FileError);
+  REQUIRE_FALSE(dump_sender.is_busy());
+  REQUIRE(log.size() == 1);
+  REQUIRE(log[0][0] == sds::CANCEL);
+}
+
+TEST_CASE("ACK-driven dump round-trips sample data with valid checksums") {
+  TestFileOps file_ops;
+  // 42 samples: one full packet (40) plus a zero-padded second packet.
+  etl::vector<int16_t, 64> samples;
+  for (int i = 0; i < 42; ++i) {
+    samples.push_back(static_cast<int16_t>(i * 700 - 14000));
+  }
+  for (const int16_t s : samples) {
+    file_ops.content.push_back(static_cast<uint8_t>(s & 0xFF));
+    file_ops.content.push_back(static_cast<uint8_t>((s >> 8) & 0xFF));
+  }
+
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(5);
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out,
+                                  ONE_SECOND_US);
+
+  // Host ACKs the header, then each packet.
+  REQUIRE(dump_sender.handle_response(sds::ACK, out, ONE_SECOND_US) ==
+          sds::Result::OK);
+  REQUIRE(dump_sender.handle_response(sds::ACK, out, ONE_SECOND_US) ==
+          sds::Result::OK);
+  REQUIRE(dump_sender.handle_response(sds::ACK, out, ONE_SECOND_US) ==
+          sds::Result::SampleComplete);
+  REQUIRE_FALSE(dump_sender.is_busy());
+  REQUIRE_FALSE(file_ops.file_is_open);
+
+  // Header + 2 data packets.
+  REQUIRE(log.size() == 3);
+  size_t sample_index = 0;
+  for (size_t p = 1; p < log.size(); ++p) {
+    const auto &packet = log[p];
+    REQUIRE(packet.size() == 123);
+    REQUIRE(packet[0] == sds::DATA_PACKET);
+    REQUIRE(packet[1] == p - 1); // packet number
+
+    const auto data = etl::span<const uint8_t>{&packet[2], 120};
+    REQUIRE(packet[122] == sds::calculate_data_checksum(packet[1], data));
+
+    for (size_t i = 0; i < 40; ++i) {
+      const int16_t decoded = unpack_sample(&packet[2 + i * 3]);
+      const int16_t expected =
+          sample_index < samples.size() ? samples[sample_index] : 0;
+      REQUIRE(decoded == expected);
+      ++sample_index;
+    }
+  }
+}
+
+TEST_CASE("NAK resends the previous message unchanged") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {1000, -1000});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(7);
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out,
+                                  ONE_SECOND_US);
+
+  SECTION("NAK after the header resends the header") {
+    dump_sender.handle_response(sds::NAK, out, ONE_SECOND_US);
+    REQUIRE(log.size() == 2);
+    REQUIRE(log[1] == log[0]);
+  }
+
+  SECTION("NAK after a data packet resends that packet") {
+    dump_sender.handle_response(sds::ACK, out, ONE_SECOND_US); // packet 0
+    dump_sender.handle_response(sds::NAK, out, ONE_SECOND_US);
+    REQUIRE(log.size() == 3);
+    REQUIRE(log[2] == log[1]);
+    // The retransmitted packet still completes the transfer on ACK.
+    REQUIRE(dump_sender.handle_response(sds::ACK, out, ONE_SECOND_US) ==
+            sds::Result::SampleComplete);
+  }
+}
+
+TEST_CASE("CANCEL from the host aborts the dump and closes the file") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {1, 2, 3, 4});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(3);
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out,
+                                  ONE_SECOND_US);
+  REQUIRE(file_ops.file_is_open);
+
+  REQUIRE(dump_sender.handle_response(sds::CANCEL, out, ONE_SECOND_US) ==
+          sds::Result::Cancelled);
+  REQUIRE_FALSE(dump_sender.is_busy());
+  REQUIRE_FALSE(file_ops.file_is_open);
+}
+
+TEST_CASE("A silent host gets the dump open-loop") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {500, -500, 250, -250});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(9);
+  absolute_time_t now = ONE_SECOND_US;
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out, now);
+
+  // No response within the 2 s header window: first packet goes out anyway.
+  now += Sender::HEADER_RESPONSE_TIMEOUT_US + 1;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::OK);
+  REQUIRE(log.size() == 2);
+  REQUIRE(log[1][0] == sds::DATA_PACKET);
+
+  // The single packet covers all 4 samples; the next interval completes.
+  now += Sender::OPEN_LOOP_INTERVAL_US + 1;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::SampleComplete);
+  REQUIRE_FALSE(dump_sender.is_busy());
+  REQUIRE_FALSE(file_ops.file_is_open);
+}
+
+TEST_CASE("A host that sends WAIT and then vanishes trips the stall timeout") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {500, -500});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(2);
+  absolute_time_t now = ONE_SECOND_US;
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out, now);
+  dump_sender.handle_response(sds::WAIT, out, now);
+
+  // WAIT suppresses open-loop fallback...
+  now += 10 * ONE_SECOND_US;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::OK);
+  REQUIRE(dump_sender.is_busy());
+  REQUIRE(log.size() == 1); // only the header went out
+
+  // ...but not the stall timeout.
+  now += Sender::STALL_TIMEOUT_US;
+  REQUIRE(dump_sender.update(out, now) == sds::Result::Cancelled);
+  REQUIRE_FALSE(dump_sender.is_busy());
+  REQUIRE_FALSE(file_ops.file_is_open);
+}
+
+TEST_CASE("A second dump request during an active dump is refused") {
+  TestFileOps file_ops;
+  fill_with_samples(file_ops.content, {1, 2});
+  musin::NullLogger logger;
+  Sender dump_sender(file_ops, logger);
+  MessageLog log;
+  MockSender out{log};
+
+  const auto request = make_dump_request(1);
+  dump_sender.handle_dump_request(etl::span<const uint8_t>{request}, out,
+                                  ONE_SECOND_US);
+  REQUIRE(log.size() == 1);
+
+  const auto result = dump_sender.handle_dump_request(
+      etl::span<const uint8_t>{request}, out, ONE_SECOND_US);
+  REQUIRE(result == sds::Result::StateError);
+  REQUIRE(log.back()[0] == sds::CANCEL);
+  REQUIRE(dump_sender.is_busy()); // original dump unaffected
+}
+
+} // namespace

--- a/test/drum/sds_protocol_test.cpp
+++ b/test/drum/sds_protocol_test.cpp
@@ -45,9 +45,10 @@ struct TestFileOps {
 
 using Protocol = sds::Protocol<TestFileOps>;
 
-// Records replies so tests can assert no traffic is generated on timeout.
+// Records replies so tests can assert on generated traffic. The protocol
+// takes the sender by value, so record through a member reference.
 struct MockSender {
-  etl::vector<sds::MessageType, 16> replies;
+  etl::vector<sds::MessageType, 16> &replies;
   void operator()(sds::MessageType type, uint8_t) {
     replies.push_back(type);
   }
@@ -62,13 +63,19 @@ etl::array<uint8_t, 17> make_dump_header(uint32_t length_words) {
           0x1E, // sample number low (= 30)
           0x00, // sample number high
           16,   // bit depth
-          0x10, 0x30, 0x01, // sample period (~44.1k), arbitrary nonzero
+          0x10,
+          0x30,
+          0x01, // sample period (~44.1k), arbitrary nonzero
           static_cast<uint8_t>(length_words & 0x7F),
           static_cast<uint8_t>((length_words >> 7) & 0x7F),
           static_cast<uint8_t>((length_words >> 14) & 0x7F),
-          0x00, 0x00, 0x00, // loop start
-          0x00, 0x00, 0x00, // loop end
-          0x00};            // loop type
+          0x00,
+          0x00,
+          0x00, // loop start
+          0x00,
+          0x00,
+          0x00,  // loop end
+          0x00}; // loop type
 }
 
 // Builds an all-zero data packet with a valid checksum.
@@ -86,7 +93,8 @@ TEST_CASE("SDS transfer times out after 30s of inactivity") {
   TestFileOps file_ops;
   musin::NullLogger logger;
   Protocol protocol(file_ops, logger);
-  MockSender sender;
+  etl::vector<sds::MessageType, 16> replies;
+  MockSender sender{replies};
 
   const auto header = make_dump_header(400); // 800 bytes, multi-packet
   const absolute_time_t start = ONE_SECOND_US;
@@ -115,7 +123,8 @@ TEST_CASE("SDS activity resets the inactivity timer") {
   TestFileOps file_ops;
   musin::NullLogger logger;
   Protocol protocol(file_ops, logger);
-  MockSender sender;
+  etl::vector<sds::MessageType, 16> replies;
+  MockSender sender{replies};
 
   const auto header = make_dump_header(400);
   const absolute_time_t start = ONE_SECOND_US;
@@ -125,7 +134,8 @@ TEST_CASE("SDS activity resets the inactivity timer") {
   const absolute_time_t packet_time = start + 20 * ONE_SECOND_US;
   REQUIRE_FALSE(protocol.check_timeout(packet_time));
   const auto packet = make_data_packet(0);
-  protocol.process_message(etl::span<const uint8_t>{packet}, sender, packet_time);
+  protocol.process_message(etl::span<const uint8_t>{packet}, sender,
+                           packet_time);
   REQUIRE(protocol.is_busy());
 
   // 25s after the packet (45s after the header) is still within the window.
@@ -135,6 +145,73 @@ TEST_CASE("SDS activity resets the inactivity timer") {
   // 31s after the packet finally trips the timeout.
   REQUIRE(protocol.check_timeout(packet_time + 31 * ONE_SECOND_US));
   REQUIRE_FALSE(protocol.is_busy());
+}
+
+TEST_CASE("A retransmitted packet is re-ACKed without writing its data") {
+  TestFileOps file_ops;
+  musin::NullLogger logger;
+  Protocol protocol(file_ops, logger);
+  etl::vector<sds::MessageType, 16> replies;
+  MockSender sender{replies};
+
+  const auto header = make_dump_header(400); // 800 bytes, multi-packet
+  protocol.process_message(etl::span<const uint8_t>{header}, sender,
+                           ONE_SECOND_US);
+
+  const auto packet0 = make_data_packet(0);
+  protocol.process_message(etl::span<const uint8_t>{packet0}, sender,
+                           2 * ONE_SECOND_US);
+  const size_t bytes_after_first = file_ops.bytes_written;
+  REQUIRE(bytes_after_first == 80);
+
+  // The host never saw our ACK and sends packet 0 again: it must be
+  // acknowledged again but not appended a second time.
+  sender.replies.clear();
+  protocol.process_message(etl::span<const uint8_t>{packet0}, sender,
+                           3 * ONE_SECOND_US);
+  REQUIRE(file_ops.bytes_written == bytes_after_first);
+  REQUIRE(sender.replies.size() == 1);
+  REQUIRE(sender.replies[0] == sds::ACK);
+  REQUIRE(protocol.is_busy());
+
+  // The transfer then continues normally with packet 1.
+  const auto packet1 = make_data_packet(1);
+  protocol.process_message(etl::span<const uint8_t>{packet1}, sender,
+                           4 * ONE_SECOND_US);
+  REQUIRE(file_ops.bytes_written == bytes_after_first + 80);
+}
+
+TEST_CASE("An out-of-sequence packet is NAKed and not written") {
+  TestFileOps file_ops;
+  musin::NullLogger logger;
+  Protocol protocol(file_ops, logger);
+  etl::vector<sds::MessageType, 16> replies;
+  MockSender sender{replies};
+
+  const auto header = make_dump_header(400);
+  protocol.process_message(etl::span<const uint8_t>{header}, sender,
+                           ONE_SECOND_US);
+
+  SECTION("a skipped-ahead packet number") {
+    const auto packet2 = make_data_packet(2); // expected: 0
+    sender.replies.clear();
+    protocol.process_message(etl::span<const uint8_t>{packet2}, sender,
+                             2 * ONE_SECOND_US);
+    REQUIRE(file_ops.bytes_written == 0);
+    REQUIRE(sender.replies.size() == 1);
+    REQUIRE(sender.replies[0] == sds::NAK);
+    REQUIRE(protocol.is_busy()); // transfer survives; host can retry
+  }
+
+  SECTION("packet 127 before any packet was received is not a duplicate") {
+    const auto packet127 = make_data_packet(127); // (0 - 1) & 0x7F
+    sender.replies.clear();
+    protocol.process_message(etl::span<const uint8_t>{packet127}, sender,
+                             2 * ONE_SECOND_US);
+    REQUIRE(file_ops.bytes_written == 0);
+    REQUIRE(sender.replies.size() == 1);
+    REQUIRE(sender.replies[0] == sds::NAK);
+  }
 }
 
 TEST_CASE("SDS check_timeout is a no-op while idle") {

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -710,6 +710,11 @@ async function test_universal_identity() {
 }
 
 // Wait for ACK/NAK/WAIT/CANCEL with timeout and CTRL+C escape
+// TODO: The device now re-ACKs a retransmission of the previous packet
+// instead of appending its data twice, so a lost ACK can be handled by
+// resending the same packet after a short timeout (e.g. PACKET_TIMEOUT with
+// a few retries) rather than waiting out the 30 s cap below and dropping to
+// non-handshaking mode.
 function waitForResponse(timeout, packetNum = 0, allowWaitEscape = true) {
   return new Promise((resolve) => {
     // For WAIT responses, use longer timeout but still have escape hatch

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -18,6 +18,7 @@
 
 const midi = require('midi');
 const fs = require('fs');
+const path = require('path');
 const readline = require('readline');
 const { WaveFile } = require('wavefile');
 
@@ -1127,10 +1128,13 @@ function unpack16BitSample(b0, b1, b2) {
 
 // Download a sample from the device using an SDS Dump Request.
 // The device streams the stored 16-bit PCM back; we ACK each packet.
+// Resolves to 'ok' or 'empty' (device cancelled: nothing stored in the slot);
+// throws on real failures. Timeout errors carry `.timeout = true` so batch
+// downloads can tell a missing device apart from an empty slot.
 async function receiveSample(slot, outputPath, rawMode = false, verboseMode = false) {
   if (slot < 0 || slot > 127) {
     console.error(`Error: Sample number must be between 0-127, got: ${slot}`);
-    return false;
+    throw new Error(`Sample number must be between 0-127, got: ${slot}`);
   }
 
   const finalPath = outputPath || `slot_${slot.toString().padStart(2, '0')}.${rawMode ? 'pcm' : 'wav'}`;
@@ -1162,7 +1166,9 @@ async function receiveSample(slot, outputPath, rawMode = false, verboseMode = fa
     const resetTimer = (ms) => {
       clearTimeout(session.timer);
       session.timer = setTimeout(() => {
-        finish(new Error(`Timeout waiting for device after ${ms}ms.`));
+        const err = new Error(`Timeout waiting for device after ${ms}ms.`);
+        err.timeout = true;
+        finish(err);
       }, ms);
     };
 
@@ -1170,7 +1176,7 @@ async function receiveSample(slot, outputPath, rawMode = false, verboseMode = fa
       const messageType = message[3];
 
       if (messageType === SDS_CANCEL) {
-        finish(new Error('Device cancelled the dump - the slot is probably empty.'));
+        finish(null, { empty: true });
         return;
       }
 
@@ -1272,6 +1278,11 @@ async function receiveSample(slot, outputPath, rawMode = false, verboseMode = fa
     currentTransferInfo = null;
   });
 
+  if (result.empty) {
+    console.log(`Slot ${slot} is empty - device cancelled the dump.`);
+    return 'empty';
+  }
+
   if (rawMode) {
     fs.writeFileSync(finalPath, result.pcm);
   } else {
@@ -1283,7 +1294,59 @@ async function receiveSample(slot, outputPath, rawMode = false, verboseMode = fa
 
   const seconds = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log(`\n\nDownload complete: ${result.pcm.length} bytes at ${result.sampleRate}Hz written to ${finalPath} in ${seconds} s`);
-  return true;
+  return 'ok';
+}
+
+// Batch sample download: probe each slot with a dump request and skip the
+// ones the device cancels (empty). Consecutive timeouts mean the device is
+// gone, not that slots are empty, so those abort the whole batch.
+const BATCH_TIMEOUT_LIMIT = 3;
+
+async function receiveMultipleSamples(slots, outputDir, rawMode = false, verboseMode = false) {
+  console.log(`\n=== Batch SDS Download: slots ${slots[0]}-${slots[slots.length - 1]} → ${outputDir} ===`);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const failures = [];
+  let downloaded = 0;
+  let empty = 0;
+  let consecutiveTimeouts = 0;
+
+  for (const slot of slots) {
+    const fileName = `slot_${slot.toString().padStart(2, '0')}.${rawMode ? 'pcm' : 'wav'}`;
+    const outputPath = path.join(outputDir, fileName);
+    try {
+      const status = await receiveSample(slot, outputPath, rawMode, verboseMode);
+      consecutiveTimeouts = 0;
+      if (status === 'empty') {
+        empty++;
+      } else {
+        downloaded++;
+      }
+    } catch (error) {
+      console.error(`\nSlot ${slot} failed: ${error.message}`);
+      failures.push({ slot, error: error.message });
+      if (error.timeout) {
+        consecutiveTimeouts++;
+        if (consecutiveTimeouts >= BATCH_TIMEOUT_LIMIT) {
+          console.error(`\nAborting: ${BATCH_TIMEOUT_LIMIT} consecutive timeouts - is the device still connected?`);
+          break;
+        }
+      } else {
+        consecutiveTimeouts = 0;
+      }
+    }
+    // Give the device a moment to settle between dump requests, matching
+    // the grace period used for batch uploads.
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+
+  console.log(`\n=== Download Summary ===`);
+  console.log(`Downloaded: ${downloaded}, empty: ${empty}, failed: ${failures.length}`);
+  if (failures.length > 0) {
+    failures.forEach(f => console.log(`  slot ${f.slot}: ${f.error}`));
+  }
+
+  return failures.length === 0;
 }
 
 // Helper function to check if argument is a sample rate
@@ -1368,6 +1431,40 @@ function parseFileSlotArgs(args) {
 }
 
 // Command line interface
+// Parse 'receive' arguments into a single-slot or batch download request.
+// Accepts: <slot> [output_file] | <start>-<end> [output_dir] | --all [output_dir]
+function parseReceiveArgs(args) {
+  const rawMode = args.includes('--raw');
+  const positional = args.filter(arg => !arg.startsWith('-') || /^-\d/.test(arg));
+  const target = args.includes('--all') ? '--all' : positional.shift();
+
+  if (target === undefined) {
+    throw new Error("'receive' requires a slot number (0-127), a range (e.g. 30-40), or --all.");
+  }
+
+  let range = null;
+  if (target === '--all') {
+    range = [0, 127];
+  } else if (/^\d+-\d+$/.test(target)) {
+    range = target.split('-').map(s => parseInt(s, 10));
+  }
+
+  if (range) {
+    const [start, end] = range;
+    if (start > end || start < 0 || end > 127) {
+      throw new Error(`Invalid slot range: ${target}. Slots must be 0-127 with start <= end.`);
+    }
+    const slots = Array.from({ length: end - start + 1 }, (_, i) => start + i);
+    return { mode: 'batch', slots, outputDir: positional.shift() || '.', rawMode };
+  }
+
+  const slot = parseInt(target, 10);
+  if (!/^\d+$/.test(target) || slot < 0 || slot > 127) {
+    throw new Error("'receive' requires a slot number (0-127), a range (e.g. 30-40), or --all.");
+  }
+  return { mode: 'single', slot, outputPath: positional.shift(), rawMode };
+}
+
 const command = process.argv[2];
 const verbose = process.argv.includes('--verbose') || process.argv.includes('-v');
 // TEST ONLY: --stall-after=N abandons the transfer after N data packets
@@ -1381,6 +1478,7 @@ if (!command) {
   console.log("Usage:");
   console.log("  drumtool.js send <file:slot> [file:slot] ... [sample_rate] [--verbose|-v]");
   console.log("  drumtool.js receive <slot> [output_file] [--raw] [--verbose|-v]");
+  console.log("  drumtool.js receive <start>-<end>|--all [output_dir] [--raw] [--verbose|-v]");
   console.log("  drumtool.js version");
   console.log("  drumtool.js storage");
   console.log("  drumtool.js format");
@@ -1394,7 +1492,8 @@ if (!command) {
   console.log("");
   console.log("Commands:");
   console.log("  send           - Transfer audio samples (WAV or raw PCM) using SDS protocol");
-  console.log("  receive        - Download a sample from the device (WAV by default, --raw for PCM)");
+  console.log("  receive        - Download samples from the device (WAV by default, --raw for PCM).");
+  console.log("                   A range or --all downloads every occupied slot, skipping empty ones");
   console.log("  version        - Get device firmware version");
   console.log("  storage        - Get device storage information");
   console.log("  format         - Format device filesystem");
@@ -1435,6 +1534,8 @@ if (!command) {
   console.log("  drumtool.js reboot-bootloader                 # Enter bootloader mode");
   console.log("  drumtool.js receive 0 kick.wav                # Download slot 0 as WAV");
   console.log("  drumtool.js receive 30 --raw                  # Download slot 30 as raw PCM");
+  console.log("  drumtool.js receive --all backup/             # Download every occupied slot");
+  console.log("  drumtool.js receive 30-40 backup/             # Download slots 30-40");
   console.log("  drumtool.js get-sequencer --json > state.json # Save sequencer pattern");
   console.log("  drumtool.js set-sequencer state.json          # Restore sequencer pattern");
   console.log("  drumtool.js set-setting midi_channel 1        # Use MIDI channel 1");
@@ -1502,10 +1603,10 @@ async function main() {
         process.exit(1);
       }
     } else if (command === 'receive') {
-      const slotStr = process.argv[3];
-      const slot = parseInt(slotStr, 10);
-      if (slotStr === undefined || isNaN(slot) || slot < 0 || slot > 127) {
-        console.error("Error: 'receive' requires a slot number (0-127).");
+      try {
+        parseReceiveArgs(process.argv.slice(3));
+      } catch (error) {
+        console.error(`Error: ${error.message}`);
         process.exit(1);
       }
     } else if (command === 'flash') {
@@ -1571,11 +1672,14 @@ async function main() {
         : await transferMultipleSamples(transfers, verbose);
       process.exitCode = success ? 0 : 1;
     } else if (command === 'receive') {
-      const slot = parseInt(process.argv[3], 10);
-      const extraArgs = process.argv.slice(4);
-      const rawMode = extraArgs.includes('--raw');
-      const outputPath = extraArgs.find(arg => !arg.startsWith('-'));
-      const success = await receiveSample(slot, outputPath, rawMode, verbose);
+      const receive = parseReceiveArgs(process.argv.slice(3)); // Already validated above
+      let success;
+      if (receive.mode === 'batch') {
+        success = await receiveMultipleSamples(receive.slots, receive.outputDir, receive.rawMode, verbose);
+      } else {
+        const status = await receiveSample(receive.slot, receive.outputPath, receive.rawMode, verbose);
+        success = status === 'ok';
+      }
       process.exitCode = success ? 0 : 1;
     } else if (command === 'version') {
       await get_firmware_version();

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -141,6 +141,7 @@ let activeMidiInput = null;
 
 // Message handling
 let pendingResponse = null;
+let activeReceiveSession = null; // Set while a sample download is in progress
 let deviceStatus = 'unknown'; // 'ok', 'slow', 'error', 'unknown'
 let isTransferActive = false;
 let currentTransferInfo = null; // To hold info about the active transfer
@@ -173,7 +174,15 @@ function handleMidiMessage(deltaTime, message) {
   if (isSdsMessage(message)) {
     const messageType = message[3];
     const packetNum = message.length > 4 ? message[4] : 0;
-    
+
+    // Route dump header / data packets to an active sample download
+    if (activeReceiveSession &&
+        (messageType === SDS_DUMP_HEADER || messageType === SDS_DATA_PACKET ||
+         messageType === SDS_CANCEL)) {
+      activeReceiveSession.onMessage(message);
+      return;
+    }
+
     // Handle responses during handshaking
     if (pendingResponse && (messageType === SDS_ACK || messageType === SDS_NAK || 
                            messageType === SDS_WAIT || messageType === SDS_CANCEL)) {
@@ -1092,6 +1101,169 @@ async function transferSample(filePath, sampleNumber, sampleRate = 44100, verbos
   }
 }
 
+// Unpack a 16-bit sample from the SDS left-justified 3-byte format
+function unpack16BitSample(b0, b1, b2) {
+  const unsignedSample = ((b0 & 0x7F) << 9) | ((b1 & 0x7F) << 2) | ((b2 & 0x7F) >> 5);
+  return unsignedSample - 0x8000;
+}
+
+// Download a sample from the device using an SDS Dump Request.
+// The device streams the stored 16-bit PCM back; we ACK each packet.
+async function receiveSample(slot, outputPath, rawMode = false, verboseMode = false) {
+  if (slot < 0 || slot > 127) {
+    console.error(`Error: Sample number must be between 0-127, got: ${slot}`);
+    return false;
+  }
+
+  const finalPath = outputPath || `slot_${slot.toString().padStart(2, '0')}.${rawMode ? 'pcm' : 'wav'}`;
+  console.log(`\n=== SDS Download: slot ${slot} → ${finalPath} ===`);
+
+  const startTime = Date.now();
+
+  const result = await new Promise((resolve, reject) => {
+    const session = {
+      header: null,
+      totalBytes: 0,
+      bytesReceived: 0,
+      expectedPacket: 0,
+      chunks: [],
+      timer: null,
+      lastProgressUpdate: -1,
+    };
+
+    const finish = (err, data) => {
+      clearTimeout(session.timer);
+      activeReceiveSession = null;
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    };
+
+    const resetTimer = (ms) => {
+      clearTimeout(session.timer);
+      session.timer = setTimeout(() => {
+        finish(new Error(`Timeout waiting for device after ${ms}ms.`));
+      }, ms);
+    };
+
+    session.onMessage = (message) => {
+      const messageType = message[3];
+
+      if (messageType === SDS_CANCEL) {
+        finish(new Error('Device cancelled the dump - the slot is probably empty.'));
+        return;
+      }
+
+      if (messageType === SDS_DUMP_HEADER) {
+        // F0 7E 65 01 sl sh ee p*3 g*3 h*3 i*3 jj F7
+        session.header = {
+          sampleNumber: (message[4] & 0x7F) | ((message[5] & 0x7F) << 7),
+          bitDepth: message[6],
+          periodNs: (message[7] & 0x7F) | ((message[8] & 0x7F) << 7) | ((message[9] & 0x7F) << 14),
+          lengthWords: (message[10] & 0x7F) | ((message[11] & 0x7F) << 7) | ((message[12] & 0x7F) << 14),
+        };
+        session.header.sampleRate = session.header.periodNs > 0
+          ? Math.round(1000000000 / session.header.periodNs) : 44100;
+        session.totalBytes = session.header.lengthWords * 2;
+
+        if (session.header.bitDepth !== 16) {
+          finish(new Error(`Unsupported bit depth: ${session.header.bitDepth}`));
+          return;
+        }
+        if (verboseMode) {
+          console.log(`Dump header: ${session.totalBytes} bytes, ${session.header.sampleRate}Hz, ${session.header.bitDepth}-bit`);
+        }
+        sendSDSMessage([SDS_ACK, 0]);
+        resetTimer(HEADER_TIMEOUT);
+        return;
+      }
+
+      if (messageType === SDS_DATA_PACKET) {
+        if (!session.header) {
+          return; // Data before header; ignore
+        }
+        if (message.length !== 127) { // F0 7E 65 02 num data*120 checksum F7
+          sendSDSMessage([SDS_NAK, session.expectedPacket]);
+          return;
+        }
+        const packetNum = message[4];
+        const data = message.slice(5, 125);
+        const checksum = message[125];
+        if (checksum !== calculateChecksum(packetNum, data)) {
+          if (verboseMode) {
+            console.log(`\nPacket ${packetNum} checksum mismatch - requesting resend`);
+          }
+          sendSDSMessage([SDS_NAK, packetNum]);
+          resetTimer(HEADER_TIMEOUT);
+          return;
+        }
+
+        // Duplicate of an already-ACKed packet (our ACK got lost): re-ACK.
+        if (packetNum !== session.expectedPacket) {
+          sendSDSMessage([SDS_ACK, packetNum]);
+          return;
+        }
+
+        const packetBytes = Buffer.alloc(80);
+        for (let i = 0; i < 40; i++) {
+          const sample = unpack16BitSample(data[i * 3], data[i * 3 + 1], data[i * 3 + 2]);
+          packetBytes.writeInt16LE(sample, i * 2);
+        }
+        const remaining = session.totalBytes - session.bytesReceived;
+        session.chunks.push(packetBytes.subarray(0, Math.min(80, remaining)));
+        session.bytesReceived += Math.min(80, remaining);
+        session.expectedPacket = (packetNum + 1) & 0x7F;
+
+        sendSDSMessage([SDS_ACK, packetNum]);
+        resetTimer(HEADER_TIMEOUT);
+
+        const percent = Math.floor((session.bytesReceived / session.totalBytes) * 100);
+        if (percent > session.lastProgressUpdate && process.stdout.clearLine) {
+          session.lastProgressUpdate = percent;
+          const barLength = 40;
+          const filled = Math.round(barLength * (percent / 100));
+          const bar = '█'.repeat(filled) + '░'.repeat(barLength - filled);
+          process.stdout.clearLine(0);
+          process.stdout.cursorTo(0);
+          process.stdout.write(`Progress: ${percent}% |${bar}| ${session.bytesReceived}/${session.totalBytes} bytes`);
+        }
+
+        if (session.bytesReceived >= session.totalBytes) {
+          finish(null, {
+            pcm: Buffer.concat(session.chunks),
+            sampleRate: session.header.sampleRate,
+          });
+        }
+      }
+    };
+
+    activeReceiveSession = session;
+    isTransferActive = true;
+    currentTransferInfo = { sampleNumber: slot };
+    sendSDSMessage([SDS_DUMP_REQUEST, slot & 0x7F, (slot >> 7) & 0x7F]);
+    resetTimer(HEADER_TIMEOUT);
+  }).finally(() => {
+    activeReceiveSession = null;
+    isTransferActive = false;
+    currentTransferInfo = null;
+  });
+
+  if (rawMode) {
+    fs.writeFileSync(finalPath, result.pcm);
+  } else {
+    const samples = new Int16Array(result.pcm.buffer, result.pcm.byteOffset, result.pcm.length / 2);
+    const wav = new WaveFile();
+    wav.fromScratch(1, result.sampleRate, '16', samples);
+    fs.writeFileSync(finalPath, wav.toBuffer());
+  }
+
+  const seconds = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`\n\nDownload complete: ${result.pcm.length} bytes at ${result.sampleRate}Hz written to ${finalPath} in ${seconds} s`);
+  return true;
+}
+
 // Helper function to check if argument is a sample rate
 function isSampleRate(arg) {
   const rateMatch = arg.match(/^(\d+)$/);
@@ -1186,6 +1358,7 @@ if (!command) {
   console.log("");
   console.log("Usage:");
   console.log("  drumtool.js send <file:slot> [file:slot] ... [sample_rate] [--verbose|-v]");
+  console.log("  drumtool.js receive <slot> [output_file] [--raw] [--verbose|-v]");
   console.log("  drumtool.js version");
   console.log("  drumtool.js storage");
   console.log("  drumtool.js format");
@@ -1199,6 +1372,7 @@ if (!command) {
   console.log("");
   console.log("Commands:");
   console.log("  send           - Transfer audio samples (WAV or raw PCM) using SDS protocol");
+  console.log("  receive        - Download a sample from the device (WAV by default, --raw for PCM)");
   console.log("  version        - Get device firmware version");
   console.log("  storage        - Get device storage information");
   console.log("  format         - Format device filesystem");
@@ -1237,6 +1411,8 @@ if (!command) {
   console.log("  drumtool.js storage                           # Check storage usage");
   console.log("  drumtool.js format                            # Format filesystem");
   console.log("  drumtool.js reboot-bootloader                 # Enter bootloader mode");
+  console.log("  drumtool.js receive 0 kick.wav                # Download slot 0 as WAV");
+  console.log("  drumtool.js receive 30 --raw                  # Download slot 30 as raw PCM");
   console.log("  drumtool.js get-sequencer --json > state.json # Save sequencer pattern");
   console.log("  drumtool.js set-sequencer state.json          # Restore sequencer pattern");
   console.log("  drumtool.js set-setting midi_channel 1        # Use MIDI channel 1");
@@ -1303,6 +1479,13 @@ async function main() {
         console.error(`Error: ${error.message}`);
         process.exit(1);
       }
+    } else if (command === 'receive') {
+      const slotStr = process.argv[3];
+      const slot = parseInt(slotStr, 10);
+      if (slotStr === undefined || isNaN(slot) || slot < 0 || slot > 127) {
+        console.error("Error: 'receive' requires a slot number (0-127).");
+        process.exit(1);
+      }
     } else if (command === 'flash') {
       const file = process.argv[3];
       if (!file) {
@@ -1339,7 +1522,7 @@ async function main() {
     } else if (command !== 'version' && command !== 'storage' && command !== 'format' &&
                command !== 'reboot-bootloader' && command !== 'identity' &&
                command !== 'get-sequencer') {
-      console.error(`Error: Unknown command '${command}'. Use 'send', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', 'flash', 'get-sequencer', 'set-sequencer', 'get-setting', or 'set-setting'.`);
+      console.error(`Error: Unknown command '${command}'. Use 'send', 'receive', 'version', 'storage', 'format', 'reboot-bootloader', 'identity', 'flash', 'get-sequencer', 'set-sequencer', 'get-setting', or 'set-setting'.`);
       process.exit(1);
     }
 
@@ -1364,6 +1547,13 @@ async function main() {
       const success = transfers.length === 1 
         ? await transferSample(transfers[0].filePath, transfers[0].slot, transfers[0].sampleRate, verbose)
         : await transferMultipleSamples(transfers, verbose);
+      process.exitCode = success ? 0 : 1;
+    } else if (command === 'receive') {
+      const slot = parseInt(process.argv[3], 10);
+      const extraArgs = process.argv.slice(4);
+      const rawMode = extraArgs.includes('--raw');
+      const outputPath = extraArgs.find(arg => !arg.startsWith('-'));
+      const success = await receiveSample(slot, outputPath, rawMode, verbose);
       process.exitCode = success ? 0 : 1;
     } else if (command === 'version') {
       await get_firmware_version();

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -39,6 +39,8 @@ const SDS_WAIT = 0x7C;
 const SYSEX_CHANNEL = 0x65; // DRUM device channel (same as existing protocol)
 const PACKET_TIMEOUT = 20;   // 20ms timeout per packet as per SDS spec
 const HEADER_TIMEOUT = 2000; // 2 second timeout for dump header
+const PACKET_RETRY_WINDOW = 5000; // Give up on a packet after this long without any response
+const WAIT_RESPONSE_TIMEOUT = 30000; // Deadline for the follow-up after a WAIT
 
 // Custom SysEx Configuration (for firmware/format commands)
 const SYSEX_MANUFACTURER_ID = [0x00, 0x22, 0x01]; // Dato Musical Instruments
@@ -710,25 +712,68 @@ async function test_universal_identity() {
 }
 
 // Wait for ACK/NAK/WAIT/CANCEL with timeout and CTRL+C escape
-// TODO: The device now re-ACKs a retransmission of the previous packet
-// instead of appending its data twice, so a lost ACK can be handled by
-// resending the same packet after a short timeout (e.g. PACKET_TIMEOUT with
-// a few retries) rather than waiting out the 30 s cap below and dropping to
-// non-handshaking mode.
-function waitForResponse(timeout, packetNum = 0, allowWaitEscape = true) {
+function waitForResponse(timeout, packetNum = 0) {
   return new Promise((resolve) => {
-    // For WAIT responses, use longer timeout but still have escape hatch
-    const maxWaitTime = allowWaitEscape ? 30000 : timeout; // 30s max even for WAIT
     const timer = setTimeout(() => {
       pendingResponse = null;
       resolve({ type: 'timeout', packet: packetNum });
-    }, maxWaitTime);
+    }, timeout);
 
     pendingResponse = {
       resolve,
       timer
     };
   });
+}
+
+// Send one data packet and wait for its ACK, retransmitting on timeout.
+// The device re-ACKs a retransmission of the previous packet without
+// rewriting its data, so resending after a lost packet or lost ACK is safe
+// (firmware with SDS download support or newer). Returns 'ack', 'cancel' or
+// 'failed'.
+async function deliverPacket(packet, expectedPacketNum, verbose) {
+  sendSDSMessage(packet);
+  let deadline = Date.now() + PACKET_RETRY_WINDOW;
+  let responseTimeout = PACKET_TIMEOUT;
+
+  while (Date.now() < deadline) {
+    const response = await waitForResponse(responseTimeout, expectedPacketNum);
+    responseTimeout = PACKET_TIMEOUT;
+
+    switch (response.type) {
+      case SDS_ACK:
+        if (response.packet === expectedPacketNum) {
+          return 'ack';
+        }
+        // Stale ACK for an earlier packet we retransmitted; keep waiting.
+        break;
+      case SDS_NAK:
+        if (verbose) {
+          console.log(`\nPacket ${expectedPacketNum} NAK - retrying`);
+        }
+        sendSDSMessage(packet);
+        break;
+      case SDS_WAIT:
+        // Device is busy (e.g. flash housekeeping): hold off retransmission
+        // and give it a long window for the follow-up response.
+        if (verbose) {
+          console.log(`\nPacket ${expectedPacketNum} WAIT - device is busy`);
+        }
+        deviceStatus = 'slow';
+        responseTimeout = WAIT_RESPONSE_TIMEOUT;
+        deadline = Date.now() + WAIT_RESPONSE_TIMEOUT;
+        break;
+      case SDS_CANCEL:
+        return 'cancel';
+      default: // timeout: the packet or its ACK was lost in transit
+        if (verbose) {
+          console.log(`\nPacket ${expectedPacketNum} timeout - retransmitting`);
+        }
+        sendSDSMessage(packet);
+        break;
+    }
+  }
+  return 'failed';
 }
 
 // Convert sample rate to SDS period format (3-byte nanosecond period)
@@ -998,69 +1043,23 @@ async function transferSample(filePath, sampleNumber, sampleRate = 44100, verbos
       if (verbose && packetNum < 5) { // Debug first few packets
         console.log(`Packet ${packetNum} size:`, packet.length, "checksum:", `0x${packet[packet.length-1].toString(16)}`);
       }
-      sendSDSMessage(packet);
-      
       if (handshaking) {
-        const response = await waitForResponse(PACKET_TIMEOUT, packetNum & 0x7F);
-        
-        if (response.type === SDS_ACK) {
-          deviceStatus = 'ok';
-          successfulPackets++;
-          offset += 80; // Move to next 40 samples (80 bytes)
-          packetNum++;
-        } else if (response.type === SDS_NAK) {
-          if (verbose) {
-            if (showProgress) {
-              console.log(`\nPacket ${packetNum & 0x7F} NAK - retrying`);
-            } else {
-              console.log(`Packet ${packetNum & 0x7F} NAK - retrying`);
-            }
-          }
-          continue; // Retry same packet
-        } else if (response.type === SDS_WAIT) {
-          if (verbose) {
-            console.log(`\nPacket ${packetNum & 0x7F} WAIT - device is busy, waiting for final response...`);
-          }
-          deviceStatus = 'slow';
-          // Wait indefinitely for ACK/NAK/CANCEL after WAIT
-          const finalResponse = await waitForResponse(30000, packetNum & 0x7F, true);
-          if (finalResponse.type === SDS_ACK) {
-            successfulPackets++;
-            offset += 80;
-            packetNum++;
-          } else if (finalResponse.type === SDS_NAK) {
-            continue; // Retry same packet
-          } else if (finalResponse.type === SDS_CANCEL) {
-            throw new Error('Device cancelled transfer - storage may be full');
-          } else {
-            // Even WAIT can timeout - assume non-handshaking
-            if (verbose) {
-              console.log(`Final response timeout after WAIT - assuming non-handshaking`);
-            }
-            successfulPackets++;
-            offset += 80;
-            packetNum++;
-            handshaking = false;
-          }
-        } else if (response.type === SDS_CANCEL) {
+        const status = await deliverPacket(packet, packetNum & 0x7F, verbose);
+        if (status === 'cancel') {
           throw new Error('Device cancelled transfer - storage may be full');
-        } else {
-          // Timeout - assume non-handshaking mode
-          if (verbose) {
-            if (showProgress) {
-              console.log(`\nPacket ${packetNum & 0x7F} timeout - continuing without handshaking`);
-            } else {
-              console.log(`Packet ${packetNum & 0x7F} timeout - continuing without handshaking`);
-            }
-          }
-          successfulPackets++;
-          offset += 80;
-          packetNum++;
-          // Switch to non-handshaking mode for remaining packets
-          handshaking = false;
         }
+        if (status !== 'ack') {
+          throw new Error(`No response for packet ${packetNum & 0x7F} after ${PACKET_RETRY_WINDOW}ms`);
+        }
+        deviceStatus = 'ok';
+        successfulPackets++;
+        offset += 80; // Move to next 40 samples (80 bytes)
+        packetNum++;
       } else {
-        // Non-handshaking mode - advance immediately
+        // Non-handshaking mode (the device never ACKed the header): pace
+        // packets open-loop so the receiver can keep up.
+        sendSDSMessage(packet);
+        await new Promise(resolve => setTimeout(resolve, 10));
         successfulPackets++;
         offset += 80;
         packetNum++;

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -171,7 +171,7 @@ function isCustomMessage(message) {
 // MIDI message handler - will be attached during initialization
 function handleMidiMessage(deltaTime, message) {
   if (process.env.DRUMTOOL_DEBUG) {
-    console.log('IN :', message.map(b => b.toString(16).padStart(2, '0')).join(' '));
+    console.log(`IN +${deltaTime.toFixed(4)}:`, message.map(b => b.toString(16).padStart(2, '0')).join(' '));
   }
   // Handle SDS messages
   if (isSdsMessage(message)) {
@@ -1206,6 +1206,7 @@ async function receiveSample(slot, outputPath, rawMode = false, verboseMode = fa
         // Duplicate of an already-ACKed packet (our ACK got lost): re-ACK.
         if (packetNum !== session.expectedPacket) {
           sendSDSMessage([SDS_ACK, packetNum]);
+          resetTimer(HEADER_TIMEOUT);
           return;
         }
 
@@ -1245,6 +1246,9 @@ async function receiveSample(slot, outputPath, rawMode = false, verboseMode = fa
     activeReceiveSession = session;
     isTransferActive = true;
     currentTransferInfo = { sampleNumber: slot };
+    // Abort any dump a previous (crashed/disconnected) host left running;
+    // the device ignores a CANCEL when idle.
+    sendSDSMessage([SDS_CANCEL, 0]);
     sendSDSMessage([SDS_DUMP_REQUEST, slot & 0x7F, (slot >> 7) & 0x7F]);
     resetTimer(HEADER_TIMEOUT);
   }).finally(() => {

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -170,6 +170,9 @@ function isCustomMessage(message) {
 
 // MIDI message handler - will be attached during initialization
 function handleMidiMessage(deltaTime, message) {
+  if (process.env.DRUMTOOL_DEBUG) {
+    console.log('IN :', message.map(b => b.toString(16).padStart(2, '0')).join(' '));
+  }
   // Handle SDS messages
   if (isSdsMessage(message)) {
     const messageType = message[3];

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -37,7 +37,12 @@ const SDS_WAIT = 0x7C;
 
 // Device Configuration
 const SYSEX_CHANNEL = 0x65; // DRUM device channel (same as existing protocol)
-const PACKET_TIMEOUT = 20;   // 20ms timeout per packet as per SDS spec
+// Retransmit only after the device's slowest routine ACKs. Flash
+// housekeeping (littlefs commits, and the file close on the final packet)
+// can delay an ACK by well over 100 ms; retransmitting sooner floods the
+// device with duplicates whose late replies (stale NAKs once the duplicate
+// is no longer "the previous packet") disrupt the following transfer.
+const PACKET_TIMEOUT = 500;
 const HEADER_TIMEOUT = 2000; // 2 second timeout for dump header
 const PACKET_RETRY_WINDOW = 5000; // Give up on a packet after this long without any response
 const WAIT_RESPONSE_TIMEOUT = 30000; // Deadline for the follow-up after a WAIT
@@ -748,6 +753,10 @@ async function deliverPacket(packet, expectedPacketNum, verbose) {
         // Stale ACK for an earlier packet we retransmitted; keep waiting.
         break;
       case SDS_NAK:
+        if (response.packet !== expectedPacketNum) {
+          // Stale NAK for a duplicate of an earlier packet; keep waiting.
+          break;
+        }
         if (verbose) {
           console.log(`\nPacket ${expectedPacketNum} NAK - retrying`);
         }

--- a/tools/drumtool/drumtool.js
+++ b/tools/drumtool/drumtool.js
@@ -846,9 +846,11 @@ async function transferMultipleSamples(transfers, verboseMode = false) {
       results.push({ filePath, slot, success: false, error: error.message });
     }
     
-    // Brief pause between transfers to avoid overwhelming the device
+    // The device closes and flushes the file before sending the final ACK,
+    // so it is ready for the next dump header as soon as a transfer ends; a
+    // short grace period is enough.
     if (i < transfers.length - 1) {
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise(resolve => setTimeout(resolve, 10));
     }
   }
   

--- a/tools/make_factory_uf2.py
+++ b/tools/make_factory_uf2.py
@@ -114,6 +114,35 @@ def wav_to_pcm(path):
     return w.readframes(w.getnframes())
 
 
+PICOBIN_BLOCK_MARKER_START = 0xFFFFDED3
+PICOBIN_ITEM_TYPE_IMAGE_TYPE = 0x42
+PICOBIN_IMAGE_TYPE_EXE_TBYB_BITS = 0x8000
+
+
+def clear_tbyb(firmware):
+  """Clear the try-before-you-buy flag in the picobin IMAGE_TYPE item.
+
+  The build sets TBYB so A/B updates boot as flash-update trials, but the
+  bootrom refuses to boot an unbought TBYB image on a normal power-on. The
+  factory image must ship pre-bought — the same state rom_explicit_buy
+  leaves in flash after a successful update."""
+  cleared = 0
+  marker = struct.pack("<I", PICOBIN_BLOCK_MARKER_START)
+  pos = firmware.find(marker)
+  while pos >= 0:
+    item_offset = pos + 4
+    if firmware[item_offset] == PICOBIN_ITEM_TYPE_IMAGE_TYPE:
+      flags, = struct.unpack_from("<H", firmware, item_offset + 2)
+      if flags & PICOBIN_IMAGE_TYPE_EXE_TBYB_BITS:
+        struct.pack_into("<H", firmware, item_offset + 2,
+                         flags & ~PICOBIN_IMAGE_TYPE_EXE_TBYB_BITS)
+        cleared += 1
+    pos = firmware.find(marker, pos + 4)
+  if cleared != 1:
+    raise ValueError(f"expected exactly one TBYB IMAGE_TYPE item, "
+                     f"patched {cleared}")
+
+
 # Disk format written by the littlefs vendored in pico-vfs
 # (musin/ports/pico/libraries/pico-vfs/vendor/littlefs, LFS_DISK_VERSION).
 PICO_VFS_LFS_DISK_VERSION = (2, 1)
@@ -189,6 +218,7 @@ def main():
   firmware = bytearray(b"\xFF" * fw_a_size)
   uf2_payload_into(firmware, pathlib.Path(args.firmware).read_bytes(), FLASH_BASE,
                    skip_outside=True)
+  clear_tbyb(firmware)
   used = max((i for i, b in enumerate(firmware) if b != 0xFF), default=-1) + 1
   image[fw_a_offset:fw_a_offset + used] = firmware[:used]
   image[fw_b_offset:fw_b_offset + used] = firmware[:used]

--- a/tools/make_factory_uf2.py
+++ b/tools/make_factory_uf2.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   # Pinned: the vendored littlefs must write the same disk format as the
+#   # littlefs in pico-vfs (currently disk version 2.1). A mismatched image
+#   # makes the firmware reformat the data partition, discarding the samples.
+#   # After changing this pin or updating pico-vfs, verify a composed image
+#   # mounts on hardware before shipping.
+#   "littlefs-python==0.18.0",
+# ]
+# ///
+"""Compose a factory-flash UF2 from its parts, without a golden device.
+
+Run with `uv run tools/make_factory_uf2.py ...` to get the pinned
+littlefs-python automatically, or install it into your environment yourself.
+
+Assembles into one sparse, absolute-family UF2:
+  - the partition table (created via `picotool partition create`)
+  - the firmware image, placed in both partition A and B
+  - a littlefs filesystem built on the host from the factory sample WAVs,
+    placed in the data partition
+
+Sample WAVs must be 16-bit mono; the slot number is taken from the leading
+digits of the filename (e.g. `30_kick_disco.wav` -> `/30.pcm`), matching the
+naming the SDS receive path uses on the device.
+
+The littlefs geometry (4096-byte blocks, 256-byte program size) and disk
+version must match the littlefs vendored in pico-vfs; a mismatch makes the
+firmware treat the partition as corrupt and reformat it, silently discarding
+the samples. Verify on hardware after changing littlefs-python or pico-vfs.
+
+Requires: picotool on PATH.
+
+Usage:
+  uv run tools/make_factory_uf2.py --firmware drum/build/drum-1.0.0-rc.2.uf2 \
+      --samples samples/factory_kit -o drum-factory.uf2
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import wave
+
+FLASH_BASE = 0x10000000
+PARTITION_TABLE_REGION = 0x2000  # flash reserved for the partition table
+BLOCK_SIZE = 4096  # littlefs block == flash sector
+PROG_SIZE = 256  # flash page
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+UF2_FLAG_FAMILY_ID = 0x00002000
+FAMILY_ABSOLUTE = 0xE48BFF57
+UF2_PAYLOAD = 256
+
+
+def parse_size(text):
+  match = re.fullmatch(r"(\d+)([KM]?)", text)
+  if not match:
+    raise ValueError(f"unsupported partition size: {text}")
+  return int(match.group(1)) * {"": 1, "K": 1024, "M": 1024 * 1024}[match.group(2)]
+
+
+def partition_offsets(table_json_path):
+  """Sequential 4K-aligned allocation after the partition-table region,
+  mirroring picotool's layout. Returns [(offset, size), ...] by id order."""
+  with open(table_json_path) as f:
+    table = json.load(f)
+  offsets = []
+  cursor = PARTITION_TABLE_REGION
+  for part in table["partitions"]:
+    size = parse_size(part["size"])
+    offsets.append((cursor, size))
+    cursor += size
+  return offsets
+
+
+def uf2_payload_into(image, data, base, skip_outside=False):
+  """Write each UF2 block's payload of `data` into `image` at addr - base.
+
+  skip_outside ignores blocks outside the region: SDK firmware UF2s carry an
+  address-wrap marker block at the top of the 16MB flash address space."""
+  for offset in range(0, len(data), 512):
+    block = data[offset:offset + 512]
+    magic0, magic1, _flags, addr, size = struct.unpack_from("<5I", block, 0)
+    if (magic0, magic1) != (UF2_MAGIC_START0, UF2_MAGIC_START1):
+      raise ValueError(f"bad UF2 magic at offset {offset:#x}")
+    dest = addr - base
+    if dest < 0 or dest + size > len(image):
+      if skip_outside:
+        continue
+      raise ValueError(f"UF2 block at {addr:#x} outside target region")
+    image[dest:dest + size] = block[32:32 + size]
+
+
+def create_partition_table(table_json_path):
+  with tempfile.NamedTemporaryFile(suffix=".uf2") as tmp:
+    subprocess.run(
+        ["picotool", "partition", "create", str(table_json_path), tmp.name],
+        check=True, capture_output=True, text=True)
+    return pathlib.Path(tmp.name).read_bytes()
+
+
+def wav_to_pcm(path):
+  with wave.open(str(path)) as w:
+    if w.getnchannels() != 1 or w.getsampwidth() != 2:
+      raise ValueError(f"{path.name}: expected 16-bit mono WAV, got "
+                       f"{w.getnchannels()} ch / {w.getsampwidth() * 8}-bit")
+    return w.readframes(w.getnframes())
+
+
+# Disk format written by the littlefs vendored in pico-vfs
+# (musin/ports/pico/libraries/pico-vfs/vendor/littlefs, LFS_DISK_VERSION).
+PICO_VFS_LFS_DISK_VERSION = (2, 1)
+
+
+def build_littlefs_image(samples_dir, partition_size):
+  import littlefs
+  from littlefs import LittleFS
+
+  if littlefs.__LFS_DISK_VERSION__ != PICO_VFS_LFS_DISK_VERSION:
+    raise RuntimeError(
+        f"littlefs-python {littlefs.__version__} writes disk format "
+        f"{littlefs.__LFS_DISK_VERSION__}, but pico-vfs expects "
+        f"{PICO_VFS_LFS_DISK_VERSION}; the firmware would reformat the "
+        "data partition on first mount")
+
+  fs = LittleFS(block_size=BLOCK_SIZE,
+                block_count=partition_size // BLOCK_SIZE,
+                prog_size=PROG_SIZE, read_size=PROG_SIZE)
+  wavs = sorted(pathlib.Path(samples_dir).glob("*.wav"))
+  if not wavs:
+    raise ValueError(f"no .wav files in {samples_dir}")
+  for wav_path in wavs:
+    match = re.match(r"(\d+)", wav_path.stem)
+    if not match:
+      raise ValueError(f"{wav_path.name}: filename must start with slot number")
+    slot = int(match.group(1))
+    with fs.open(f"/{slot:02d}.pcm", "wb") as f:
+      f.write(wav_to_pcm(wav_path))
+    print(f"  /{slot:02d}.pcm <- {wav_path.name}")
+  return bytes(fs.context.buffer)
+
+
+def emit_uf2(image, path):
+  """Emit `image` (flash-relative) as a sparse absolute-family UF2,
+  skipping erased (all-0xFF) 256-byte pages."""
+  pages = [offset for offset in range(0, len(image), UF2_PAYLOAD)
+           if image[offset:offset + UF2_PAYLOAD].count(0xFF) != UF2_PAYLOAD]
+  out = bytearray()
+  for index, offset in enumerate(pages):
+    block = bytearray(512)
+    struct.pack_into("<8I", block, 0, UF2_MAGIC_START0, UF2_MAGIC_START1,
+                     UF2_FLAG_FAMILY_ID, FLASH_BASE + offset, UF2_PAYLOAD,
+                     index, len(pages), FAMILY_ABSOLUTE)
+    block[32:32 + UF2_PAYLOAD] = image[offset:offset + UF2_PAYLOAD]
+    struct.pack_into("<I", block, 508, UF2_MAGIC_END)
+    out += block
+  pathlib.Path(path).write_bytes(out)
+  return len(pages)
+
+
+def main():
+  repo_root = pathlib.Path(__file__).resolve().parent.parent
+  parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+  parser.add_argument("--firmware", required=True,
+                      help="firmware UF2 from drum/build.sh (linked at flash base)")
+  parser.add_argument("--samples", default=str(repo_root / "samples/factory_kit"),
+                      help="directory of NN_name.wav factory samples")
+  parser.add_argument("--partition-table",
+                      default=str(repo_root / "drum/partition_table.json"))
+  parser.add_argument("-o", "--output", default="drum-factory.uf2")
+  args = parser.parse_args()
+
+  offsets = partition_offsets(args.partition_table)
+  (fw_a_offset, fw_a_size), (fw_b_offset, _), (data_offset, data_size) = offsets
+  flash_size = data_offset + data_size
+  image = bytearray(b"\xFF" * flash_size)
+
+  print("Partition table...")
+  uf2_payload_into(image, create_partition_table(args.partition_table), FLASH_BASE)
+
+  print(f"Firmware -> A @ {fw_a_offset:#x} and B @ {fw_b_offset:#x}...")
+  firmware = bytearray(b"\xFF" * fw_a_size)
+  uf2_payload_into(firmware, pathlib.Path(args.firmware).read_bytes(), FLASH_BASE,
+                   skip_outside=True)
+  used = max((i for i, b in enumerate(firmware) if b != 0xFF), default=-1) + 1
+  image[fw_a_offset:fw_a_offset + used] = firmware[:used]
+  image[fw_b_offset:fw_b_offset + used] = firmware[:used]
+
+  print(f"Factory samples -> littlefs @ {data_offset:#x} ({data_size // 1024}K)...")
+  image[data_offset:data_offset + data_size] = \
+      build_littlefs_image(args.samples, data_size)
+
+  blocks = emit_uf2(image, args.output)
+  print(f"wrote {args.output}: {blocks} blocks, {blocks * 512 / 1e6:.1f} MB")
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/tools/sparse_uf2.py
+++ b/tools/sparse_uf2.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Strip erased-flash (all-0xFF) blocks from a UF2 image.
+
+A full-flash dump from `picotool save` includes every erased sector. The
+RP2350 bootrom erases each sector before the first write that touches it,
+so blocks whose payload is entirely 0xFF can be dropped: written sectors
+still end up with 0xFF in the skipped gaps, and untouched sectors stay
+erased on factory-blank flash.
+
+Note: the resulting sparse image only programs the blocks it contains. On
+a previously used device, regions the image skips entirely keep their old
+contents. Intended for factory flashing of blank devices.
+
+Usage: sparse_uf2.py input.uf2 [output.uf2]
+"""
+
+import struct
+import sys
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_BLOCK_SIZE = 512
+
+
+def strip_empty_blocks(data: bytes) -> bytes:
+  if len(data) % UF2_BLOCK_SIZE != 0:
+    raise ValueError("input size is not a multiple of 512 bytes")
+
+  kept = []
+  for offset in range(0, len(data), UF2_BLOCK_SIZE):
+    block = data[offset:offset + UF2_BLOCK_SIZE]
+    magic0, magic1 = struct.unpack_from("<II", block, 0)
+    if (magic0, magic1) != (UF2_MAGIC_START0, UF2_MAGIC_START1):
+      raise ValueError(f"bad UF2 magic at offset {offset:#x}")
+    payload_size, = struct.unpack_from("<I", block, 16)
+    payload = block[32:32 + payload_size]
+    if payload.count(0xFF) != payload_size:
+      kept.append(bytearray(block))
+
+  for index, block in enumerate(kept):
+    struct.pack_into("<II", block, 20, index, len(kept))
+
+  return b"".join(kept)
+
+
+def main() -> int:
+  if len(sys.argv) not in (2, 3):
+    print(__doc__.strip(), file=sys.stderr)
+    return 1
+
+  src = sys.argv[1]
+  dst = sys.argv[2] if len(sys.argv) == 3 else src.removesuffix(".uf2") + "-sparse.uf2"
+
+  with open(src, "rb") as f:
+    data = f.read()
+  sparse = strip_empty_blocks(data)
+  with open(dst, "wb") as f:
+    f.write(sparse)
+
+  total = len(data) // UF2_BLOCK_SIZE
+  kept = len(sparse) // UF2_BLOCK_SIZE
+  print(f"{src}: {total} blocks -> {kept} blocks "
+        f"({len(sparse) / 1e6:.1f} MB, dropped {total - kept} empty)")
+  print(f"wrote {dst}")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
## Summary
- The device now acts as an SDS dump **sender**: an SDS Dump Request (`F0 7E 65 03 sl sh F7`) streams the stored `/NN.pcm` back to the host.
- New `sds::DumpSender` state machine (`drum/sysex/sds_dump_sender.h`), paced from the main loop. Per-packet ACK/NAK/WAIT/CANCEL handshake per the SDS spec, with open-loop fallback (50 ms/packet) for silent hosts and a 30 s stall timeout. Empty slots get CANCEL.
- `StandardFileOps` gains a move-only `ReadHandle` (`open_read`/`read`/`size`) — first read path in file ops.
- Upload/download mutual exclusion in `SysExHandler`; conflicting requests are refused (CANCEL/NAK). Downloads participate in `is_busy()` and transfer-state UI events.
- Outgoing dump headers always report 44100 Hz (device is 44.1 kHz-only; `.pcm` files carry no rate metadata).
- **drumtool**: new `receive <slot> [output] [--raw]` command — writes a mono 16-bit WAV (via `wavefile`) or raw PCM, with checksum verification, NAK-driven retransmits, progress bar, and SDS CANCEL on Ctrl-C. Opt-in `DRUMTOOL_DEBUG=1` logs raw incoming MIDI.
- **Bugfix (load-bearing)**: `tud_midi_packet_write` silently drops packets when the 64-byte USB MIDI TX FIFO is full, truncating any outgoing SysEx longer than the FIFO — the host never saw the closing F7. `musin::usb::midi_send` now drains USB and retries, with a 10 ms deadline. This was latent: nothing the device sent before exceeded 43 bytes.
- Docs: new "Sample Transfer (MIDI Sample Dump Standard)" section in `drum/README.md` covering both directions.

## Testing
- 8 new host-side Catch2 tests for `DumpSender` (header encoding, full ACK-driven dump with packet decode + checksum verification, zero-padded final packet, NAK retransmit, host CANCEL, open-loop fallback, WAIT-then-vanish stall timeout, concurrent-request refusal). All 66 drum tests pass.
- **Verified on hardware**: flashed via SysEx A/B update, `drumtool.js receive 30` round-trips 1600 bytes of PCM; hex dump shows the expected waveform.