### PR TITLE
feat: separate DIN and USB MIDI clock policies

### DIFF
--- a/drum/README.md
+++ b/drum/README.md
@@ -109,8 +109,9 @@
 
 ### Clock Output
 - **24 PPQN** (Pulses Per Quarter Note)
-- **Continuous when playing**
-- **Stops when sequencer stopped**
+- **DIN MIDI:** continuous (sends clock even when stopped, per `SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER_DIN`)
+- **USB MIDI:** only when playing (per `SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER_USB`)
+- **EXTERNAL_SYNC bridge:** always forwarded to both transports
 
 ## Configuration Notes
 - The MIDI channel is configurable via the `SetSetting` SysEx command (see Settings Commands below)

--- a/drum/config.h
+++ b/drum/config.h
@@ -27,7 +27,8 @@ constexpr size_t MAX_PATH_LENGTH = 64;
 // MIDI Configuration
 // The MIDI channel (default 10, GM Percussion Standard) is a runtime
 // setting; see drum/settings.h.
-constexpr bool SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER = true;
+constexpr bool SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER_DIN = true;
+constexpr bool SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER_USB = false;
 constexpr bool SEND_SYNC_CLOCK_WHEN_STOPPED_AS_MASTER = true;
 constexpr bool RETRIGGER_SYNC_ON_PLAYBUTTON = true;
 constexpr bool IGNORE_MIDI_NOTE_OFF = true;

--- a/drum/main.cpp
+++ b/drum/main.cpp
@@ -73,11 +73,11 @@ static musin::timing::SpeedAdapter
 static musin::timing::SyncOut sync_out(DATO_SUBMARINE_SYNC_OUT_PIN);
 static musin::timing::TempoHandler
     tempo_handler(clock_router, speed_adapter,
-                  drum::config::SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER,
                   musin::timing::ClockSource::INTERNAL);
 static musin::timing::MidiClockOut
     midi_clock_out(tempo_handler,
-                   drum::config::SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER);
+                   drum::config::SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER_DIN,
+                   drum::config::SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER_USB);
 static drum::SequencerController<drum::config::NUM_TRACKS,
                                  drum::config::NUM_STEPS_PER_TRACK>
     sequencer_controller(tempo_handler, logger);

--- a/drum/sequencer_controller.h
+++ b/drum/sequencer_controller.h
@@ -307,7 +307,7 @@ private:
 
   // Trace velocities match the MIDI velocity range so the display maps them
   // to brightness exactly like pattern steps.
-  static constexpr uint8_t TRACE_INITIAL_VELOCITY = 127;
+  static constexpr uint8_t TRACE_INITIAL_VELOCITY = 96;
   static constexpr uint8_t TRACE_FADE_STEPS = 8;
   static constexpr uint32_t TRACE_FADE_TICKS =
       TRACE_FADE_STEPS * musical_timing::TICKS_PER_STEP;

--- a/drum/sequencer_effect_swing.h
+++ b/drum/sequencer_effect_swing.h
@@ -39,8 +39,8 @@ public:
     Late,
   };
 
-  static constexpr uint8_t EARLY_ZONE_TICKS = 1;
-  static constexpr uint8_t LATE_ZONE_TICKS = 1;
+  static constexpr uint8_t EARLY_ZONE_TICKS = 2;
+  static constexpr uint8_t LATE_ZONE_TICKS = 2;
 
   /**
    * @brief Classify a live hit's clock phase relative to the swung step grid.

--- a/musin/midi/midi_wrapper.h
+++ b/musin/midi/midi_wrapper.h
@@ -43,6 +43,8 @@ namespace internal {
 // These functions perform the actual MIDI sending via underlying libraries.
 // They are called by the midi_message_queue processor.
 void _sendRealTime_actual(MidiType message);
+void _sendRealTime_usb_actual(MidiType message);
+void _sendRealTime_din_actual(MidiType message);
 void _sendControlChange_actual(uint8_t channel, uint8_t controller,
                                uint8_t value);
 void _sendNoteOn_actual(uint8_t channel, uint8_t note, uint8_t velocity);

--- a/musin/ports/pico/port/midi_wrapper.cpp
+++ b/musin/ports/pico/port/midi_wrapper.cpp
@@ -164,6 +164,18 @@ void MIDI::internal::_sendRealTime_actual(const midi::MidiType message) {
   }
 }
 
+void MIDI::internal::_sendRealTime_usb_actual(const midi::MidiType message) {
+  usb_midi.sendRealTime(message);
+}
+
+void MIDI::internal::_sendRealTime_din_actual(const midi::MidiType message) {
+  // DIN MIDI: try non-blocking write first to minimize jitter
+  // Fall back to blocking write to guarantee delivery if FIFO is full
+  if (!midi_uart.write_nonblocking(static_cast<byte>(message))) {
+    midi_uart.write(static_cast<byte>(message));
+  }
+}
+
 void MIDI::internal::_sendControlChange_actual(const byte channel,
                                                const byte controller,
                                                const byte value) {

--- a/musin/timing/midi_clock_out.cpp
+++ b/musin/timing/midi_clock_out.cpp
@@ -5,9 +5,11 @@
 namespace musin::timing {
 
 MidiClockOut::MidiClockOut(musin::timing::TempoHandler &tempo_handler_ref,
-                           bool send_when_stopped_as_master)
+                           bool send_when_stopped_din,
+                           bool send_when_stopped_usb)
     : tempo_handler_(tempo_handler_ref),
-      send_when_stopped_(send_when_stopped_as_master) {
+      send_when_stopped_din_(send_when_stopped_din),
+      send_when_stopped_usb_(send_when_stopped_usb) {
 }
 
 void MidiClockOut::notification(musin::timing::ClockEvent event) {
@@ -21,11 +23,15 @@ void MidiClockOut::notification(musin::timing::ClockEvent event) {
   }
 
   if (event.source == ClockSource::INTERNAL) {
-    // As clock sender, respect playback policy
-    if (tempo_handler_.get_playback_state() == PlaybackState::PLAYING ||
-        send_when_stopped_) {
+    // As clock sender, respect per-transport playback policy
+    const bool playing =
+        tempo_handler_.get_playback_state() == PlaybackState::PLAYING;
+    if (playing || send_when_stopped_din_) {
       // Direct send bypasses queue to minimize jitter
-      MIDI::internal::_sendRealTime_actual(midi::Clock);
+      MIDI::internal::_sendRealTime_din_actual(midi::Clock);
+    }
+    if (playing || send_when_stopped_usb_) {
+      MIDI::internal::_sendRealTime_usb_actual(midi::Clock);
     }
     return;
   }

--- a/musin/timing/midi_clock_out.h
+++ b/musin/timing/midi_clock_out.h
@@ -10,17 +10,22 @@ namespace musin::timing {
 /**
  * Observes raw 24 PPQN ClockEvent and emits MIDI realtime Clock ticks
  * according to playback policy and active source.
+ *
+ * DIN MIDI and USB MIDI transport policies are independent: each may be
+ * configured to send clock when the sequencer is stopped or only when
+ * playing.
  */
 class MidiClockOut : public etl::observer<musin::timing::ClockEvent> {
 public:
   MidiClockOut(musin::timing::TempoHandler &tempo_handler_ref,
-               bool send_when_stopped_as_master);
+               bool send_when_stopped_din, bool send_when_stopped_usb);
 
   void notification(musin::timing::ClockEvent event) override;
 
 private:
   musin::timing::TempoHandler &tempo_handler_;
-  const bool send_when_stopped_;
+  const bool send_when_stopped_din_;
+  const bool send_when_stopped_usb_;
 };
 
 } // namespace musin::timing

--- a/musin/timing/tempo_handler.cpp
+++ b/musin/timing/tempo_handler.cpp
@@ -6,14 +6,12 @@ namespace musin::timing {
 
 TempoHandler::TempoHandler(ClockRouter &clock_router_ref,
                            SpeedAdapter &speed_adapter_ref,
-                           bool send_midi_clock_when_stopped,
                            ClockSource initial_source)
     : clock_router_ref_(clock_router_ref),
       speed_adapter_ref_(speed_adapter_ref),
       _playback_state(PlaybackState::STOPPED),
       current_speed_modifier_(SpeedModifier::NORMAL_SPEED), phase_12_(0),
-      tick_count_(0),
-      _send_midi_clock_when_stopped(send_midi_clock_when_stopped) {
+      tick_count_(0) {
   clock_router_ref_.set_source_change_listener(this);
   speed_adapter_ref_.add_observer(*this);
   set_clock_source(initial_source);

--- a/musin/timing/tempo_handler.h
+++ b/musin/timing/tempo_handler.h
@@ -50,7 +50,6 @@ class TempoHandler
 public:
   explicit TempoHandler(ClockRouter &clock_router_ref,
                         SpeedAdapter &speed_adapter_ref,
-                        bool send_midi_clock_when_stopped,
                         ClockSource initial_source = ClockSource::INTERNAL);
 
   // Prevent copying and assignment
@@ -92,7 +91,6 @@ private:
   SpeedModifier current_speed_modifier_;
   uint8_t phase_12_;
   uint64_t tick_count_;
-  const bool _send_midi_clock_when_stopped;
   bool initialized_ = false;
   float min_bpm_ = 60.0f;
   float max_bpm_ = 360.0f;

--- a/test/midi_test_support.cpp
+++ b/test/midi_test_support.cpp
@@ -1,8 +1,8 @@
 #include "midi_test_support.h"
 #include "musin/hal/null_logger.h"
 #include "musin/midi/midi_output_queue.h" // For midi_output_queue and MIDI_QUEUE_SIZE
-#include <algorithm>                       // For std::equal, std::min
-#include <utility>                         // For std::move
+#include <algorithm>                      // For std::equal, std::min
+#include <utility>                        // For std::move
 
 // --- Mock Time Implementation ---
 // Time functions are defined as static inline in the mock pico/time.h
@@ -22,22 +22,33 @@ void reset_mock_midi_calls() {
 
 // --- MockMidiCallRecord Implementation ---
 MockMidiCallRecord::MockMidiCallRecord()
-    : channel(0), p1(0), p2(0), p_int(0), rt_type(::midi::InvalidType), sysex_length(0) {}
+    : channel(0), p1(0), p2(0), p_int(0), rt_type(::midi::InvalidType),
+      sysex_length(0) {
+}
 
-MockMidiCallRecord::MockMidiCallRecord(std::string name, uint8_t ch, uint8_t param1,
-                                       uint8_t param2, int paramInt, ::midi::MidiType realtimeType,
-                                       std::vector<uint8_t> sx_data, unsigned sx_len)
-    : function_name(std::move(name)), channel(ch), p1(param1), p2(param2), p_int(paramInt),
-      rt_type(realtimeType), sysex_data(std::move(sx_data)), sysex_length(sx_len) {}
+MockMidiCallRecord::MockMidiCallRecord(std::string name, uint8_t ch,
+                                       uint8_t param1, uint8_t param2,
+                                       int paramInt,
+                                       ::midi::MidiType realtimeType,
+                                       std::vector<uint8_t> sx_data,
+                                       unsigned sx_len)
+    : function_name(std::move(name)), channel(ch), p1(param1), p2(param2),
+      p_int(paramInt), rt_type(realtimeType), sysex_data(std::move(sx_data)),
+      sysex_length(sx_len) {
+}
 
-MockMidiCallRecord MockMidiCallRecord::NoteOn(uint8_t ch, uint8_t note, uint8_t vel) {
+MockMidiCallRecord MockMidiCallRecord::NoteOn(uint8_t ch, uint8_t note,
+                                              uint8_t vel) {
   return {"_sendNoteOn_actual", ch, note, vel, 0, ::midi::InvalidType, {}, 0};
 }
-MockMidiCallRecord MockMidiCallRecord::NoteOff(uint8_t ch, uint8_t note, uint8_t vel) {
+MockMidiCallRecord MockMidiCallRecord::NoteOff(uint8_t ch, uint8_t note,
+                                               uint8_t vel) {
   return {"_sendNoteOff_actual", ch, note, vel, 0, ::midi::InvalidType, {}, 0};
 }
-MockMidiCallRecord MockMidiCallRecord::ControlChange(uint8_t ch, uint8_t ctrl, uint8_t val) {
-  return {"_sendControlChange_actual", ch, ctrl, val, 0, ::midi::InvalidType, {}, 0};
+MockMidiCallRecord MockMidiCallRecord::ControlChange(uint8_t ch, uint8_t ctrl,
+                                                     uint8_t val) {
+  return {"_sendControlChange_actual", ch, ctrl, val, 0,
+          ::midi::InvalidType,         {}, 0};
 }
 MockMidiCallRecord MockMidiCallRecord::PitchBend(uint8_t ch, int bend) {
   return {"_sendPitchBend_actual", ch, 0, 0, bend, ::midi::InvalidType, {}, 0};
@@ -45,38 +56,56 @@ MockMidiCallRecord MockMidiCallRecord::PitchBend(uint8_t ch, int bend) {
 MockMidiCallRecord MockMidiCallRecord::RealTime(::midi::MidiType type) {
   return {"_sendRealTime_actual", 0, 0, 0, 0, type, {}, 0};
 }
-MockMidiCallRecord MockMidiCallRecord::SysEx(unsigned length, const uint8_t *bytes) {
+MockMidiCallRecord MockMidiCallRecord::RealTimeUsb(::midi::MidiType type) {
+  return {"_sendRealTime_usb_actual", 0, 0, 0, 0, type, {}, 0};
+}
+MockMidiCallRecord MockMidiCallRecord::RealTimeDin(::midi::MidiType type) {
+  return {"_sendRealTime_din_actual", 0, 0, 0, 0, type, {}, 0};
+}
+MockMidiCallRecord MockMidiCallRecord::SysEx(unsigned length,
+                                             const uint8_t *bytes) {
   std::vector<uint8_t> data_vec;
   if (bytes && length > 0) {
     data_vec.assign(bytes, bytes + length);
   }
-  return {"_sendSysEx_actual", 0, 0, 0, 0, ::midi::InvalidType, std::move(data_vec), length};
+  return {"_sendSysEx_actual", 0,     0, 0, 0, ::midi::InvalidType,
+          std::move(data_vec), length};
 }
 
 bool MockMidiCallRecord::operator==(const MockMidiCallRecord &other) const {
-  return function_name == other.function_name && channel == other.channel && p1 == other.p1 &&
-         p2 == other.p2 && p_int == other.p_int && rt_type == other.rt_type &&
-         sysex_length == other.sysex_length &&
-         std::equal(sysex_data.begin(), sysex_data.end(), other.sysex_data.begin(),
-                    other.sysex_data.end());
+  return function_name == other.function_name && channel == other.channel &&
+         p1 == other.p1 && p2 == other.p2 && p_int == other.p_int &&
+         rt_type == other.rt_type && sysex_length == other.sysex_length &&
+         std::equal(sysex_data.begin(), sysex_data.end(),
+                    other.sysex_data.begin(), other.sysex_data.end());
 }
 
 // --- Mock MIDI::internal Function Implementations ---
 namespace MIDI::internal {
 void _sendNoteOn_actual(uint8_t channel, uint8_t note, uint8_t velocity) {
-  mock_midi_calls.push_back(MockMidiCallRecord::NoteOn(channel, note, velocity));
+  mock_midi_calls.push_back(
+      MockMidiCallRecord::NoteOn(channel, note, velocity));
 }
 void _sendNoteOff_actual(uint8_t channel, uint8_t note, uint8_t velocity) {
-  mock_midi_calls.push_back(MockMidiCallRecord::NoteOff(channel, note, velocity));
+  mock_midi_calls.push_back(
+      MockMidiCallRecord::NoteOff(channel, note, velocity));
 }
-void _sendControlChange_actual(uint8_t channel, uint8_t controller, uint8_t value) {
-  mock_midi_calls.push_back(MockMidiCallRecord::ControlChange(channel, controller, value));
+void _sendControlChange_actual(uint8_t channel, uint8_t controller,
+                               uint8_t value) {
+  mock_midi_calls.push_back(
+      MockMidiCallRecord::ControlChange(channel, controller, value));
 }
 void _sendPitchBend_actual(uint8_t channel, int bend) {
   mock_midi_calls.push_back(MockMidiCallRecord::PitchBend(channel, bend));
 }
 void _sendRealTime_actual(::midi::MidiType message) {
   mock_midi_calls.push_back(MockMidiCallRecord::RealTime(message));
+}
+void _sendRealTime_usb_actual(::midi::MidiType message) {
+  mock_midi_calls.push_back(MockMidiCallRecord::RealTimeUsb(message));
+}
+void _sendRealTime_din_actual(::midi::MidiType message) {
+  mock_midi_calls.push_back(MockMidiCallRecord::RealTimeDin(message));
 }
 void _sendSysEx_actual(unsigned length, const uint8_t *bytes) {
   mock_midi_calls.push_back(MockMidiCallRecord::SysEx(length, bytes));

--- a/test/midi_test_support.h
+++ b/test/midi_test_support.h
@@ -10,9 +10,12 @@
 namespace MIDI::internal {
 void _sendNoteOn_actual(uint8_t channel, uint8_t note, uint8_t velocity);
 void _sendNoteOff_actual(uint8_t channel, uint8_t note, uint8_t velocity);
-void _sendControlChange_actual(uint8_t channel, uint8_t controller, uint8_t value);
+void _sendControlChange_actual(uint8_t channel, uint8_t controller,
+                               uint8_t value);
 void _sendPitchBend_actual(uint8_t channel, int bend);
 void _sendRealTime_actual(::midi::MidiType message);
+void _sendRealTime_usb_actual(::midi::MidiType message);
+void _sendRealTime_din_actual(::midi::MidiType message);
 void _sendSysEx_actual(unsigned length, const uint8_t *bytes);
 } // namespace MIDI::internal
 
@@ -33,15 +36,20 @@ struct MockMidiCallRecord {
 
   // Constructors
   MockMidiCallRecord();
-  MockMidiCallRecord(std::string name, uint8_t ch, uint8_t param1, uint8_t param2, int paramInt,
-                     ::midi::MidiType realtimeType, std::vector<uint8_t> sx_data, unsigned sx_len);
+  MockMidiCallRecord(std::string name, uint8_t ch, uint8_t param1,
+                     uint8_t param2, int paramInt,
+                     ::midi::MidiType realtimeType,
+                     std::vector<uint8_t> sx_data, unsigned sx_len);
 
   // Factory methods for convenience
   static MockMidiCallRecord NoteOn(uint8_t ch, uint8_t note, uint8_t vel);
   static MockMidiCallRecord NoteOff(uint8_t ch, uint8_t note, uint8_t vel);
-  static MockMidiCallRecord ControlChange(uint8_t ch, uint8_t ctrl, uint8_t val);
+  static MockMidiCallRecord ControlChange(uint8_t ch, uint8_t ctrl,
+                                          uint8_t val);
   static MockMidiCallRecord PitchBend(uint8_t ch, int bend);
   static MockMidiCallRecord RealTime(::midi::MidiType type);
+  static MockMidiCallRecord RealTimeUsb(::midi::MidiType type);
+  static MockMidiCallRecord RealTimeDin(::midi::MidiType type);
   static MockMidiCallRecord SysEx(unsigned length, const uint8_t *bytes);
 
   bool operator==(const MockMidiCallRecord &other) const;

--- a/test/musin/timing/tempo_handler_external_sync_test.cpp
+++ b/test/musin/timing/tempo_handler_external_sync_test.cpp
@@ -57,7 +57,6 @@ TEST_CASE("TempoHandler external manual sync primes next SyncIn downbeat") {
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
-                             /*send_midi_clock_when_stopped*/ false,
                              ClockSource::EXTERNAL_SYNC);
 
   clock_router.add_observer(speed_adapter);
@@ -92,7 +91,6 @@ TEST_CASE("TempoHandler speed change with pending downbeat waits then aligns") {
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
-                             /*send_midi_clock_when_stopped*/ false,
                              ClockSource::EXTERNAL_SYNC);
 
   clock_router.add_observer(speed_adapter);
@@ -134,7 +132,6 @@ TEST_CASE("TempoHandler cable disconnect during pending sync switches source") {
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
-                             /*send_midi_clock_when_stopped*/ false,
                              ClockSource::EXTERNAL_SYNC);
 
   clock_router.add_observer(speed_adapter);
@@ -172,7 +169,6 @@ TEST_CASE(
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
-                             /*send_midi_clock_when_stopped*/ false,
                              ClockSource::EXTERNAL_SYNC);
 
   clock_router.add_observer(speed_adapter);
@@ -205,7 +201,6 @@ TEST_CASE("TempoHandler multiple speed changes before downbeat uses final "
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
-                             /*send_midi_clock_when_stopped*/ false,
                              ClockSource::EXTERNAL_SYNC);
 
   clock_router.add_observer(speed_adapter);
@@ -253,7 +248,6 @@ TEST_CASE("TempoHandler speed change without pending downbeat realigns on next "
 
   musin::timing::SpeedAdapter speed_adapter(SpeedModifier::NORMAL_SPEED);
   TempoHandler tempo_handler(clock_router, speed_adapter,
-                             /*send_midi_clock_when_stopped*/ false,
                              ClockSource::EXTERNAL_SYNC);
 
   clock_router.add_observer(speed_adapter);

--- a/test/musin/timing/tempo_handler_test.cpp
+++ b/test/musin/timing/tempo_handler_test.cpp
@@ -59,11 +59,9 @@ TEST_CASE("TempoHandler internal clock emits tempo events and MIDI clock") {
   musin::timing::SpeedAdapter speed_adapter;
 
   // Send MIDI clock even when stopped for this test to simplify assertion
-  TempoHandler th(clock_router, speed_adapter,
-                  /*send_midi_clock_when_stopped*/ true, ClockSource::INTERNAL);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::INTERNAL);
 
-  musin::timing::MidiClockOut midi_out(th,
-                                       /*send_when_stopped_as_master*/ true);
+  musin::timing::MidiClockOut midi_out(th, /*din*/ true, /*usb*/ true);
   clock_router.add_observer(midi_out);
   clock_router.add_observer(speed_adapter);
 
@@ -91,8 +89,10 @@ TEST_CASE("TempoHandler internal clock emits tempo events and MIDI clock") {
   // Expect at least 3 MIDI realtime Clock messages
   size_t rt_count = 0;
   for (const auto &call : mock_midi_calls) {
-    if (call.function_name == std::string("_sendRealTime_actual") &&
-        call.rt_type == ::midi::Clock) {
+    if (call.rt_type == ::midi::Clock &&
+        (call.function_name == std::string("_sendRealTime_actual") ||
+         call.function_name == std::string("_sendRealTime_din_actual") ||
+         call.function_name == std::string("_sendRealTime_usb_actual"))) {
       ++rt_count;
     }
   }
@@ -111,9 +111,7 @@ TEST_CASE("TempoHandler external sync passes through ticks (half-speed now "
                                           ClockSource::EXTERNAL_SYNC);
   musin::timing::SpeedAdapter speed_adapter;
 
-  TempoHandler th(clock_router, speed_adapter,
-                  /*send_midi_clock_when_stopped*/ false,
-                  ClockSource::EXTERNAL_SYNC);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::EXTERNAL_SYNC);
 
   th.set_speed_modifier(SpeedModifier::HALF_SPEED);
   clock_router.add_observer(speed_adapter);
@@ -147,8 +145,7 @@ TEST_CASE("TempoHandler manual sync in MIDI emits immediate resync") {
                                           ClockSource::MIDI);
   musin::timing::SpeedAdapter speed_adapter;
 
-  TempoHandler th(clock_router, speed_adapter,
-                  /*send_midi_clock_when_stopped*/ false, ClockSource::MIDI);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::MIDI);
   clock_router.add_observer(speed_adapter);
 
   TempoEventRecorder rec;
@@ -172,8 +169,7 @@ TEST_CASE("TempoHandler DOUBLE_SPEED with MIDI source forwards every tick") {
                                           ClockSource::MIDI);
 
   musin::timing::SpeedAdapter speed_adapter;
-  TempoHandler th(clock_router, speed_adapter,
-                  /*send_midi_clock_when_stopped*/ false, ClockSource::MIDI);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::MIDI);
 
   th.set_speed_modifier(SpeedModifier::DOUBLE_SPEED);
   clock_router.add_observer(speed_adapter);
@@ -205,8 +201,7 @@ TEST_CASE("TempoHandler DOUBLE_SPEED maintains phase progression") {
                                           ClockSource::INTERNAL);
 
   musin::timing::SpeedAdapter speed_adapter;
-  TempoHandler th(clock_router, speed_adapter,
-                  /*send_midi_clock_when_stopped*/ false, ClockSource::MIDI);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::MIDI);
 
   TempoEventRecorder rec;
   th.add_observer(rec);
@@ -246,9 +241,7 @@ TEST_CASE("TempoHandler auto-switches from INTERNAL to MIDI when active") {
                                           ClockSource::INTERNAL);
 
   musin::timing::SpeedAdapter speed_adapter_auto;
-  TempoHandler th(clock_router, speed_adapter_auto,
-                  /*send_midi_clock_when_stopped*/ false,
-                  ClockSource::INTERNAL);
+  TempoHandler th(clock_router, speed_adapter_auto, ClockSource::INTERNAL);
 
   // Initially should be INTERNAL
   REQUIRE(th.get_clock_source() == ClockSource::INTERNAL);
@@ -273,8 +266,7 @@ TEST_CASE("TempoHandler prefers EXTERNAL_SYNC over MIDI when cable connected") {
                                           ClockSource::MIDI);
 
   musin::timing::SpeedAdapter speed_adapter_pref;
-  TempoHandler th(clock_router, speed_adapter_pref,
-                  /*send_midi_clock_when_stopped*/ false, ClockSource::MIDI);
+  TempoHandler th(clock_router, speed_adapter_pref, ClockSource::MIDI);
 
   // Make MIDI active
   midi_proc.on_midi_clock_tick_received();
@@ -310,9 +302,7 @@ TEST_CASE("ClockRouter stays on MIDI even after inactivity") {
                                           ClockSource::MIDI);
 
   musin::timing::SpeedAdapter speed_adapter_never;
-  TempoHandler th(clock_router, speed_adapter_never,
-                  /*send_midi_clock_when_stopped*/ false,
-                  ClockSource::INTERNAL);
+  TempoHandler th(clock_router, speed_adapter_never, ClockSource::INTERNAL);
 
   // Start with MIDI active, switch to it
   midi_proc.on_midi_clock_tick_received();
@@ -341,8 +331,7 @@ TEST_CASE(
                                           ClockSource::MIDI);
 
   musin::timing::SpeedAdapter speed_adapter_lb;
-  TempoHandler th(clock_router, speed_adapter_lb,
-                  /*send_midi_clock_when_stopped*/ false, ClockSource::MIDI);
+  TempoHandler th(clock_router, speed_adapter_lb, ClockSource::MIDI);
   clock_router.add_observer(speed_adapter_lb);
 
   TempoEventRecorder rec;
@@ -376,8 +365,7 @@ TEST_CASE("TempoHandler manual sync with MIDI emits immediate resync") {
                                           ClockSource::INTERNAL);
 
   musin::timing::SpeedAdapter speed_adapter_def;
-  TempoHandler th(clock_router, speed_adapter_def,
-                  /*send_midi_clock_when_stopped*/ false, ClockSource::MIDI);
+  TempoHandler th(clock_router, speed_adapter_def, ClockSource::MIDI);
   clock_router.add_observer(speed_adapter_def);
 
   TempoEventRecorder rec;
@@ -410,9 +398,7 @@ TEST_CASE("TempoHandler set_bpm only affects internal clock source") {
                                           ClockSource::INTERNAL);
 
   musin::timing::SpeedAdapter speed_adapter_bpm;
-  TempoHandler th(clock_router, speed_adapter_bpm,
-                  /*send_midi_clock_when_stopped*/ false,
-                  ClockSource::INTERNAL);
+  TempoHandler th(clock_router, speed_adapter_bpm, ClockSource::INTERNAL);
 
   // Test BPM setting works with INTERNAL source
   th.set_bpm(140.0f);
@@ -446,10 +432,9 @@ TEST_CASE("TempoHandler playback state affects MIDI clock transmission") {
   // Test with send_midi_clock_when_stopped = false
   musin::timing::SpeedAdapter speed_adapter_stopped;
   TempoHandler th_stopped(clock_router, speed_adapter_stopped,
-                          /*send_midi_clock_when_stopped*/ false,
                           ClockSource::INTERNAL);
-  musin::timing::MidiClockOut midi_out_stopped(
-      th_stopped, /*send_when_stopped_as_master*/ false);
+  musin::timing::MidiClockOut midi_out_stopped(th_stopped, /*din*/ false,
+                                               /*usb*/ false);
 
   th_stopped.set_playback_state(PlaybackState::STOPPED);
 
@@ -460,10 +445,9 @@ TEST_CASE("TempoHandler playback state affects MIDI clock transmission") {
   // Test with send_midi_clock_when_stopped = true
   musin::timing::SpeedAdapter speed_adapter_always;
   TempoHandler th_always(clock_router, speed_adapter_always,
-                         /*send_midi_clock_when_stopped*/ true,
                          ClockSource::INTERNAL);
-  musin::timing::MidiClockOut midi_out_always(
-      th_always, /*send_when_stopped_as_master*/ true);
+  musin::timing::MidiClockOut midi_out_always(th_always, /*din*/ true,
+                                              /*usb*/ true);
 
   th_always.set_playback_state(PlaybackState::STOPPED);
 
@@ -484,8 +468,10 @@ TEST_CASE("TempoHandler playback state affects MIDI clock transmission") {
   // Verify at least one MIDI clock was sent
   size_t rt_count = 0;
   for (const auto &call : mock_midi_calls) {
-    if (call.function_name == std::string("_sendRealTime_actual") &&
-        call.rt_type == ::midi::Clock) {
+    if (call.rt_type == ::midi::Clock &&
+        (call.function_name == std::string("_sendRealTime_actual") ||
+         call.function_name == std::string("_sendRealTime_din_actual") ||
+         call.function_name == std::string("_sendRealTime_usb_actual"))) {
       ++rt_count;
     }
   }
@@ -503,8 +489,8 @@ TEST_CASE("MidiClockOut uses direct send bypassing queue") {
                                           ClockSource::INTERNAL);
   musin::timing::SpeedAdapter speed_adapter;
 
-  TempoHandler th(clock_router, speed_adapter, true, ClockSource::INTERNAL);
-  musin::timing::MidiClockOut midi_out(th, true);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::INTERNAL);
+  musin::timing::MidiClockOut midi_out(th, /*din*/ true, /*usb*/ true);
 
   clock_router.add_observer(midi_out);
   clock_router.add_observer(speed_adapter);
@@ -524,8 +510,10 @@ TEST_CASE("MidiClockOut uses direct send bypassing queue") {
   // The direct send path calls _sendRealTime_actual immediately
   size_t rt_count = 0;
   for (const auto &call : mock_midi_calls) {
-    if (call.function_name == std::string("_sendRealTime_actual") &&
-        call.rt_type == ::midi::Clock) {
+    if (call.rt_type == ::midi::Clock &&
+        (call.function_name == std::string("_sendRealTime_actual") ||
+         call.function_name == std::string("_sendRealTime_din_actual") ||
+         call.function_name == std::string("_sendRealTime_usb_actual"))) {
       ++rt_count;
     }
   }
@@ -548,9 +536,8 @@ TEST_CASE("MidiClockOut direct send works for EXTERNAL_SYNC source") {
                                           ClockSource::EXTERNAL_SYNC);
   musin::timing::SpeedAdapter speed_adapter;
 
-  TempoHandler th(clock_router, speed_adapter, true,
-                  ClockSource::EXTERNAL_SYNC);
-  musin::timing::MidiClockOut midi_out(th, true);
+  TempoHandler th(clock_router, speed_adapter, ClockSource::EXTERNAL_SYNC);
+  musin::timing::MidiClockOut midi_out(th, /*din*/ true, /*usb*/ true);
 
   clock_router.add_observer(midi_out);
 
@@ -565,12 +552,54 @@ TEST_CASE("MidiClockOut direct send works for EXTERNAL_SYNC source") {
   // Verify MIDI clock was sent directly
   size_t rt_count = 0;
   for (const auto &call : mock_midi_calls) {
-    if (call.function_name == std::string("_sendRealTime_actual") &&
-        call.rt_type == ::midi::Clock) {
+    if (call.rt_type == ::midi::Clock &&
+        (call.function_name == std::string("_sendRealTime_actual") ||
+         call.function_name == std::string("_sendRealTime_din_actual") ||
+         call.function_name == std::string("_sendRealTime_usb_actual"))) {
       ++rt_count;
     }
   }
 
   REQUIRE(rt_count >= 3);
   REQUIRE(musin::midi::midi_output_queue.empty());
+}
+
+TEST_CASE("MidiClockOut splits DIN and USB clock policy when stopped") {
+  reset_test_state();
+
+  InternalClock internal_clock(120.0f);
+  MidiClockProcessor midi_proc;
+  musin::timing::SyncIn sync_in(0, 1);
+  musin::timing::SyncOut sync_out(0);
+  musin::timing::ClockRouter clock_router(internal_clock, midi_proc, sync_in,
+                                          ClockSource::INTERNAL);
+  musin::timing::SpeedAdapter speed_adapter;
+
+  TempoHandler th(clock_router, speed_adapter, ClockSource::INTERNAL);
+  // DIN keeps clock when stopped, USB only when playing
+  musin::timing::MidiClockOut midi_out(th, /*din*/ true, /*usb*/ false);
+
+  th.set_playback_state(PlaybackState::STOPPED);
+  reset_test_state();
+
+  ClockEvent tick{ClockSource::INTERNAL};
+  midi_out.notification(tick);
+
+  size_t din_count = 0;
+  size_t usb_count = 0;
+  for (const auto &call : mock_midi_calls) {
+    if (call.rt_type != ::midi::Clock) {
+      continue;
+    }
+    if (call.function_name == std::string("_sendRealTime_din_actual")) {
+      ++din_count;
+    }
+    if (call.function_name == std::string("_sendRealTime_usb_actual")) {
+      ++usb_count;
+    }
+  }
+
+  // Stopped: DIN sends (flag true), USB does not (flag false)
+  REQUIRE(din_count == 1);
+  REQUIRE(usb_count == 0);
 }


### PR DESCRIPTION
## Summary
- Split `SEND_MIDI_CLOCK_WHEN_STOPPED_AS_MASTER` into per-transport settings: DIN keeps sending clock while stopped (`_DIN = true`), USB only sends while playing (`_USB = false`)
- `MidiClockOut` now takes both flags and sends to each transport independently via new `_sendRealTime_din_actual` / `_sendRealTime_usb_actual` helpers; EXTERNAL_SYNC bridge still forwards to both
- Removed the now-unused `send_midi_clock_when_stopped` parameter from `TempoHandler`
- Tuning: widen swing early/late zones from 1 to 2 ticks; lower trace initial velocity to 96 so the fadeout completes in 8 steps
- Updated tests and MIDI test support for the per-transport clock behavior